### PR TITLE
feat(cluster): persist the node identity across restarts

### DIFF
--- a/agent/src/state.rs
+++ b/agent/src/state.rs
@@ -31,32 +31,6 @@ const NODE_ID_KEY: &str = "node_id";
 
 type ProbeState = Probe;
 
-/// Loads this instance's persistent [`NodeID`] from the database, generating and storing a fresh
-/// one on first run. Persisting the identity means a restart resumes the same node — continuing to
-/// advertise its probe state — instead of appearing as a new node whose old state must later be
-/// garbage-collected.
-fn load_or_create_node_id(database: &Database) -> Result<NodeID, Box<dyn Error>> {
-    let read = database.begin_read()?;
-    // `open_table` errors on a read transaction if the table has never been created, which is the
-    // expected first-run case — fall through to generating a new identity.
-    if let Ok(table) = read.open_table(CLUSTER_IDENTITY_TABLE) {
-        if let Some(existing) = table.get(NODE_ID_KEY)? {
-            return Ok(NodeID::from(existing.value()));
-        }
-    }
-    drop(read);
-
-    let node_id = NodeID::new();
-    let id: u128 = node_id.into();
-    let write = database.begin_write()?;
-    {
-        let mut table = write.open_table(CLUSTER_IDENTITY_TABLE)?;
-        table.insert(NODE_ID_KEY, id)?;
-    }
-    write.commit()?;
-    Ok(node_id)
-}
-
 #[derive(Clone)]
 pub struct State {
     config_path: PathBuf,
@@ -71,17 +45,15 @@ pub struct State {
 impl State {
     #[cfg(test)]
     pub async fn test(temp_dir: PathBuf) -> Self {
-        let config_path = temp_dir.join("config.yml");
+        // Construct through the real `new()` path so tests exercise identical setup (including
+        // persisting the node identity), writing the in-memory test config to disk for it to load.
         let config = Config::test(&temp_dir);
-        let database = Arc::new(Database::create(temp_dir.join("state.redb")).unwrap());
-        let node_id = load_or_create_node_id(&database).unwrap();
-        let this = Self {
-            config_path,
-            config_last_modified: Arc::new(Mutex::new(std::time::SystemTime::now())),
-            config: Arc::new(RwLock::new(Arc::new(config))),
-            node_id,
-            database,
-        };
+        let config_path = temp_dir.join("config.yml");
+        tokio::fs::write(&config_path, serde_yaml::to_string(&config).unwrap())
+            .await
+            .unwrap();
+
+        let this = Self::new(&config_path).await.unwrap();
 
         let test_probe = &this.get_config().probes[0];
 
@@ -89,7 +61,7 @@ impl State {
             .await
             .unwrap();
         this.update_probe_config(test_probe).await.unwrap();
-        this.update_probe_state(&test_probe.name, &&ProbeResult::test()).await.unwrap();
+        this.update_probe_state(&test_probe.name, &ProbeResult::test()).await.unwrap();
 
         this
     }
@@ -99,7 +71,7 @@ impl State {
         let config = Config::load_from_path(&config_path).await?;
 
         let database = Arc::new(Database::create(config.state.clone())?);
-        let node_id = load_or_create_node_id(&database)?;
+        let node_id = Self::load_or_create_node_id(&database)?;
 
         Ok(Self {
             config_path,
@@ -110,6 +82,32 @@ impl State {
             node_id,
             database,
         })
+    }
+
+    /// Loads this instance's persistent [`NodeID`] from the database, generating and storing a fresh
+    /// one on first run. Persisting the identity means a restart (via [`State::new`]) resumes the
+    /// same node — continuing to advertise its probe state — instead of appearing as a new node
+    /// whose old state must later be garbage-collected.
+    fn load_or_create_node_id(database: &Database) -> Result<NodeID, Box<dyn Error>> {
+        let read = database.begin_read()?;
+        // `open_table` errors on a read transaction if the table has never been created, which is
+        // the expected first-run case — fall through to generating a new identity.
+        if let Ok(table) = read.open_table(CLUSTER_IDENTITY_TABLE)
+            && let Some(existing) = table.get(NODE_ID_KEY)?
+        {
+            return Ok(NodeID::from(existing.value()));
+        }
+        drop(read);
+
+        let node_id = NodeID::new();
+        let id: u128 = node_id.into();
+        let write = database.begin_write()?;
+        {
+            let mut table = write.open_table(CLUSTER_IDENTITY_TABLE)?;
+            table.insert(NODE_ID_KEY, id)?;
+        }
+        write.commit()?;
+        Ok(node_id)
     }
 
     pub async fn reload(&self) -> Result<(), Box<dyn Error>> {
@@ -692,11 +690,11 @@ mod tests {
 
         let first = {
             let db = Database::create(&path).unwrap();
-            load_or_create_node_id(&db).unwrap()
+            State::load_or_create_node_id(&db).unwrap()
         };
         let second = {
             let db = Database::create(&path).unwrap();
-            load_or_create_node_id(&db).unwrap()
+            State::load_or_create_node_id(&db).unwrap()
         };
 
         assert_eq!(first, second, "NodeID must be stable across restarts");

--- a/agent/src/state.rs
+++ b/agent/src/state.rs
@@ -23,8 +23,39 @@ const CLUSTER_PEERS_TABLE: TableDefinition<String, (u128, u64)> =
 // Maps a (NodeID, Probe Name) to a tuple of (Version, MsgPack Snapshot)
 const CLUSTER_FIELDS_TABLE: TableDefinition<(u128, String), (u64, &[u8])> =
     TableDefinition::new("cluster_fields");
+// Stores this instance's persistent identity so that a restart resumes the same NodeID (and keeps
+// advertising its existing probe state) rather than appearing as a brand-new node.
+const CLUSTER_IDENTITY_TABLE: TableDefinition<&str, u128> =
+    TableDefinition::new("cluster_identity");
+const NODE_ID_KEY: &str = "node_id";
 
 type ProbeState = Probe;
+
+/// Loads this instance's persistent [`NodeID`] from the database, generating and storing a fresh
+/// one on first run. Persisting the identity means a restart resumes the same node — continuing to
+/// advertise its probe state — instead of appearing as a new node whose old state must later be
+/// garbage-collected.
+fn load_or_create_node_id(database: &Database) -> Result<NodeID, Box<dyn Error>> {
+    let read = database.begin_read()?;
+    // `open_table` errors on a read transaction if the table has never been created, which is the
+    // expected first-run case — fall through to generating a new identity.
+    if let Ok(table) = read.open_table(CLUSTER_IDENTITY_TABLE) {
+        if let Some(existing) = table.get(NODE_ID_KEY)? {
+            return Ok(NodeID::from(existing.value()));
+        }
+    }
+    drop(read);
+
+    let node_id = NodeID::new();
+    let id: u128 = node_id.into();
+    let write = database.begin_write()?;
+    {
+        let mut table = write.open_table(CLUSTER_IDENTITY_TABLE)?;
+        table.insert(NODE_ID_KEY, id)?;
+    }
+    write.commit()?;
+    Ok(node_id)
+}
 
 #[derive(Clone)]
 pub struct State {
@@ -42,12 +73,14 @@ impl State {
     pub async fn test(temp_dir: PathBuf) -> Self {
         let config_path = temp_dir.join("config.yml");
         let config = Config::test(&temp_dir);
+        let database = Arc::new(Database::create(temp_dir.join("state.redb")).unwrap());
+        let node_id = load_or_create_node_id(&database).unwrap();
         let this = Self {
             config_path,
             config_last_modified: Arc::new(Mutex::new(std::time::SystemTime::now())),
             config: Arc::new(RwLock::new(Arc::new(config))),
-            node_id: NodeID::new(),
-            database: Arc::new(Database::create(temp_dir.join("state.redb")).unwrap()),
+            node_id,
+            database,
         };
 
         let test_probe = &this.get_config().probes[0];
@@ -66,6 +99,7 @@ impl State {
         let config = Config::load_from_path(&config_path).await?;
 
         let database = Arc::new(Database::create(config.state.clone())?);
+        let node_id = load_or_create_node_id(&database)?;
 
         Ok(Self {
             config_path,
@@ -73,7 +107,7 @@ impl State {
 
             config: Arc::new(RwLock::new(Arc::new(config))),
 
-            node_id: NodeID::new(),
+            node_id,
             database,
         })
     }
@@ -578,5 +612,24 @@ mod tests {
             node.get_encryption_key().unwrap(),
             node.parse_secret_key(&only).unwrap()
         );
+    }
+
+    /// The node identity is persisted, so reopening the same state database yields the same NodeID
+    /// — a restart resumes the node rather than appearing as a new one.
+    #[test]
+    fn node_id_persists_across_database_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.redb");
+
+        let first = {
+            let db = Database::create(&path).unwrap();
+            load_or_create_node_id(&db).unwrap()
+        };
+        let second = {
+            let db = Database::create(&path).unwrap();
+            load_or_create_node_id(&db).unwrap()
+        };
+
+        assert_eq!(first, second, "NodeID must be stable across restarts");
     }
 }

--- a/docs/guide/clustering.md
+++ b/docs/guide/clustering.md
@@ -209,10 +209,11 @@ cluster:
 How long to retain information about a probe before it is considered stale and removed
 in the next garbage collection cycle.
 
-Every time you start Grey, it starts reporting probe state under a new node identifier,
-so it is normal and expected that application restarts will result in probe state for
-old instances not being updated and eventually needing to be removed. Once removed,
-the aggregated probe metrics will be adjusted to account for the loss of this data.
+Each Grey instance persists its node identifier in its state database, so a restart resumes
+the same identity and continues updating its existing probe state rather than appearing as a
+new node. Probe records are still removed once they have not been updated for `gc_probe_expiry`
+— for example when an instance is permanently retired, or when its state database is reset — and
+the aggregated probe metrics are adjusted to account for the loss of this data.
 
 ```yaml
 cluster:


### PR DESCRIPTION
## Problem

Each instance generated a fresh random `NodeID` on every start (`NodeID::new()` in `State::new`). A restart therefore appeared as a **brand-new node**: its previous probe-state advertisements stopped being updated and had to be aged out via `gc_probe_expiry`, and the cluster briefly double-counted the instance (old id + new id) until the old records expired.

This was previously called out as expected behaviour in the clustering guide — this PR removes the root cause.

## Fix

- Persist the `NodeID` in the state database via a new `cluster_identity` redb table, and load it on startup (`load_or_create_node_id`), generating one only on first run.
- A restart now resumes the **same** identity and continues advertising its existing probe state.
- Updates `docs/guide/clustering.md` (the `gc_probe_expiry` section) which documented the old new-id-per-restart behaviour.

## Tests

- `node_id_persists_across_database_reopen` — reopening the same state database yields the same NodeID.
- Full agent suite passes (`cargo test -p grey --bins`, 54 tests).

## Based on latest `main`

Branched from the current `origin/main` (after M3/L2/L1/H1/M1 merged).

Part of the cluster-reliability work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)