### PR TITLE
ci: replace archived actions-rs/toolchain with dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,11 +55,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Rust Stable
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           components: llvm-tools-preview
 
       - name: Setup Cache
@@ -83,10 +81,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
           components: llvm-tools-preview
 
       - name: install protoc
@@ -191,11 +187,9 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Rust Stable
-        uses: actions-rs/toolchain@v1.0.7
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
           components: llvm-tools-preview
 
       - name: Check out code


### PR DESCRIPTION
## Summary

`actions-rs/toolchain` has been [archived](https://github.com/actions-rs/toolchain) and is no longer maintained. This replaces all three usages in `.github/workflows/rust.yml` with the actively maintained [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain).

## Changes

- `build-ui`, `test`, and `build-app` jobs now use `dtolnay/rust-toolchain@stable`.
- The toolchain channel (`stable`) is now selected via the action ref (`@stable`) instead of the `toolchain:` input.
- `override: true` was dropped — `dtolnay/rust-toolchain` installs the requested toolchain as the default, so the override is no longer needed.
- The `target:` input was renamed to the plural `targets:` as required by the new action.

## Note / out of scope

This PR is scoped to `actions-rs/toolchain` as requested. The same archived `actions-rs` org still provides two other actions in these workflows that may warrant a follow-up:

- `actions-rs/cargo` (4 usages in `rust.yml`) — these still function against the default toolchain set by `dtolnay/rust-toolchain`, but could be replaced with direct `run: cargo ...` steps (using `cross` directly for the cross-compiled `arm64` build).
- `actions-rs/audit-check` (in `security_audit.yml`) — the maintained successor is `rustsec/audit-check`.

Happy to fold those in if you'd like.

https://claude.ai/code/session_01ARDxiDSNCYyj5ARPbGvuPM

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARDxiDSNCYyj5ARPbGvuPM)_