### PR TITLE
ci: migrate to SierraSoftworks/setup-protoc fork

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
           components: llvm-tools-preview
 
       - name: install protoc
-        uses: arduino/setup-protoc@v3
+        uses: SierraSoftworks/setup-protoc@v3.0.1
         with:
           version: ${{ env.PROTOC_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -180,7 +180,7 @@ jobs:
 
     steps:
       - name: install protoc
-        uses: arduino/setup-protoc@v3
+        uses: SierraSoftworks/setup-protoc@v3.0.1
         if: ${{ !matrix.cross }}
         with:
           version: ${{ env.PROTOC_VERSION }}


### PR DESCRIPTION
## Summary

Replaces the deprecated `arduino/setup-protoc@v3` action with the maintained fork `SierraSoftworks/setup-protoc@v3.0.1`.

The fork is a drop-in replacement — its `action.yml` exposes the same inputs (`version`, `repo-token`, `include-pre-releases`) and outputs (`version`, `path`), so only the `uses:` reference changes; the surrounding `with:` blocks (including `version: ${{ env.PROTOC_VERSION }}`) are untouched.

## Changes

- `.github/workflows/rust.yml` (2 occurrences)

## Verification

CI exercises the `install protoc` step on this PR — a green run confirms the fork works as a drop-in replacement.

https://claude.ai/code/session_01QfUTCb69wLXXWD3hTgyWBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfUTCb69wLXXWD3hTgyWBn)_