### PR TITLE
feat: support DNS name resolution for cluster peers

### DIFF
--- a/agent/src/cluster/client.rs
+++ b/agent/src/cluster/client.rs
@@ -45,7 +45,12 @@ where
     store: S,
     transport: T,
 
-    seed_peers: Vec<S::Address>,
+    seed_peers: Vec<String>,
+    /// How frequently the seed peers are re-resolved by the background resolver loop.
+    seed_resolve_interval: std::time::Duration,
+    /// The most recently resolved seed peer addresses, maintained by the resolver loop so that the
+    /// gossip hot path never has to perform DNS resolution itself.
+    resolved_seed_peers: std::sync::Mutex<Vec<S::Address>>,
 
     gossip_factor: usize,
     gossip_interval: std::time::Duration,
@@ -67,6 +72,8 @@ where
             gossip_factor: 1,
             gossip_interval: std::time::Duration::from_secs(10),
             seed_peers: Vec::new(),
+            seed_resolve_interval: std::time::Duration::from_secs(60),
+            resolved_seed_peers: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -84,18 +91,61 @@ where
         }
     }
 
-    pub fn with_seed_peers(self, addresses: Vec<S::Address>) -> Self {
+    pub fn with_seed_peers(self, addresses: Vec<String>) -> Self {
         Self {
-            store: self.store,
-            transport: self.transport,
-            gossip_factor: self.gossip_factor,
-            gossip_interval: self.gossip_interval,
             seed_peers: addresses,
+            ..self
+        }
+    }
+
+    pub fn with_seed_resolve_interval(self, interval: std::time::Duration) -> Self {
+        Self {
+            seed_resolve_interval: interval,
+            ..self
         }
     }
 
     pub async fn run(&self) {
-        tokio::join!(self.gossip_loop(), self.receive_loop());
+        tokio::join!(self.gossip_loop(), self.receive_loop(), self.resolve_loop());
+    }
+
+    /// Periodically re-resolves the configured seed peers in the background so that DNS changes are
+    /// picked up without forcing the gossip loop to perform (potentially blocking) DNS lookups on
+    /// every round. The resolved addresses are cached and read cheaply by [`Self::gossip`].
+    async fn resolve_loop(&self) {
+        if self.seed_peers.is_empty() {
+            return;
+        }
+
+        loop {
+            self.refresh_seed_peers().await;
+            tokio::time::sleep(self.seed_resolve_interval).await;
+        }
+    }
+
+    /// Resolves every configured seed peer and updates the cached address list. If resolution yields
+    /// no addresses at all (for example during a transient DNS outage), the previously resolved
+    /// addresses are retained rather than dropping all of our seeds.
+    async fn refresh_seed_peers(&self) {
+        let mut resolved = Vec::new();
+        for seed in self.seed_peers.iter() {
+            match self.transport.resolve(seed).await {
+                Ok(addresses) if addresses.is_empty() => {
+                    warn!(name: "gossip.seed.resolve", { peer.seed = %seed }, "Seed peer '{seed}' did not resolve to any addresses, skipping it.");
+                }
+                Ok(addresses) => resolved.extend(addresses),
+                Err(err) => {
+                    warn!(name: "gossip.seed.resolve", { peer.seed = %seed, exception = %err }, "Failed to resolve seed peer '{seed}', skipping it: {err:?}");
+                }
+            }
+        }
+
+        if resolved.is_empty() && !self.seed_peers.is_empty() {
+            warn!(name: "gossip.seed.resolve", "Failed to resolve any seed peers, retaining the previously resolved addresses.");
+            return;
+        }
+
+        *self.resolved_seed_peers.lock().unwrap() = resolved;
     }
 
     async fn gossip_loop(&self) {
@@ -123,12 +173,15 @@ where
         let mut peer_addresses = sample_peers(discovered, self.gossip_factor);
 
         // Always include the seed peers. A node that has been partitioned long enough to be
-        // forgotten by its discovered peers can still rejoin the cluster via a live seed.
-        peer_addresses.extend(self.seed_peers.iter().cloned());
+        // forgotten by its discovered peers can still rejoin the cluster via a live seed. The
+        // resolved addresses are maintained by the background resolver loop so we never block the
+        // gossip hot path on DNS resolution here.
+        peer_addresses.extend(self.resolved_seed_peers.lock().unwrap().iter().cloned());
 
         // `Vec::dedup` only removes *consecutive* duplicates; a seed that is also a sampled peer
         // would not be adjacent to its duplicate. Dedup by identity instead.
         let peer_addresses = unique_preserving_order(peer_addresses);
+
         if peer_addresses.is_empty() {
             return Ok(());
         }
@@ -323,7 +376,7 @@ mod tests {
             .with_gossip_interval(Duration::from_millis(10));
         let client2 = GossipClient::new(store2.clone(), transport2)
             .with_gossip_interval(Duration::from_millis(10))
-            .with_seed_peers(vec![node1]);
+            .with_seed_peers(vec![node1.to_string()]);
 
         {
             let local_set = tokio::task::LocalSet::new();

--- a/agent/src/cluster/client.rs
+++ b/agent/src/cluster/client.rs
@@ -50,7 +50,7 @@ where
     seed_resolve_interval: std::time::Duration,
     /// The most recently resolved seed peer addresses, maintained by the resolver loop so that the
     /// gossip hot path never has to perform DNS resolution itself.
-    resolved_seed_peers: std::sync::Mutex<Vec<S::Address>>,
+    resolved_seed_peers: tokio::sync::RwLock<Vec<S::Address>>,
 
     gossip_factor: usize,
     gossip_interval: std::time::Duration,
@@ -73,7 +73,7 @@ where
             gossip_interval: std::time::Duration::from_secs(10),
             seed_peers: Vec::new(),
             seed_resolve_interval: std::time::Duration::from_secs(60),
-            resolved_seed_peers: std::sync::Mutex::new(Vec::new()),
+            resolved_seed_peers: tokio::sync::RwLock::new(Vec::new()),
         }
     }
 
@@ -145,7 +145,7 @@ where
             return;
         }
 
-        *self.resolved_seed_peers.lock().unwrap() = resolved;
+        *self.resolved_seed_peers.write().await = resolved;
     }
 
     async fn gossip_loop(&self) {
@@ -176,7 +176,7 @@ where
         // forgotten by its discovered peers can still rejoin the cluster via a live seed. The
         // resolved addresses are maintained by the background resolver loop so we never block the
         // gossip hot path on DNS resolution here.
-        peer_addresses.extend(self.resolved_seed_peers.lock().unwrap().iter().cloned());
+        peer_addresses.extend(self.resolved_seed_peers.read().await.iter().cloned());
 
         // `Vec::dedup` only removes *consecutive* duplicates; a seed that is also a sampled peer
         // would not be adjacent to its duplicate. Dedup by identity instead.

--- a/agent/src/cluster/node.rs
+++ b/agent/src/cluster/node.rs
@@ -17,6 +17,15 @@ impl Display for NodeID {
     }
 }
 
+impl std::str::FromStr for NodeID {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Mirrors the base-36 encoding used by `Display`.
+        u128::from_str_radix(s, 36).map(Self)
+    }
+}
+
 impl From<u128> for NodeID {
     fn from(value: u128) -> Self {
         Self(value)

--- a/agent/src/cluster/transport/mod.rs
+++ b/agent/src/cluster/transport/mod.rs
@@ -10,6 +10,17 @@ pub use tests::InMemoryGossipTransport;
 pub trait GossipTransport<Id: Eq + Hash, State: Versioned> {
     type Address;
 
+    /// Resolves a seed peer specification (e.g. a `host:port` or `ip:port` string) into zero or
+    /// more concrete peer addresses.
+    ///
+    /// This is invoked on every gossip round so that DNS-based seed peers are re-resolved as their
+    /// underlying records change (for example in environments like Tailscale + MagicDNS, or when a
+    /// peer is rescheduled onto a new IP address).
+    fn resolve(
+        &self,
+        address: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<Self::Address>, Box<dyn std::error::Error>>>;
+
     fn send(
         &self,
         address: Self::Address,
@@ -63,10 +74,19 @@ mod tests {
 
     impl<P, T> GossipTransport<P, T> for InMemoryGossipTransport<P, T>
     where
-        P: Eq + Hash + Clone + Send + 'static,
+        P: Eq + Hash + Clone + Send + std::str::FromStr + 'static,
         T: Versioned + Send + 'static,
     {
         type Address = P;
+
+        async fn resolve(
+            &self,
+            address: &str,
+        ) -> Result<Vec<Self::Address>, Box<dyn std::error::Error>> {
+            P::from_str(address)
+                .map(|addr| vec![addr])
+                .map_err(|_| format!("Failed to parse peer address '{address}'").into())
+        }
 
         async fn send(
             &self,

--- a/agent/src/cluster/transport/udp.rs
+++ b/agent/src/cluster/transport/udp.rs
@@ -44,6 +44,16 @@ where
 {
     type Address = SocketAddr;
 
+    async fn resolve(
+        &self,
+        address: &str,
+    ) -> Result<Vec<Self::Address>, Box<dyn std::error::Error>> {
+        // `lookup_host` accepts both `ip:port` and `host:port` specifications, performing a DNS
+        // lookup for the latter, and yields one entry per resolved address (e.g. both A and AAAA
+        // records).
+        Ok(tokio::net::lookup_host(address).await?.collect())
+    }
+
     async fn send(
         &self,
         address: Self::Address,
@@ -89,6 +99,50 @@ mod tests {
         let addr_str = format!("127.0.0.1:{}", port);
         let addr = addr_str.parse().unwrap();
         (addr_str, addr)
+    }
+
+    #[tokio::test]
+    async fn udp_gossip_transport_resolves_addresses() {
+        let (addr_str, _addr) = random_local_addr();
+        let transport: UdpGossipTransport<_, _> =
+            UdpGossipTransport::new(&addr_str, Aes256Gcm, StaticKeyProvider::new([7u8; 32]))
+                .await
+                .unwrap();
+
+        // IP literals should resolve to themselves without any DNS lookup.
+        let resolved = GossipTransport::<TestPeer, LastWriteWinsValue<i32>>::resolve(
+            &transport,
+            "127.0.0.1:8888",
+        )
+        .await
+        .unwrap();
+        assert_eq!(resolved, vec!["127.0.0.1:8888".parse().unwrap()]);
+
+        // Hostnames should be resolved via DNS; `localhost` is guaranteed to resolve locally.
+        let resolved = GossipTransport::<TestPeer, LastWriteWinsValue<i32>>::resolve(
+            &transport,
+            "localhost:8888",
+        )
+        .await
+        .unwrap();
+        assert!(
+            resolved.iter().all(|addr| addr.ip().is_loopback()),
+            "expected localhost to resolve to loopback addresses, got {resolved:?}"
+        );
+        assert!(
+            resolved.iter().any(|addr| addr.port() == 8888),
+            "expected resolved addresses to preserve the requested port, got {resolved:?}"
+        );
+
+        // Unparseable specifications should surface an error rather than silently yielding nothing.
+        assert!(
+            GossipTransport::<TestPeer, LastWriteWinsValue<i32>>::resolve(
+                &transport,
+                "not a valid address"
+            )
+            .await
+            .is_err()
+        );
     }
 
     #[tokio::test]

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -123,6 +123,10 @@ pub struct ClusterConfig {
     #[serde(default = "default::cluster::gossip_factor")]
     pub gossip_factor: usize,
 
+    #[serde(default = "default::cluster::peer_resolve_interval")]
+    #[serde(with = "humantime_serde")]
+    pub peer_resolve_interval: std::time::Duration,
+
     #[serde(default = "default::cluster::gc_interval")]
     #[serde(with = "humantime_serde")]
     pub gc_interval: std::time::Duration,
@@ -144,6 +148,7 @@ impl Default for ClusterConfig {
             secrets: vec![],
             gossip_interval: default::cluster::gossip_interval(),
             gossip_factor: default::cluster::gossip_factor(),
+            peer_resolve_interval: default::cluster::peer_resolve_interval(),
             gc_interval: default::cluster::gc_interval(),
             gc_probe_expiry: default::cluster::gc_probe_expiry(),
             gc_peer_expiry: default::cluster::gc_peer_expiry(),
@@ -187,6 +192,10 @@ mod default {
 
         pub fn gossip_factor() -> usize {
             2
+        }
+
+        pub fn peer_resolve_interval() -> std::time::Duration {
+            std::time::Duration::from_secs(60)
         }
 
         pub fn gc_interval() -> std::time::Duration {

--- a/agent/src/engine.rs
+++ b/agent/src/engine.rs
@@ -66,15 +66,8 @@ impl Engine {
             let cluster_client = cluster::GossipClient::new(self.state.clone(), cluster_transport)
                 .with_gossip_factor(self.state.get_config().cluster.gossip_factor)
                 .with_gossip_interval(self.state.get_config().cluster.gossip_interval)
-                .with_seed_peers(
-                    self.state
-                        .get_config()
-                        .cluster
-                        .peers
-                        .iter()
-                        .filter_map(|p| p.parse().ok())
-                        .collect(),
-                );
+                .with_seed_resolve_interval(self.state.get_config().cluster.peer_resolve_interval)
+                .with_seed_peers(self.state.get_config().cluster.peers.clone());
 
             tokio::task::spawn_local(async move {
                 cluster_client.run().await;

--- a/docs/guide/clustering.md
+++ b/docs/guide/clustering.md
@@ -88,15 +88,22 @@ cluster:
 ```
 
 #### peers
-Initial peer addresses for cluster discovery. These should be IP addresses which
+Initial peer addresses for cluster discovery. These should be addresses which
 are accessible from the current node (either over a private network, a VPN, or over
 the public internet).
+
+Each entry may be either an `ip:port` literal or a `hostname:port` value. Hostnames
+are resolved via DNS, which makes it possible to use dynamic naming systems such as
+Tailscale + MagicDNS, Kubernetes service names, or Docker Compose service aliases.
+DNS names are re-resolved periodically in the background, so peers whose IP addresses
+change over time will continue to be reachable without restarting Grey.
 
 ```yaml
 cluster:
   peers:
     - 10.0.0.2:8888
-    - 10.0.0.3:8888
+    - grey-worker-1.example.com:8888
+    - my-node.tailnet-1234.ts.net:8888
 ```
 
 #### secrets
@@ -196,6 +203,19 @@ For clusters with N nodes, optimal gossip_factor is typically `log₂(N) + 1`:
 - 2-4 nodes: gossip_factor = 2
 - 5-8 nodes: gossip_factor = 3  
 - 9-16 nodes: gossip_factor = 4
+
+#### peer_resolve_interval
+How frequently the DNS names configured in `peers` are re-resolved in the background.
+
+Seed peers that are configured as hostnames are resolved on a background loop (rather than
+on every gossip round) so that DNS lookups never add latency to the gossip hot path. Lowering
+this value makes Grey react more quickly to seed peers whose IP addresses change, at the cost
+of slightly more frequent DNS lookups. IP-literal peers are unaffected by this setting.
+
+```yaml
+cluster:
+  peer_resolve_interval: 60s  # Default
+```
 
 #### gc_interval
 How frequently to run the garbage collector to remove stale peers and expired probes.


### PR DESCRIPTION
Closes #616

## Summary

- `cluster.peers` entries now accept `hostname:port` in addition to `ip:port`, enabling dynamic naming systems such as Tailscale + MagicDNS, Kubernetes service names, and Docker Compose aliases
- DNS resolution happens on a **dedicated background resolver loop** (not per-gossip-round) so the gossip hot path never pays DNS lookup latency or blocks a threadpool thread
- Resolved addresses are cached in the client; on a transient DNS outage the previously resolved addresses are retained rather than dropping all seeds
- New `cluster.peer_resolve_interval` config option (default `60s`) controls how often seed hostnames are re-resolved

## Design: why a background loop?

On Linux, `getaddrinfo` (what `tokio::net::lookup_host` uses) does **not** cache in-process and dispatches to a blocking threadpool. Without OS-level caching (e.g. `systemd-resolved`, `nscd`) — absent in many container images — calling it on every gossip round adds blocking dispatch overhead to a tight loop. The background resolver loop decouples resolution frequency from gossip frequency entirely.

## Changes

| File | Change |
|------|--------|
| `cluster/transport/mod.rs` | New `GossipTransport::resolve` trait method |
| `cluster/transport/udp.rs` | UDP impl via `tokio::net::lookup_host`; new resolve test |
| `cluster/client.rs` | Seed peers as `Vec<String>`; background `resolve_loop` + address cache |
| `cluster/node.rs` | `FromStr` for `NodeID` (round-trips its base-36 `Display`) |
| `config.rs` | New `cluster.peer_resolve_interval` option (default 60s) |
| `engine.rs` | Pass raw peer strings + resolve interval to cluster client |
| `docs/guide/clustering.md` | Documented hostname support and the new option |

## Test plan

- [ ] All existing cluster tests pass (`cargo test -p grey cluster`)
- [ ] New `udp_gossip_transport_resolves_addresses` test covers IP literals, `localhost` hostname resolution, and parse errors
- [ ] Manual test with `hostname:port` peer in a two-node cluster

https://claude.ai/code/session_013Eyg6MwpufdrBrbHtmwxym

---
_Generated by [Claude Code](https://claude.ai/code/session_013Eyg6MwpufdrBrbHtmwxym)_