### PR TITLE
ci: scope rust-cache per matrix target in build-app

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -208,6 +208,13 @@ jobs:
 
       - name: Setup Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          # Give each matrix entry its own cache scope. Without this, every
+          # entry in the matrix shares the same automatic cache key (derived
+          # from the job name + Cargo.lock), so the jobs clobber one another's
+          # caches and targets like aarch64 (built via cross) never get a
+          # usable cache restored, forcing a full rebuild on every run.
+          key: ${{ matrix.target }}
 
       - name: cargo build
         uses: actions-rs/cargo@v1.0.3


### PR DESCRIPTION
## Problem

The `linux-arm64` build (and the other matrix entries in `build-app`) don't benefit from caching across builds, slowing down testing and releases.

The root cause is in `.github/workflows/rust.yml`. The `build-app` job runs a 5-entry matrix (windows-amd64, linux-amd64, linux-arm64-via-cross, darwin-amd64, darwin-arm64), but the `Swatinem/rust-cache@v2` step had **no distinguishing cache key**.

`Swatinem/rust-cache` derives its automatic cache key from the `github.job` name, the rustc version, and the `Cargo.lock` hash — **not** from matrix values. So all five matrix entries shared one identical cache key:

- Only the first entry to finish saves its cache; the rest get "cache already exists."
- On subsequent runs every entry — including `aarch64-unknown-linux-gnu` (built via `cross`) — restores whichever target's artifacts won the race (e.g. amd64).
- Those artifacts don't match the target being built, so the cache is useless and the build starts from scratch every time.

## Fix

Give each matrix entry its own cache scope via `key: ${{ matrix.target }}`. Each `target` value is unique across the matrix, so every target — including the cross-compiled arm64 build — now gets its own cache that is restored on subsequent runs.

The cross build already mounts the host's `CARGO_HOME` and the project's `target/` directory, so once the cache key no longer collides, both the registry and the build artifacts persist and are reused across runs.

https://claude.ai/code/session_01WxkKTs5VFL5RbFiCHstesR

---
_Generated by [Claude Code](https://claude.ai/code/session_01WxkKTs5VFL5RbFiCHstesR)_