### PR TITLE
ci: speed up UI build by avoiding trunk source builds

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,6 +39,21 @@ jobs:
     runs-on: macos-latest
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+
+      # Install trunk before switching the default Rust toolchain so that the
+      # rustup override doesn't interfere, and pass the GITHUB_TOKEN so that
+      # binstall isn't rate-limited by the GitHub API (which forces a slow
+      # build from source).
+      - name: Install trunk (for building web UI)
+        run: cargo binstall --no-confirm trunk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get Rust Stable
         uses: actions-rs/toolchain@v1.0.7
         with:
@@ -46,19 +61,6 @@ jobs:
           override: true
           target: wasm32-unknown-unknown
           components: llvm-tools-preview
-
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Install cargo-binstall
-        uses: cargo-bins/cargo-binstall@main
-        if: ${{ !matrix.cross }}
-
-      - name: Install trunk (for building web UI)
-        if: ${{ !matrix.cross }}
-        run: |
-          cargo binstall --no-confirm trunk
-          echo "/home/runner/.cargo/bin" >> $GITHUB_PATH
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary

The "Build UI" job was taking up to 10 minutes, mostly in the `cargo binstall trunk` step. The logs show why: binstall's GitHub API requests were returning `403 Forbidden` (rate limited), each retry waited 120s, and after the resolution timeout it gave up and compiled trunk from source on the runner.

This PR fixes that in `.github/workflows/rust.yml`:

- **Pass `GITHUB_TOKEN` to `cargo binstall`** so release-artifact lookups against `api.github.com` are authenticated and no longer rate-limited — trunk now installs as a prebuilt binary in seconds instead of being built from source.
- **Install trunk before the Rust toolchain step** so the `rustup override` applied by `actions-rs/toolchain` can't interfere with the install (this was the source of the "default toolchain implicitly overridden" warning during the source-build fallback).
- **Minor cleanup:** removed the leftover `if: ${{ !matrix.cross }}` conditionals (this job has no matrix) and the `echo "/home/runner/.cargo/bin" >> $GITHUB_PATH` line, which pointed at a Linux path on a macOS runner and was a no-op (`~/.cargo/bin` is already on the PATH).

## Testing

- Workflow YAML change only; validated the structure locally. The real verification is the "Build User Interface" job duration on this PR's CI run — the `Install trunk` step should drop from ~8–10 minutes to well under a minute.

https://claude.ai/code/session_01JikBnKDNTtmG6dsQzGhcyt

---
_Generated by [Claude Code](https://claude.ai/code/session_01JikBnKDNTtmG6dsQzGhcyt)_