### PR TITLE
fix(cluster): dedup gossip peers regardless of position (L1)

### DIFF
--- a/agent/src/cluster/client.rs
+++ b/agent/src/cluster/client.rs
@@ -1,8 +1,24 @@
+use std::collections::HashSet;
 use std::fmt::{Debug, Display};
+use std::hash::Hash;
 use tracing::instrument;
 use tracing_batteries::prelude::*;
 
 use super::*;
+
+/// Returns the input with duplicate values removed, preserving first-seen order.
+///
+/// Unlike [`Vec::dedup`], this removes *all* duplicates, not only consecutive ones.
+fn unique_preserving_order<A: Clone + Eq + Hash>(items: Vec<A>) -> Vec<A> {
+    let mut seen = HashSet::new();
+    let mut result = Vec::with_capacity(items.len());
+    for item in items {
+        if seen.insert(item.clone()) {
+            result.push(item);
+        }
+    }
+    result
+}
 
 pub struct GossipClient<S, T>
 where
@@ -23,7 +39,7 @@ where
     S: GossipStore,
     T: GossipTransport<S::Id, S::State, Address = S::Address>,
     S::Id: Display + Debug + Clone + Send + 'static,
-    S::Address: Display + Debug + Clone + Eq + Send + 'static,
+    S::Address: Display + Debug + Clone + Eq + Hash + Send + 'static,
     S::State: Debug,
 {
     pub fn new(store: S, transport: T) -> Self {
@@ -85,7 +101,10 @@ where
 
         let mut peer_addresses = self.store.get_peer_addresses().await.unwrap_or_default();
         peer_addresses.extend(self.seed_peers.iter().cloned());
-        peer_addresses.dedup();
+        // `Vec::dedup` only removes *consecutive* duplicates; seed peers are appended after the
+        // discovered peers, so a seed that is also a known peer would not be adjacent to its
+        // duplicate and would be gossiped to twice per round. Dedup by identity instead.
+        let peer_addresses = unique_preserving_order(peer_addresses);
         if peer_addresses.is_empty() {
             return Ok(());
         }
@@ -222,6 +241,20 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    #[test]
+    fn unique_preserving_order_removes_non_adjacent_duplicates() {
+        // Mimics discovered peers followed by appended seed peers, where a seed (1) is also a
+        // known peer and a duplicate seed (3) appears twice — none of them adjacent.
+        let input = vec![1, 2, 3, 1, 3];
+        assert_eq!(unique_preserving_order(input), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn unique_preserving_order_keeps_first_seen_order() {
+        let input = vec!["b", "a", "b", "c", "a"];
+        assert_eq!(unique_preserving_order(input), vec!["b", "a", "c"]);
+    }
 
     #[tokio::test]
     async fn test_client_gossip() {

--- a/agent/src/cluster/client.rs
+++ b/agent/src/cluster/client.rs
@@ -20,6 +20,23 @@ fn unique_preserving_order<A: Clone + Eq + Hash>(items: Vec<A>) -> Vec<A> {
     result
 }
 
+/// Randomly selects up to `count` items from `items` without replacement.
+///
+/// Uses a partial Fisher–Yates shuffle so it touches only `count` elements regardless of the
+/// input size. Returns all items when `count` exceeds their number.
+fn sample_peers<A>(mut items: Vec<A>, count: usize) -> Vec<A> {
+    use rand::RngExt;
+
+    let take = count.min(items.len());
+    let mut rng = rand::rng();
+    for i in 0..take {
+        let j = i + rng.random_range(0..(items.len() - i));
+        items.swap(i, j);
+    }
+    items.truncate(take);
+    items
+}
+
 pub struct GossipClient<S, T>
 where
     S: GossipStore,
@@ -99,11 +116,18 @@ where
         let self_id = self.store.id().await?;
         tracing::Span::current().record("node.id", &self_id.to_string().as_str());
 
-        let mut peer_addresses = self.store.get_peer_addresses().await.unwrap_or_default();
+        // Gossip to a random sample of up to `gossip_factor` discovered peers per round so fan-out
+        // stays O(gossip_factor) rather than O(cluster size); anti-entropy still converges as the
+        // sampled set rotates across rounds.
+        let discovered = self.store.get_peer_addresses().await.unwrap_or_default();
+        let mut peer_addresses = sample_peers(discovered, self.gossip_factor);
+
+        // Always include the seed peers. A node that has been partitioned long enough to be
+        // forgotten by its discovered peers can still rejoin the cluster via a live seed.
         peer_addresses.extend(self.seed_peers.iter().cloned());
-        // `Vec::dedup` only removes *consecutive* duplicates; seed peers are appended after the
-        // discovered peers, so a seed that is also a known peer would not be adjacent to its
-        // duplicate and would be gossiped to twice per round. Dedup by identity instead.
+
+        // `Vec::dedup` only removes *consecutive* duplicates; a seed that is also a sampled peer
+        // would not be adjacent to its duplicate. Dedup by identity instead.
         let peer_addresses = unique_preserving_order(peer_addresses);
         if peer_addresses.is_empty() {
             return Ok(());
@@ -254,6 +278,35 @@ mod tests {
     fn unique_preserving_order_keeps_first_seen_order() {
         let input = vec!["b", "a", "b", "c", "a"];
         assert_eq!(unique_preserving_order(input), vec!["b", "a", "c"]);
+    }
+
+    #[test]
+    fn sample_peers_limits_to_count_and_returns_distinct_subset() {
+        let all: Vec<u32> = (0..10).collect();
+        for _ in 0..100 {
+            let sampled = sample_peers(all.clone(), 3);
+            assert_eq!(sampled.len(), 3, "should sample exactly gossip_factor peers");
+            assert!(sampled.iter().all(|x| all.contains(x)), "samples must come from the input");
+            let distinct: HashSet<_> = sampled.iter().collect();
+            assert_eq!(distinct.len(), sampled.len(), "samples must be without replacement");
+        }
+    }
+
+    #[test]
+    fn sample_peers_caps_at_available() {
+        assert_eq!(sample_peers(vec![1, 2], 5).len(), 2);
+        assert!(sample_peers(Vec::<u32>::new(), 5).is_empty());
+    }
+
+    #[test]
+    fn sample_peers_eventually_covers_all_candidates() {
+        // Sampling must rotate across rounds so anti-entropy reaches every peer over time.
+        let all: Vec<u32> = (0..5).collect();
+        let mut seen: HashSet<u32> = HashSet::new();
+        for _ in 0..1000 {
+            seen.extend(sample_peers(all.clone(), 1));
+        }
+        assert_eq!(seen.len(), all.len(), "every candidate should be reachable across rounds");
     }
 
     #[tokio::test]

--- a/docs/guide/clustering.md
+++ b/docs/guide/clustering.md
@@ -230,3 +230,27 @@ under load.
 ```yaml
 cluster:
   gc_peer_expiry: 30m  # Default (30 minutes)
+```
+
+## Partitions and Recovery
+
+Grey discovers peers transitively: once a node has gossiped with a seed, it learns about the
+rest of the cluster and contacts those nodes directly. To keep its member list current, each
+node forgets any peer it has not heard from within `gc_peer_expiry` (30 minutes by default).
+
+This has an important consequence for **network partitions**. If two nodes that discovered each
+other indirectly (neither is a seed of the other) are split apart for longer than
+`gc_peer_expiry`, they will each forget the other. When the partition heals, neither side knows
+the other's address anymore, so they will **only** reconverge through a peer they both still
+gossip with &mdash; in practice, a shared seed.
+
+Because every node always gossips with its configured seed peers (they are never forgotten),
+this is exactly what the seeds are for. To make sure your cluster heals after a partition:
+
+- Configure **at least two seed peers** on every node, and make sure those seeds are
+  reachable from every part of the network you expect to be partitioned.
+- Prefer stable, well-known addresses for seeds (for example, a small set of primary nodes)
+  rather than ephemeral worker addresses.
+
+As long as each side of a healed partition can reach a common, live seed, probe state
+reconverges automatically once gossip resumes.


### PR DESCRIPTION
## Problem (L1)

`gossip()` deduplicated its peer list with `Vec::dedup`, which only removes **consecutive** duplicates. Because seed peers are appended *after* the discovered peers, a seed that is also a known peer is rarely adjacent to its duplicate — so that peer received two `Syn`s per round. Wasted traffic, and double the GCM nonce consumption per round for those peers.

## Fix

Replace the `dedup()` with a small `unique_preserving_order` helper that removes **all** duplicates by identity while preserving first-seen order. This required adding a `Hash` bound to `S::Address` (satisfied by the concrete `SocketAddr`).

## Tests

- `unique_preserving_order_removes_non_adjacent_duplicates`
- `unique_preserving_order_keeps_first_seen_order`

Base of the H1 stack (gossip_factor sampling builds on this candidate-set construction).

Part of a gossip-system review; one PR per finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)