### PR TITLE
feat: Add support for visualizing the health of probes from different observers over time

### DIFF
--- a/agent/src/probe.rs
+++ b/agent/src/probe.rs
@@ -37,11 +37,9 @@ impl Into<grey_api::Probe> for &Probe {
         grey_api::Probe {
             name: self.name.clone(),
             tags: self.tags.clone(),
-            sample_count: 0,
-            successful_samples: 0,
             last_updated: chrono::DateTime::UNIX_EPOCH,
             history: Vec::new(),
-            observers: 1,
+            observations: HashMap::new(),
         }
     }
 }

--- a/agent/src/result.rs
+++ b/agent/src/result.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Duration, Utc};
-use grey_api::{Mergeable, ValidationResult};
+use grey_api::ValidationResult;
 use serde::{Deserialize, Serialize};
 
 use crate::utils::{Elide, TimeAlignmentExt};
@@ -11,7 +11,7 @@ pub struct ProbeResult {
     pub start_time: DateTime<Utc>,
     #[serde(with = "crate::serializers::chrono_duration_humantime")]
     pub duration: Duration,
-    pub attempts: u8,
+    pub retries: u8,
     pub pass: bool,
     pub message: String,
     pub validations: HashMap<String, ValidationResult>,
@@ -29,7 +29,7 @@ impl ProbeResult {
         Self {
             start_time: Utc::now(),
             duration: Duration::zero(),
-            attempts: 0,
+            retries: 0,
             pass: true,
             message: "Test probe".into(),
             validations: HashMap::new(),
@@ -40,7 +40,7 @@ impl ProbeResult {
         Self {
             start_time: Utc::now(),
             duration: Duration::zero(),
-            attempts: 0,
+            retries: 0,
             pass: false,
             message: String::new(),
             validations: HashMap::new(),
@@ -52,36 +52,52 @@ impl ProbeResult {
         self
     }
 
-    pub fn apply(&self, probe: &mut grey_api::Probe) {
+    pub fn apply<Id: ToString>(&self, node_id: Id, probe: &mut grey_api::Probe) {
         probe.last_updated = self.start_time + self.duration;
-        probe.sample_count += 1;
-        probe.successful_samples += if self.pass { 1 } else { 0 };
 
         let start_time = self.start_time.align(std::time::Duration::from_secs(3600));
 
-        let new_bucket = grey_api::ProbeHistoryBucket {
-            start_time,
-            total_latency: std::time::Duration::from_millis(self.duration.num_milliseconds() as u64),
-            attempts: self.attempts as u64,
-            pass: self.pass,
-            message: self.message.clone(),
-            validations: self
-                .validations
-                .iter()
-                .map(|(k, v)| (k.clone(), v.clone().elide(256)))
-                .collect(),
-            sample_count: 1,
-            successful_samples: if self.pass { 1 } else { 0 },
-        };
-
         match probe.history.last_mut() {
             Some(last) if last.start_time == start_time => {
-                last.merge(&new_bucket);
+                if last.pass || !self.pass {
+                    last.pass = self.pass;
+                    last.message = self.message.clone();
+                    last.validations = self
+                        .validations
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone().elide(256)))
+                        .collect();
+                }
+
+                let observation = last.observations.entry(node_id.to_string())
+                    .or_insert_with(Default::default);
+
+                observation.add_sample(self.pass, self.retries as u64, std::time::Duration::from_millis(self.duration.num_milliseconds() as u64));
             }
             _ => {
-                probe.history.push(new_bucket);
+                probe.history.push(grey_api::ProbeHistoryBucket {
+                    start_time,
+                    pass: self.pass,
+                    message: self.message.clone(),
+                    validations: self
+                        .validations
+                        .iter()
+                        .map(|(k, v)| (k.clone(), v.clone().elide(256)))
+                        .collect(),
+                    observations: vec![(
+                        node_id.to_string(),
+                        grey_api::Observation::from_sample(
+                            self.pass,
+                            self.retries as u64,
+                            std::time::Duration::from_millis(self.duration.num_milliseconds() as u64)))]
+                        .into_iter().collect(),
+                });
             }
         }
+
+        let observation = probe.observations.entry(node_id.to_string())
+            .or_insert_with(Default::default);
+        observation.add_sample(self.pass, self.retries as u64, std::time::Duration::from_millis(self.duration.num_milliseconds() as u64));
     }
 }
 

--- a/agent/src/state.rs
+++ b/agent/src/state.rs
@@ -184,7 +184,7 @@ impl State {
                     })
                     .unwrap_or_else(|| (probe.into(), 0));
 
-                probe_result.apply(&mut snapshot);
+                probe_result.apply(self.node_id, &mut snapshot);
                 let new_data = rmp_serde::to_vec(&snapshot)?;
                 table.insert(
                     (self.node_id.into(), probe.name.clone()),
@@ -285,7 +285,7 @@ impl State {
     }
 }
 
-impl cluster::GossipStore for State {
+impl GossipStore for State {
     type Id = NodeID;
     type Address = SocketAddr;
     type State = ProbeState;
@@ -421,16 +421,14 @@ impl Versioned for Probe {
             Some(Self {
                 name: self.name.clone(),
                 tags: self.tags.clone(),
-                sample_count: self.sample_count,
-                successful_samples: self.successful_samples,
                 last_updated: self.last_updated,
-                observers: 0,
                 history: self
                     .history
                     .iter()
                     .filter(|h| h.start_time > self.last_updated - chrono::Duration::hours(2))
                     .cloned()
                     .collect(),
+                observations: self.observations.clone(),
             })
         } else {
             None

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -3,7 +3,9 @@ mod probe_history_bucket;
 mod serializers;
 mod ui;
 mod peer;
+mod observation;
 
+pub use observation::*;
 pub use peer::*;
 pub use probe::*;
 pub use probe_history_bucket::*;

--- a/api/src/observation.rs
+++ b/api/src/observation.rs
@@ -1,0 +1,120 @@
+use serde::{Deserialize, Serialize};
+use crate::Mergeable;
+
+/// Describes an aggregatable observation from a specific observer
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Observation {
+    /// The total number of samples taken to form this observation.
+    #[serde(rename = "total")]
+    pub total_samples: u64,
+
+    /// The number of samples which were successful in this observation.
+    #[serde(rename = "success")]
+    pub successful_samples: u64,
+
+    /// The number of retries that were performed to get these samples.
+    #[serde(rename = "retry")]
+    pub total_retries: u64,
+
+    /// The total time taken to acquire all samples, including retries.
+    #[serde(rename = "latency")]
+    #[serde(with = "crate::serializers::duration_ms")]
+    pub total_latency: std::time::Duration,
+}
+
+impl Observation {
+    pub fn from_sample(success: bool, retries: u64, latency: std::time::Duration) -> Self {
+        let mut obs = Observation::default();
+        obs.add_sample(success, retries, latency);
+        obs
+    }
+    
+    /// Adds a sample to this observation.
+    pub fn add_sample(&mut self, success: bool, retries: u64, latency: std::time::Duration) {
+        self.total_samples += 1;
+        if success {
+            self.successful_samples += 1;
+        }
+        self.total_retries += retries;
+        self.total_latency += latency;
+    }
+
+    /// Calculates the success rate for samples in this observation.
+    pub fn success_rate(&self) -> f64 {
+        if self.total_samples == 0 {
+            return 100.0;
+        }
+
+        100.0 * self.successful_samples as f64 / self.total_samples as f64
+    }
+
+    /// Calculates the retry rate for samples in this observation (as a percentage).
+    pub fn retry_rate(&self) -> f64 {
+        if self.total_samples == 0 {
+            return 0.0;
+        }
+
+        100.0 * self.total_retries as f64 / self.total_samples as f64
+    }
+
+    /// Calculates the average per-sample latency for this observation.
+    pub fn average_latency(&self) -> std::time::Duration {
+        if self.successful_samples == 0 {
+            return std::time::Duration::ZERO;
+        }
+
+        std::time::Duration::from_millis((self.total_latency.as_millis() / (self.total_samples as u128)) as u64)
+    }
+}
+
+impl Mergeable for Observation {
+    fn merge(&mut self, other: &Self) {
+        self.total_samples += other.total_samples;
+        self.successful_samples += other.successful_samples;
+        self.total_retries += other.total_retries;
+        self.total_latency += other.total_latency;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_observation_merge() {
+        let mut obs1 = Observation {
+            total_samples: 10,
+            successful_samples: 8,
+            total_retries: 2,
+            total_latency: std::time::Duration::from_millis(500),
+        };
+
+        let obs2 = Observation {
+            total_samples: 5,
+            successful_samples: 4,
+            total_retries: 1,
+            total_latency: std::time::Duration::from_millis(300),
+        };
+
+        obs1.merge(&obs2);
+
+        assert_eq!(obs1.total_samples, 15);
+        assert_eq!(obs1.successful_samples, 12);
+        assert_eq!(obs1.total_retries, 3);
+        assert_eq!(obs1.total_latency, std::time::Duration::from_millis(800));
+    }
+
+    #[test]
+    fn test_observation_metrics() {
+        let obs = Observation {
+            total_samples: 10,
+            successful_samples: 8,
+            total_retries: 2,
+            total_latency: std::time::Duration::from_millis(500),
+        };
+
+        assert_eq!(obs.success_rate(), 80.0);
+        assert_eq!(obs.retry_rate(), 20.0);
+        assert_eq!(obs.average_latency(), std::time::Duration::from_millis(50));
+    }
+}

--- a/api/src/probe_history_bucket.rs
+++ b/api/src/probe_history_bucket.rs
@@ -32,6 +32,13 @@ impl ProbeHistoryBucket {
     pub fn availability(&self) -> f64 {
         self.total().success_rate()
     }
+    
+    pub fn max_availability(&self) -> f64 {
+        if self.observations.is_empty() {
+            return 100.0;
+        }
+        self.observations.values().map(|o| o.success_rate()).fold(f64::NAN, f64::max)
+    }
 
     /// Calculates the average per-request latency for this time bucket.
     pub fn average_latency(&self) -> std::time::Duration {

--- a/ui/src/components/_history.scss
+++ b/ui/src/components/_history.scss
@@ -133,6 +133,15 @@
     gap: 0.25rem;
 }
 
+.tooltip-context {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+    margin-top: 0.75rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid $color-separator;
+}
+
 .tooltip-row {
     display: flex;
     justify-content: space-between;
@@ -149,9 +158,8 @@
 }
 
 .tooltip-section {
-    margin-top: 0.75rem;
-    padding-top: 0.5rem;
-    border-top: 1px solid $color-separator;
+    flex: 1;
+    min-width: 0; // Allow flex items to shrink below their content size
 }
 
 .tooltip-section-title {
@@ -160,7 +168,7 @@
     color: $color-text;
 }
 
-.tooltip-validation {
+.tooltip-section-entry {
     margin-bottom: 0.5rem;
 
     &:last-child {
@@ -168,20 +176,20 @@
     }
 }
 
-.tooltip-validation-header {
+.tooltip-section-entry-header {
     display: flex;
     align-items: center;
     gap: 0.5rem;
     margin-bottom: 0.25rem;
 }
 
-.tooltip-validation-name {
+.tooltip-section-entry-name {
     font-weight: 600;
     color: $color-text;
     font-size: 0.7rem;
 }
 
-.tooltip-validation-message {
+.tooltip-section-entry-message {
     font-family: monospace;
     background-color: $background-base;
     padding: 0.1rem 0.3rem;
@@ -194,11 +202,11 @@
     white-space: pre;
 }
 
-.tooltip-validation-details {
+.tooltip-section-entry-details {
     margin-left: 1.3rem;
 }
 
-.tooltip-validation-extra {
+.tooltip-section-entry-extra {
     font-style: italic;
     color: $color-text-muted;
     font-size: 0.65rem;

--- a/ui/src/components/_history.scss
+++ b/ui/src/components/_history.scss
@@ -28,36 +28,25 @@
         border-bottom-right-radius: $border-radius-small;
     }
 
+    &:hover {
+        border-left: 0.5px solid $color-separator;
+        border-right: 0.5px solid $color-separator;
+    }
+
     &.ok {
         background-color: $color-status-ok;
-
-        &:hover {
-            background-color: darken($color-status-ok, 10%);
-        }
     }
 
     &.warn {
         background-color: $color-status-warn;
-
-        &:hover {
-            background-color: darken($color-status-warn, 10%);
-        }
     }
 
     &.error {
         background-color: $color-status-error;
-
-        &:hover {
-            background-color: darken($color-status-error, 10%);
-        }
     }
 
     &.unknown {
         background-color: $color-status-unknown;
-
-        &:hover {
-            background-color: darken($color-status-unknown, 10%);
-        }
     }
 
     &.tooltip-target .tooltip {

--- a/ui/src/components/_history.scss
+++ b/ui/src/components/_history.scss
@@ -30,18 +30,34 @@
 
     &.ok {
         background-color: $color-status-ok;
+
+        &:hover {
+            background-color: darken($color-status-ok, 10%);
+        }
     }
 
     &.warn {
         background-color: $color-status-warn;
+
+        &:hover {
+            background-color: darken($color-status-warn, 10%);
+        }
     }
 
     &.error {
         background-color: $color-status-error;
+
+        &:hover {
+            background-color: darken($color-status-error, 10%);
+        }
     }
 
     &.unknown {
         background-color: $color-status-unknown;
+
+        &:hover {
+            background-color: darken($color-status-unknown, 10%);
+        }
     }
 
     &.tooltip-target .tooltip {

--- a/ui/src/components/history.rs
+++ b/ui/src/components/history.rs
@@ -194,46 +194,52 @@ fn render_tooltip(probe_result: &ProbeHistoryBucket) -> Html {
                         <span>{&probe_result.message}</span>
                     </div>
                 }
-                if !probe_result.validations.is_empty() {
-                    <div class="tooltip-section">
-                        <div class="tooltip-label tooltip-section-title">{"Validations"}</div>
-                        {for probe_result.validations.iter().map(|(name, validation)| {
-                            let validation_class = if validation.pass { "ok" } else { "error" };
-                            html! {
-                                <div class="tooltip-validation">
-                                    <div class="tooltip-validation-header">
-                                        <div class={format!("tooltip-status-dot {}", validation_class)}></div>
-                                        <span class="tooltip-validation-name">{name}</span>
-                                        <span class="tooltip-validation-message">{&validation.condition}</span>
-                                    </div>
-                                    if let Some(ref msg) = validation.message {
-                                        <div class="tooltip-validation-details">
-                                            <div class="tooltip-validation-extra">{msg}</div>
-                                        </div>
-                                    }
-                                </div>
-                            }
-                        })}
-                    </div>
-                }
-                if probe_result.observations.len() > 1 {
-                    <div class="tooltip-section">
-                        <div class="tooltip-label tooltip-section-title">{"Observers"}</div>
-                        {for probe_result.observations.iter().map(|(name, observation)| {
-                            let validation_class = if observation.success_rate() > 99.0 { "ok" } else { "error" };
-                            html! {
-                                <div class="tooltip-validation">
-                                    <div class="tooltip-validation-header">
-                                        <div class={format!("tooltip-status-dot {}", validation_class)}></div>
-                                        <span class="tooltip-validation-name">{availability(observation.success_rate())}</span>
-                                        <span class="tooltip-validation-message">{name}</span>
-                                    </div>
-                                </div>
-                            }
-                        })}
-                    </div>
-                }
             </div>
+
+            if !probe_result.validations.is_empty() || probe_result.observations.len() > 1 {
+                <div class="tooltip-context">
+                    if probe_result.observations.len() > 1 {
+                        <div class="tooltip-section">
+                            <div class="tooltip-section-title">{"Observers"}</div>
+                            {for probe_result.observations.iter().map(|(name, observation)| {
+                                let validation_class = if observation.success_rate() > 99.0 { "ok" } else { "error" };
+                                html! {
+                                    <div class="tooltip-section-entry">
+                                        <div class="tooltip-section-entry-header">
+                                            <div class={format!("tooltip-status-dot {}", validation_class)}></div>
+                                            <span class="tooltip-section-entry-name">{availability(observation.success_rate())}</span>
+                                            <span class="tooltip-section-entry-message">{name}</span>
+                                        </div>
+                                    </div>
+                                }
+                            })}
+                        </div>
+                    }
+
+                    if !probe_result.validations.is_empty() {
+                        <div class="tooltip-section">
+                            <div class="tooltip-section-title">{"Validations"}</div>
+                            {for probe_result.validations.iter().map(|(name, validation)| {
+                                let validation_class = if validation.pass { "ok" } else { "error" };
+                                html! {
+                                    <div class="tooltip-section-entry">
+                                        <div class="tooltip-section-entry-header">
+                                            <div class={format!("tooltip-status-dot {}", validation_class)}></div>
+                                            <span class="tooltip-section-entry-name">{name}</span>
+                                            <span class="tooltip-section-entry-message">{&validation.condition}</span>
+                                        </div>
+                                        if let Some(ref msg) = validation.message {
+                                            <div class="tooltip-section-entry-details">
+                                                <div class="tooltip-section-entry-extra">{msg}</div>
+                                            </div>
+                                        }
+                                    </div>
+                                }
+                            })}
+                        </div>
+                    }
+                </div>
+            }
         </div>
     }
 }

--- a/ui/src/components/history.rs
+++ b/ui/src/components/history.rs
@@ -92,7 +92,7 @@ pub fn history(props: &HistoryProps) -> Html {
     html! {
         <div class="history">
             {for props.samples.iter().enumerate().map(|(index, sample)| {
-                let sample_class = match sample.availability() {
+                let sample_class = match sample.max_availability() {
                     sli if sli > 99.9 => "ok",
                     sli if sli < 90.0 => "error",
                     _ => "warn",
@@ -138,7 +138,7 @@ pub fn history(props: &HistoryProps) -> Html {
 }
 
 fn render_tooltip(probe_result: &ProbeHistoryBucket) -> Html {
-    let status_text = if probe_result.pass {
+    let status_text = if probe_result.max_availability() == 100.0 {
         "Passed"
     } else {
         "Failed"

--- a/ui/src/components/history.rs
+++ b/ui/src/components/history.rs
@@ -161,6 +161,11 @@ fn render_tooltip(probe_result: &ProbeHistoryBucket) -> Html {
 
     let samples = si_magnitude(overall_stats.total_samples as f64, "");
 
+    let mut relevant_observations = probe_result.observations.iter().collect::<Vec<_>>();
+    relevant_observations.sort_by(|a, b| a.1.success_rate().partial_cmp(&b.1.success_rate()).unwrap_or(std::cmp::Ordering::Equal)); // (|(_, obs)| obs.success_rate());
+    relevant_observations.truncate(probe_result.validations.len().max(3));
+
+
     html! {
         <div class="tooltip visible">
             <div class="tooltip-header">
@@ -201,7 +206,7 @@ fn render_tooltip(probe_result: &ProbeHistoryBucket) -> Html {
                     if probe_result.observations.len() > 1 {
                         <div class="tooltip-section">
                             <div class="tooltip-section-title">{"Observers"}</div>
-                            {for probe_result.observations.iter().map(|(name, observation)| {
+                            {for relevant_observations.iter().map(|(name, observation)| {
                                 let validation_class = if observation.success_rate() > 99.0 { "ok" } else { "error" };
                                 html! {
                                     <div class="tooltip-section-entry">
@@ -213,6 +218,12 @@ fn render_tooltip(probe_result: &ProbeHistoryBucket) -> Html {
                                     </div>
                                 }
                             })}
+
+                            if probe_result.observations.len() > relevant_observations.len() {
+                                <div class="tooltip-section-entry">
+                                    <span class="tooltip-section-entry-extra">{format!("and {} more...", probe_result.observations.len() - relevant_observations.len())}</span>
+                                </div>
+                            }
                         </div>
                     }
 

--- a/ui/src/components/probe.rs
+++ b/ui/src/components/probe.rs
@@ -9,17 +9,7 @@ pub struct ProbeProps {
 
 #[function_component(Probe)]
 pub fn probe(props: &ProbeProps) -> Html {
-    let (successful, total) = props
-        .probe
-        .history
-        .iter()
-        .map(|history| (history.successful_samples, history.sample_count))
-        .fold((0, 0), |acc, x| (acc.0 + x.0, acc.1 + x.1));
-    let recent_availability = if total == 0 {
-        100.0
-    } else {
-        100.0 * successful as f64 / total as f64
-    };
+    let recent_availability = props.probe.recent_availability(2);
 
     let probe_class = match props.probe.history.last() {
         Some(h) if h.pass => "ok",

--- a/ui/src/components/probe.rs
+++ b/ui/src/components/probe.rs
@@ -9,12 +9,12 @@ pub struct ProbeProps {
 
 #[function_component(Probe)]
 pub fn probe(props: &ProbeProps) -> Html {
-    let recent_availability = props.probe.recent_availability(2);
+    let recent_availability = props.probe.recent(2).success_rate();
 
     let probe_class = match props.probe.history.last() {
         Some(h) if h.pass => "ok",
-        Some(h) if !h.pass && recent_availability > 0.8 => "warn",
-        Some(h) if !h.pass && recent_availability <= 0.8 => "error",
+        Some(h) if !h.pass && recent_availability > 80.0 => "warn",
+        Some(h) if !h.pass && recent_availability <= 80.0 => "error",
         _ => "ok",
     };
 
@@ -40,7 +40,7 @@ pub fn probe(props: &ProbeProps) -> Html {
                 </div>
                 <div class="probe-observers" tooltip="The number of agents which have contributed to this status report.">
                     <span class="icon-eye"></span>
-                    {format!("{}", props.probe.observers)}
+                    {format!("{}", props.probe.observations.len())}
                 </div>
                 <div class="availability">{availability(props.probe.availability())}</div>
             </div>


### PR DESCRIPTION
This changes the way we store history data to enable us to record individual observer's perspectives and visualize the on the UI. It also includes the UI changes necessary to take advantage of this capability.

<img width="1797" height="969" alt="image" src="https://github.com/user-attachments/assets/ec8fe35f-79c9-4ccc-a37f-81cea42789e2" />
