### PR TITLE
fix(cluster): encrypt gossip with the documented "current" key (M3)

### DIFF
--- a/agent/src/state.rs
+++ b/agent/src/state.rs
@@ -321,7 +321,10 @@ impl cluster::EncryptionKeyProvider for State {
         let config = self.get_config();
         let secret = if config.cluster.secret.is_empty() {
             config.cluster.secrets.iter()
-                .nth(2)
+                // Encrypt with the second key in the list (the "current" key in the
+                // documented rotation scheme), falling back to the first when only one
+                // key is configured. See docs/guide/clustering.md ("Key Rotation").
+                .nth(1)
                 .or(config.cluster.secrets.first())
                 .ok_or(format!("No secrets have been configured for the cluster, cannot encrypt gossip messages. You can use '{}' as a key if you need it.", self.generate_example_key()))?
         } else {
@@ -513,5 +516,67 @@ impl Versioned for Probe {
 
     fn apply(&mut self, diff: &Self::Diff) {
         self.merge(diff);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::{Aes256Gcm, EncryptionKeyProvider, EncryptionProvider};
+    use base64::prelude::*;
+
+    fn b64_key(byte: u8) -> String {
+        BASE64_STANDARD.encode([byte; 32])
+    }
+
+    async fn state_with_secrets(dir: &std::path::Path, secrets: Vec<String>) -> State {
+        let state = State::test(dir.to_path_buf()).await;
+        let mut config = Config::test(&dir.to_path_buf());
+        config.cluster.secrets = secrets;
+        *state.config.write().unwrap() = Arc::new(config);
+        state
+    }
+
+    /// During a documented 3-key rotation the list is
+    /// `[new (decrypt-only), current (encrypt+decrypt), old (decrypt-only)]`, so encryption must use
+    /// the *second* key. A peer that has rotated one step forward (dropping `old`) still holds
+    /// `current` for decryption and must be able to read the message.
+    #[tokio::test]
+    async fn encrypts_with_second_key_and_survives_rotation() {
+        let new = b64_key(1);
+        let current = b64_key(2);
+        let old = b64_key(3);
+
+        let dir_a = tempfile::tempdir().unwrap();
+        let node_a = state_with_secrets(dir_a.path(), vec![new.clone(), current.clone(), old]).await;
+
+        // Encryption uses the current (second) key, not the old (third) key.
+        assert_eq!(
+            node_a.get_encryption_key().unwrap(),
+            node_a.parse_secret_key(&current).unwrap(),
+            "expected encryption with the second (current) key"
+        );
+
+        // Node B has rotated forward and dropped `old`, but still accepts `current` for decryption.
+        let newer = b64_key(0);
+        let dir_b = tempfile::tempdir().unwrap();
+        let node_b = state_with_secrets(dir_b.path(), vec![newer, new, current]).await;
+
+        let provider = Aes256Gcm;
+        let ciphertext = provider.encrypt(&node_a, b"probe-state").unwrap();
+        let plaintext = provider.decrypt(&node_b, &ciphertext).unwrap();
+        assert_eq!(plaintext, b"probe-state");
+    }
+
+    /// With a single configured key, encryption falls back to that key.
+    #[tokio::test]
+    async fn encrypts_with_only_key_when_single() {
+        let only = b64_key(7);
+        let dir = tempfile::tempdir().unwrap();
+        let node = state_with_secrets(dir.path(), vec![only.clone()]).await;
+        assert_eq!(
+            node.get_encryption_key().unwrap(),
+            node.parse_secret_key(&only).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Problem (M3)

`State::get_encryption_key` selected `config.cluster.secrets.iter().nth(2)` — the **third** key in the list — for encrypting outgoing gossip.

The documented rotation scheme in [docs/guide/clustering.md](../blob/main/docs/guide/clustering.md) ("Key Rotation") lays the list out as:

```
- ${key_new}     # decryption only
- ${key_current} # encryption + decryption   <-- "the second key in the list will be used for encryption"
- ${key_old}     # decryption only
```

So `nth(2)` encrypted with the **old** key the operator was retiring. Consequences during a rotation:

- Peers that had already rotated forward and dropped the oldest key could no longer decrypt this node's messages.
- Zero-downtime rotation could never converge.

With ≤2 keys it fell back to `first()` (index 0), which also disagrees with "the second key".

## Fix

Encrypt with `nth(1)` (the second / "current" key), still falling back to the first key when only one key is configured.

## Tests

- `encrypts_with_second_key_and_survives_rotation` — asserts the second key is selected, and that a peer which has rotated one step forward (dropping the oldest key) can still decrypt.
- `encrypts_with_only_key_when_single` — single-key fallback.

Part of a gossip-system review; one PR per finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)