### PR TITLE
perf(cluster): await UDP datagrams instead of busy-polling (L2)

### DIFF
--- a/agent/src/cluster/client.rs
+++ b/agent/src/cluster/client.rs
@@ -140,8 +140,8 @@ where
                     }
                 },
                 Ok(_) => {
-                    // No message received, continue
-                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    // No message available (e.g. a closed in-memory channel); the UDP transport
+                    // now awaits the next datagram, so this no longer busy-polls.
                 }
                 Err(err) => {
                     // Handle error

--- a/agent/src/cluster/transport/udp.rs
+++ b/agent/src/cluster/transport/udp.rs
@@ -60,15 +60,12 @@ where
     ) -> Result<Option<(Self::Address, Message<P, T>)>, Box<dyn std::error::Error>>
     {
         let mut buf = [0; 65507];
-        match self.socket.try_recv_from(&mut buf) {
-            Ok((size, addr)) => {
-                let decrypted_data = self.encryption_provider.decrypt(&self.key_provider, &buf[..size])?;
-                let msg: Message<P, T> = rmp_serde::from_slice(&decrypted_data)?;
-                Ok(Some((addr, msg)))
-            }
-            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
-            Err(e) => Err(Box::new(e)),
-        }
+        // Await the next datagram rather than polling with `try_recv_from`; this removes the
+        // ~100 wakeups/s-per-node busy-poll and the up-to-10ms hop latency it incurred.
+        let (size, addr) = self.socket.recv_from(&mut buf).await?;
+        let decrypted_data = self.encryption_provider.decrypt(&self.key_provider, &buf[..size])?;
+        let msg: Message<P, T> = rmp_serde::from_slice(&decrypted_data)?;
+        Ok(Some((addr, msg)))
     }
 }
 


### PR DESCRIPTION
## Problem (L2)

The UDP gossip transport's `try_receive` polled with `try_recv_from` and returned `Ok(None)` on `WouldBlock`. The receive loop reacted by sleeping 10ms and retrying — ~100 wakeups/s per node when idle, plus up to 10ms of added latency on every gossip hop.

## Fix

Await `recv_from` directly so the task parks until a datagram actually arrives. This matches the in-memory transport, which already blocks on its channel. The receive loop's now-dead `Ok(None)` sleep is removed; the malformed-packet error branch keeps its small backoff to avoid a tight error loop.

## Tests

Existing cluster transport + client gossip tests pass unchanged (`cargo test -p grey --bins cluster::`), including the wrong-secret decryption-failure path.

Part of a gossip-system review; one PR per finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)