### PR TITLE
feat: add filt-rs expression checks alongside validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1310,6 +1310,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filt-rs"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b729c44478072040180e720cd278664aeb425bbfe17f6ce00b94b958b09d7c"
+dependencies = [
+ "chrono",
+ "human-errors",
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,6 +1950,7 @@ dependencies = [
  "circular-buffer",
  "clap",
  "ctrlc",
+ "filt-rs",
  "futures",
  "futures-concurrency",
  "futures-lite",
@@ -2157,6 +2170,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "human-errors"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5d10d3cf923652ca5b097e0795ddf1053f56bd7a2f4258089c64f45f1b70335"
 
 [[package]]
 name = "humantime"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ boa_runtime = { git = "https://github.com/boa-dev/boa", features = [
 chrono = { version = "0.4.45", features = ["serde"] }
 circular-buffer = "1.2.0"
 clap = { version = "4.6", features = ["derive"] }
+filt-rs = { version = "1.0.1", features = ["regex", "chrono", "serde"] }
 ctrlc = "3.5.2"
 futures = "0.3"
 futures-concurrency = "7.7.1"

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ probes:
       retries: 3
     target: !Http
       url: https://google.com?q=grey+healthcheck+system
-    validators:
-      http.status: !OneOf [200]
-      http.header.content-type: !Equals "text/html; charset=ISO-8859-1"
+    checks:
+      - http.status == 200
+      - http.header.content-type == "text/html; charset=ISO-8859-1"
     tags:
       service: Google
 
@@ -105,8 +105,28 @@ It exposes the following fields for validation:
 - `script.exit_code`: The exit code of the script execution (0 for success).
 - Custom fields set via `output[key] = value` in the script code.
 
-## Validators
-Validation is performed using one of the provided validation functions.
+## Checks
+Validation is performed using `checks`: expressions written in the
+[`filt-rs`](https://docs.rs/filt-rs/latest/filt_rs/) filter language and evaluated against
+the probe's result. Each expression references the sample's fields and supports comparisons
+(`==`, `!=`, `<`, `>`, …), membership (`in`, `contains`), pattern matching (`like`,
+`matches`), and boolean composition (`&&`, `||`, `!`). A probe fails as soon as any of its
+checks does not match.
+
+```yaml
+    checks:
+      - http.status == 200
+      - http.status in [200, 204]
+      - http.header.content-type contains "text/html"
+```
+
+## Validators (deprecated)
+> [!WARNING]
+> Validators are deprecated in favour of [checks](#checks). They still work, but new probes
+> should use checks and existing probes should migrate when convenient — each validator maps
+> directly to a check (`!Equals` → `==`, `!OneOf` → `in`, `!Contains` → `contains`).
+
+The older per-field validators are configured under a `validators` block:
 
 ### `!Equals`
 The `!Equals` validator asserts that the value of the field is equal to the

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -31,6 +31,7 @@ actix-web.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 ctrlc.workspace = true
+filt-rs.workspace = true
 boa_engine = { workspace = true, optional = true }
 boa_gc = { workspace = true, optional = true }
 boa_runtime = { workspace = true, features = ["reqwest-blocking"], optional = true }

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -199,6 +199,44 @@ impl Default for ClusterConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The shipped `checks` example must parse through the real configuration
+    /// loader, exercising `filt-rs` deserialization end-to-end and guarding the
+    /// example against drift.
+    #[tokio::test]
+    async fn loads_checks_example() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../example/checks.yml");
+        let config = Config::load_from_path(&path)
+            .await
+            .expect("example/checks.yml should load");
+
+        let probe = config
+            .probes
+            .iter()
+            .find(|p| p.name == "example.checks")
+            .expect("example.checks probe should be present");
+        assert_eq!(probe.checks.len(), 2);
+
+        // The probe that mixes a classic validator with a check round-trips both.
+        let mixed = config
+            .probes
+            .iter()
+            .find(|p| p.name == "github.repo")
+            .expect("github.repo probe should be present");
+        assert_eq!(mixed.validators.len(), 1);
+        assert_eq!(mixed.checks.len(), 1);
+
+        // A check renders as its raw expression, which is what gets reported.
+        assert_eq!(
+            mixed.checks[0].to_string(),
+            r#"http.header.content-type matches r"^text/html""#
+        );
+    }
+}
+
 mod default {
     use super::*;
 

--- a/agent/src/probe.rs
+++ b/agent/src/probe.rs
@@ -13,6 +13,12 @@ pub struct Probe {
     pub tags: HashMap<String, String>,
     #[serde(default)]
     pub validators: HashMap<String, ValidatorType>,
+    /// `filt-rs` expression checks evaluated against the whole sample, offered
+    /// alongside the per-field `validators` as a more expressive way to assert
+    /// on a probe's result. Each expression is parsed at config-load time and
+    /// reported as its own validation.
+    #[serde(default)]
+    pub checks: Vec<filt_rs::Filter>,
 }
 
 impl Probe {
@@ -24,11 +30,52 @@ impl Probe {
             target: crate::targets::TargetType::test(),
             tags: HashMap::new(),
             validators: vec![("output.test".into(), crate::validators::ValidatorType::test())].into_iter().collect(),
+            checks: vec![filt_rs::Filter::new("output.test == true").unwrap()],
         }
     }
 
     pub fn next_start_time(&self) -> Instant {
         Instant::now() + random_start_offset(self.policy.interval)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const BASE: &str = r#"
+name: example
+policy:
+  interval: 5s
+  timeout: 2s
+  retries: 3
+target: !Http
+  url: https://example.com
+"#;
+
+    #[test]
+    fn checks_default_to_empty() {
+        let probe: Probe = serde_yaml::from_str(BASE).expect("deserialize probe");
+        assert!(probe.checks.is_empty());
+    }
+
+    #[test]
+    fn deserializes_checks_into_filters() {
+        let yaml = format!(
+            "{BASE}checks:\n  - http.status >= 200 && http.status < 300\n  - http.header.content-type contains \"html\"\n"
+        );
+        let probe: Probe = serde_yaml::from_str(&yaml).expect("deserialize probe");
+        assert_eq!(probe.checks.len(), 2);
+        assert_eq!(
+            probe.checks[0].raw(),
+            "http.status >= 200 && http.status < 300"
+        );
+    }
+
+    #[test]
+    fn invalid_check_expression_fails_to_deserialize() {
+        let yaml = format!("{BASE}checks:\n  - \"http.status >\"\n");
+        assert!(serde_yaml::from_str::<Probe>(&yaml).is_err());
     }
 }
 

--- a/agent/src/probe_runner.rs
+++ b/agent/src/probe_runner.rs
@@ -240,6 +240,44 @@ impl ProbeRunner {
             }
         }
 
+        for check in &probe.checks {
+            let name = format!("check {}", check);
+            let span = info_span!(
+                "probe.validate",
+                otel.name=name,
+                field=%check,
+                validator=%check,
+                otel.status_code=?OpenTelemetryStatus::Unset,
+                otel.status_message=EmptyField
+            )
+            .entered();
+
+            let outcome = match check.matches(&sample) {
+                Ok(true) => Ok(()),
+                Ok(false) => Err(format!("The check '{}' did not pass.", check)),
+                Err(e) => Err(format!("The check '{}' could not be evaluated: {}", check, e)),
+            };
+
+            match outcome {
+                Ok(_) => {
+                    span.record("otel.status_code", "Ok");
+                    result
+                        .validations
+                        .insert(check.to_string(), ValidationResult::pass(check));
+                }
+                Err(message) => {
+                    let err: Box<dyn std::error::Error> = message.into();
+                    span.record("otel.status_code", "Error")
+                        .record("otel.status_message", err.to_string());
+                    error!(error = err, "{}", err);
+                    result
+                        .validations
+                        .insert(check.to_string(), ValidationResult::fail(check, &err));
+                    return Err(err);
+                }
+            }
+        }
+
         Ok(())
     }
 }

--- a/agent/src/sample.rs
+++ b/agent/src/sample.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display};
+use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
 use serde::{Deserialize, Serialize, de::Visitor};
 
@@ -99,6 +99,34 @@ impl Display for SampleValue {
             SampleValue::Int(value) => write!(f, "{}", value),
             SampleValue::Bool(value) => write!(f, "{}", value),
             SampleValue::List(value) => write!(f, "[{}]", value.iter().map(SampleValue::to_string).collect::<Vec<_>>().join(", ")),
+        }
+    }
+}
+
+impl filt_rs::Filterable for Sample {
+    /// Exposes the sample's collected fields to the `filt-rs` expression
+    /// language so probes can be validated with `checks` alongside the classic
+    /// per-field `validators`. Unknown keys resolve to `null`, matching both
+    /// `Sample::get` and `filt-rs`'s own convention.
+    fn get(&self, key: &str) -> filt_rs::FilterValue<'_> {
+        self.metadata
+            .get(key)
+            .map(filt_rs::FilterValue::from)
+            .unwrap_or(filt_rs::FilterValue::Null)
+    }
+}
+
+impl<'a> From<&'a SampleValue> for filt_rs::FilterValue<'a> {
+    fn from(value: &'a SampleValue) -> Self {
+        match value {
+            SampleValue::None => filt_rs::FilterValue::Null,
+            SampleValue::String(value) => filt_rs::FilterValue::String(Cow::Borrowed(value)),
+            SampleValue::Double(value) => filt_rs::FilterValue::Number(*value),
+            SampleValue::Int(value) => filt_rs::FilterValue::Number(*value as f64),
+            SampleValue::Bool(value) => filt_rs::FilterValue::Bool(*value),
+            SampleValue::List(value) => {
+                filt_rs::FilterValue::Tuple(value.iter().map(filt_rs::FilterValue::from).collect())
+            }
         }
     }
 }
@@ -307,5 +335,65 @@ mod tests {
         let serialized = serde_json::to_string(value).unwrap();
         println!("Serialized: {serialized} (from {value})");
         serde_json::from_str(&serialized).unwrap()
+    }
+
+    #[test]
+    fn test_sample_value_into_filter_value() {
+        use filt_rs::FilterValue;
+
+        assert_eq!(FilterValue::from(&SampleValue::None), FilterValue::Null);
+        assert_eq!(
+            FilterValue::from(&SampleValue::Bool(true)),
+            FilterValue::Bool(true)
+        );
+        assert_eq!(
+            FilterValue::from(&SampleValue::Int(42)),
+            FilterValue::Number(42.0)
+        );
+        assert_eq!(
+            FilterValue::from(&SampleValue::Double(3.5)),
+            FilterValue::Number(3.5)
+        );
+        assert_eq!(
+            FilterValue::from(&SampleValue::String("hello".into())),
+            FilterValue::String("hello".into())
+        );
+        assert_eq!(
+            FilterValue::from(&SampleValue::List(vec![
+                SampleValue::Int(1),
+                SampleValue::String("a".into()),
+            ])),
+            FilterValue::Tuple(vec![FilterValue::Number(1.0), FilterValue::String("a".into())])
+        );
+    }
+
+    #[test]
+    fn test_sample_is_filterable() {
+        use filt_rs::{Filter, FilterValue, Filterable};
+
+        let sample = Sample::default()
+            .with("http.status", 200)
+            .with("http.header.content-type", "text/html");
+
+        // Present keys resolve to their values; missing keys resolve to null.
+        // (Call the trait method explicitly, since the inherent `Sample::get`
+        // shadows it for direct `sample.get(..)` calls.)
+        assert_eq!(
+            Filterable::get(&sample, "http.status"),
+            FilterValue::Number(200.0)
+        );
+        assert_eq!(
+            Filterable::get(&sample, "missing.key"),
+            FilterValue::Null
+        );
+
+        // Hyphenated and dotted property names are usable directly in expressions.
+        let filter =
+            Filter::new(r#"http.status >= 200 && http.status < 300 && http.header.content-type contains "html""#)
+                .expect("parse filter");
+        assert!(filter.matches(&sample).expect("evaluate filter"));
+
+        let failing = Filter::new("http.status == 500").expect("parse filter");
+        assert!(!failing.matches(&sample).expect("evaluate filter"));
     }
 }

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -71,6 +71,10 @@ export default defineUserConfig({
         ]
       },
       {
+        text: "Checks",
+        link: "/checks/",
+      },
+      {
         text: "User Interface",
         link: "/ui/",
         children: [
@@ -125,6 +129,14 @@ export default defineUserConfig({
             '/validators/contains.md',
             '/validators/equals.md',
             '/validators/one_of.md',
+          ]
+        }
+      ],
+      '/checks/': [
+        {
+          text: "Checks",
+          children: [
+            '/checks/README.md',
           ]
         }
       ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,9 +49,9 @@ probes:
       retries: 3
     target: !Http
       url: https://google.com?q=grey+healthcheck+system
-    validators:
-      http.status: !OneOf [200]
-      http.header.content-type: !Equals "text/html; charset=ISO-8859-1"
+    checks:
+      - http.status == 200
+      - http.header.content-type == "text/html; charset=ISO-8859-1"
     tags:
       service: Google
 

--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -1,0 +1,117 @@
+# Introduction
+**Checks** are the recommended way to validate a probe's result. A check is an expression
+written in the [`filt-rs`](https://docs.rs/filt-rs/latest/filt_rs/) filter language and
+evaluated against the *whole* sample, so a single check can compare fields, combine
+conditions, match patterns, and more.
+
+::: warning
+Checks supersede the older per-field [validators](../validators/README.md), which are now
+**deprecated**. Validators continue to work, so you can migrate at your own pace, but new
+probes should use checks and existing probes should move across when convenient. See
+[Migrating from validators](#migrating-from-validators) for a field-by-field guide.
+:::
+
+::: tip
+Validators and checks can be used together on the same probe, so you can adopt checks
+gradually — expression by expression — while you migrate.
+:::
+
+Each entry under `checks:` is parsed when the configuration is loaded (so a malformed
+expression is reported immediately, not at run time), and each is reported as its own
+pass/fail validation in the dashboard and telemetry, labelled with the expression itself.
+A probe fails as soon as any one of its checks does not match.
+
+## Example
+
+```yaml{12-15}
+probes:
+  - name: http.example
+    policy:
+      interval: 5s
+      timeout: 2s
+      retries: 3
+    target: !Http
+      url: https://example.com
+    validators:
+      # Classic validators still work exactly as before.
+      http.status: !OneOf [200]
+    checks:
+      # A check is a single expression evaluated against the whole sample.
+      - http.status >= 200 && http.status < 300
+      - http.header.content-type contains "html"
+```
+
+## Expression language
+
+A check is any single `filt-rs` expression that evaluates to a truthy value when the probe
+should be considered healthy. Sample fields are referenced by the same dotted names used by
+validators (for example `http.status` or `http.header.content-type`); names containing `.`
+and `-` are supported directly, and an unknown field resolves to `null`.
+
+The most useful operators are summarised below — see the
+[`filt-rs` documentation](https://docs.rs/filt-rs/latest/filt_rs/) for the full language.
+
+| Operator                       | Meaning                                                      |
+|--------------------------------|-------------------------------------------------------------|
+| `\|\|`, `&&`, `!`              | Logical OR, AND, NOT.                                        |
+| `==`, `!=`                     | Equality (strings compare case-insensitively).              |
+| `>`, `>=`, `<`, `<=`           | Ordering comparisons.                                        |
+| `contains`, `in`               | Substring / tuple membership (`a in b` ≡ `b contains a`).   |
+| `startswith`, `endswith`       | String prefix / suffix tests.                               |
+| `like`                         | Case-insensitive glob match (`*` and `?` wildcards).        |
+| `matches`                      | Regular-expression match.                                   |
+| `+`, `-`                       | Arithmetic on numbers, datetimes, and durations.            |
+| `now()`                        | The current UTC time, for relative-time comparisons.        |
+
+The string operators are case-insensitive by default; each has a case-sensitive `_cs`
+variant (`contains_cs`, `startswith_cs`, …). String literals use double quotes (`"text"`),
+and raw strings (`r"^v\d+$"`) are handy for regular expressions.
+
+## Migrating from validators
+
+Every validator has a direct check equivalent. A validator keyed by a field path becomes an
+expression that references that same field, so migrating is largely mechanical:
+
+| Validator                                 | Equivalent check                          |
+|-------------------------------------------|-------------------------------------------|
+| `http.status: !Equals 200`                | `http.status == 200`                      |
+| `http.status: !NotEquals 500`             | `http.status != 500`                      |
+| `http.status: !OneOf [200, 204]`          | `http.status in [200, 204]`               |
+| `http.header.content-type: !Contains "html"` | `http.header.content-type contains "html"` |
+| `dns.answers: !Contains "10 mx.example.com"` | `"10 mx.example.com" in dns.answers`   |
+
+A probe that previously listed several validators becomes one check per condition (a probe
+fails as soon as any check does not match, exactly as it did with validators):
+
+```yaml
+# Before — per-field validators:
+    validators:
+      http.status: !OneOf [200, 204]
+      http.header.content-type: !Contains "html"
+
+# After — checks:
+    checks:
+      - http.status in [200, 204]
+      - http.header.content-type contains "html"
+```
+
+Once you have moved everything across, you can drop the probe's `validators:` block
+entirely. You can also fold related conditions into a single expression and reach for
+operators that validators never offered — ranges, regular expressions, and relationships
+between fields:
+
+```yaml
+    checks:
+      # A range, a regex, and a relationship between fields.
+      - http.status >= 200 && http.status < 400
+      - http.header.content-type matches r"^application/json"
+      - net.ip in dns.answers
+```
+
+::: tip Behavioural note
+`filt-rs` compares strings **case-insensitively** by default, so `==`, `contains`,
+`startswith`, and `endswith` ignore case where the equivalent validators compared exactly.
+When you need an exact, case-sensitive comparison, use the `_cs` variants
+(`contains_cs`, `startswith_cs`, `endswith_cs`) or an anchored regular expression with
+`matches`.
+:::

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -33,10 +33,18 @@ probes:
       retries: 3
     target: !Http
       url: https://google.com?q=grey+healthcheck+system
-    validators:
-      http.status: !OneOf [200]
-      http.header.content-type: !Contains "text/html"
+    checks:
+      - http.status == 200
+      - http.header.content-type contains "text/html"
 ```
+
+::: tip
+`checks` are validation expressions written in the
+[`filt-rs`](https://docs.rs/filt-rs/latest/filt_rs/) language and are the recommended way to
+assert that a target is healthy. The older per-field [validators](../validators/README.md)
+are deprecated but still supported. See the [Checks](../checks/README.md) guide for the full
+expression language.
+:::
 
 ## Step #3: Telemetry
 Grey is designed to record the health of your services through the use of OpenTelemetry tracing

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -21,7 +21,7 @@ automatically if it doesn't exist.
 
 ## Probes
 Probes are the core of Grey's configuration. Each probe defines a single target and a set
-of validators that will be used to assert that the target is healthy. In addition to these
+of checks that will be used to assert that the target is healthy. In addition to these
 properties, a probe has a `name`, and a policy governing how frequently it is executed and
 how timeouts and retries should be handled.
 
@@ -34,9 +34,9 @@ probes:
         retries: 3
       target: !Http
         url: https://example.com
-      validators:
-        http.status: !OneOf [200]
-        http.header.content-type: !Contains "text/html"
+      checks:
+        - http.status == 200
+        - http.header.content-type contains "text/html"
 ```
 
 ### Name
@@ -76,10 +76,28 @@ the URL that will be probed.
 You can read more about the various target types in the [Targets](../targets/README.md) section
 of the documentation.
 
+### Checks
+The `checks` property defines a list of expressions, written in the
+[`filt-rs`](https://docs.rs/filt-rs/latest/filt_rs/) filter language, that are evaluated
+against the probe's result to assert that the target is healthy. Each expression references
+the sample's fields (such as `http.status`) and can combine conditions, compare ranges,
+match patterns, and relate one field to another. A probe fails as soon as any of its checks
+does not match.
+
+You can read more about the expression language and the available operators in the
+[Checks](../checks/README.md) section of the documentation.
+
 ### Validators
-The `validators` property defines the set of validators that will be used to assert that
-the target is healthy. Each validator targets a specific field and accepts a distinct set
-of configuration options which are documented on their respective pages.
+
+::: warning Deprecated
+The `validators` property is deprecated in favour of [checks](#checks). It continues to work,
+but new probes should use checks and existing probes should migrate when convenient — see
+[Migrating from validators](../checks/README.md#migrating-from-validators).
+:::
+
+The `validators` property defines a set of per-field validators that will be used to assert
+that the target is healthy. Each validator targets a specific field and accepts a distinct
+set of configuration options which are documented on their respective pages.
 
 You can read more about the various validators in the [Validators](../validators/README.md)
 section of the documentation.

--- a/docs/validators/README.md
+++ b/docs/validators/README.md
@@ -3,6 +3,15 @@ Grey exposes a standard set of validators which can be used to assert that a ser
 matches your expectations. These validators are designed to be straightforward to use and broadly
 applicable, keeping the configuration simple and easy to understand.
 
+::: warning Deprecated
+Validators are **deprecated** in favour of [checks](../checks/README.md), which validate a
+probe using the more expressive `filt-rs` expression language. Validators still work, so
+existing configurations keep running, but new probes should use checks and existing probes
+should migrate when convenient. See
+[Migrating from validators](../checks/README.md#migrating-from-validators) for a
+field-by-field guide.
+:::
+
 ::: tip
 For a quick introduction to using Grey to probe a service, take a look at the
 [Usage Guide](../guide/README.md).

--- a/docs/validators/contains.md
+++ b/docs/validators/contains.md
@@ -6,6 +6,12 @@ field being tested.
 The `!Contains` validator accepts a single argument, which is the value to check for. If performing string comparisons
 this value **MUST** be a string, while if performing list membership it **MUST** be the same type as the list's elements.
 
+::: warning Deprecated
+Validators are deprecated in favour of [checks](../checks/README.md). Replace `!Contains`
+with the `contains` (or `in`) operator — see [Migrating to a check](#migrating-to-a-check)
+below.
+:::
+
 ## Example
 
 ```yaml{10-11,22-24}
@@ -34,3 +40,25 @@ probes:
       # with the value "10 smtp.example.com".
       dns.answers: !Contains "10 smtp.example.com"
 ```
+
+## Migrating to a check
+
+Use the `contains` operator for substring checks, and either `contains` or the more natural
+`in` operator for list membership:
+
+```yaml
+# Before:
+    validators:
+      http.header.content-type: !Contains "text/html"
+      dns.answers: !Contains "10 smtp.example.com"
+
+# After:
+    checks:
+      - http.header.content-type contains "text/html"
+      - "10 smtp.example.com" in dns.answers
+```
+
+::: tip
+String `contains` is **case-insensitive**; use `contains_cs` when you need an exact,
+case-sensitive substring match.
+:::

--- a/docs/validators/equals.md
+++ b/docs/validators/equals.md
@@ -3,6 +3,11 @@ The `!Equals` validator asserts that the value of the field is equal to the prov
 it accepts a single argument and requires that both the type and value of the field matches
 that of the value provided.
 
+::: warning Deprecated
+Validators are deprecated in favour of [checks](../checks/README.md). Replace `!Equals` with
+the `==` operator — see [Migrating to a check](#migrating-to-a-check) below.
+:::
+
 ## Example
 
 ```yaml{10-11}
@@ -18,3 +23,22 @@ probes:
       # This validates that the status code of the response is exactly 200
       http.status: !Equals 200
 ```
+
+## Migrating to a check
+
+Replace the validator with the `==` operator referencing the same field:
+
+```yaml
+# Before:
+    validators:
+      http.status: !Equals 200
+
+# After:
+    checks:
+      - http.status == 200
+```
+
+::: tip
+String equality with `==` is **case-insensitive**. For an exact, case-sensitive match use an
+anchored regular expression instead, e.g. `http.header.content-type matches r"^text/html$"`.
+:::

--- a/docs/validators/one_of.md
+++ b/docs/validators/one_of.md
@@ -7,6 +7,11 @@ The `!OneOf` validator accepts a list of values as its argument. The values cont
 its list must match the type of of the field being validated. For example, if the field is a string,
 the values in the list must also be strings.
 
+::: warning Deprecated
+Validators are deprecated in favour of [checks](../checks/README.md). Replace `!OneOf` with
+the `in` operator — see [Migrating to a check](#migrating-to-a-check) below.
+:::
+
 ## Example
 
 ```yaml{10-11}
@@ -21,4 +26,18 @@ probes:
     validators:
       # This validates that the status code of the response is either 200 or 204
       http.status: !OneOf [200, 204]
+```
+
+## Migrating to a check
+
+Use the `in` operator with the same list of accepted values:
+
+```yaml
+# Before:
+    validators:
+      http.status: !OneOf [200, 204]
+
+# After:
+    checks:
+      - http.status in [200, 204]
 ```

--- a/example/checks.yml
+++ b/example/checks.yml
@@ -1,0 +1,43 @@
+---
+# This example demonstrates `checks`: validation expressions written in the filt-rs
+# language (https://docs.rs/filt-rs) and evaluated against the whole probe sample.
+# Checks live happily alongside the classic per-field `validators`, so you can adopt
+# them gradually.
+ui:
+  enabled: true
+  listen: 127.0.0.1:3002
+
+probes:
+  # A probe validated entirely with checks.
+  - name: example.checks
+    policy:
+      interval: 5s
+      timeout: 2s
+      retries: 3
+    target: !Http
+      url: https://example.com
+    checks:
+      # A status-code range, instead of enumerating every acceptable value.
+      - http.status >= 200 && http.status < 300
+      # A case-insensitive substring test against a hyphenated header field.
+      - http.header.content-type contains "html"
+    tags:
+      domain: example.com
+      service: Example
+
+  # The same probe can mix classic validators with checks.
+  - name: github.repo
+    policy:
+      interval: 5s
+      timeout: 2s
+      retries: 3
+    target: !Http
+      url: https://github.com/SierraSoftworks/grey
+    validators:
+      http.status: !OneOf [200]
+    checks:
+      # A regular-expression match (requires the filt-rs `regex` feature, enabled by Grey).
+      - http.header.content-type matches r"^text/html"
+    tags:
+      domain: github.com
+      service: Coding


### PR DESCRIPTION
## Overview

Adds a new `checks` field to probes that validates a sample using
[`filt-rs`](https://docs.rs/filt-rs/latest/filt_rs/) filter expressions — a far more
expressive alternative to the existing per-field `validators`. Both run **side-by-side**, so
users can migrate at their own pace.

Where a validator asserts on a single field (`http.status: !OneOf [200]`), a check is a
single boolean expression evaluated against the whole sample
(`http.status >= 200 && http.status < 300`), unlocking ranges, regex, glob matching,
boolean composition, and relationships between fields.

## What changed

**Engine**
- Add `filt-rs` v1.0.1 (`regex`, `chrono`, `serde` features).
- Implement `filt_rs::Filterable` for `Sample` and `From<&SampleValue>` for `FilterValue`, so expressions resolve the same dotted field names validators already use (unknown keys → `null`).
- Add `Probe.checks: Vec<filt_rs::Filter>`, deserialized straight from expression strings — **malformed expressions fail at config-load time**.
- Evaluate checks in `probe_runner` mirroring the validators loop: each check is reported as its own `ValidationResult` (keyed/labelled by the expression text), with the same short-circuit-on-first-failure and tracing-span behaviour. Runtime evaluation errors surface as a failed check.

**Docs**
- New **Checks** docs section (wired into the navbar/sidebar) with the expression language and operators.
- Marked **validators as deprecated** across the docs (validators pages, configuration guide, quickstart, READMEs) with a centralized **Migrating from validators** field-by-field guide (`!Equals`→`==`, `!OneOf`→`in`, `!Contains`→`contains`/`in`).
- New `example/checks.yml` demonstrating checks alone and checks mixed with a validator.

## Reviewer notes

- **No behaviour change for existing configs** — `checks` defaults to empty and `validators` is untouched.
- **Case sensitivity**: `filt-rs` compares strings case-insensitively by default (validators compared exactly). The migration docs call this out and point to the `_cs` operator variants / anchored `matches` for exact comparisons.
- Nice side effect: `filt-rs` property names support `.` and `-`, so hyphenated fields like `http.header.content-type` work directly in expressions.

## Testing

- `cargo test -p grey` — all green (95 tests), including new coverage for `SampleValue`→`FilterValue` conversion, `Filterable` end-to-end matching, `checks` YAML deserialization (valid/empty/malformed), and a loader test that round-trips the shipped `example/checks.yml`.
- Not exercised here: running the agent live and viewing checks in the dashboard (needs network/a running instance). The UI renders the validations map generically, so checks appear without UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
