### PR TITLE
ci: fix rust cache for cross (arm64) build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -223,6 +223,16 @@ jobs:
           command: build
           args: --release --target ${{ matrix.target }} ${{ matrix.flags }}
 
+      # cross runs the compiler inside a Docker container as root, so the
+      # registry downloads and build artifacts it writes into the cached
+      # directories end up owned by root. Swatinem/rust-cache's save step runs
+      # as the unprivileged runner user and cannot prune root-owned files,
+      # which causes the cache save to fail and the cross build to never be
+      # cached. Reclaim ownership so the cache can be persisted.
+      - name: Reclaim cache ownership from cross
+        if: ${{ matrix.cross }}
+        run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
+
       - name: Upload GitHub Release Artifacts
         uses: SierraSoftworks/gh-releases@v1.0.9
         if: github.event_name == 'release'


### PR DESCRIPTION
## Problem

The `cross`-built (linux-arm64) target in `rust.yml` never benefits from `Swatinem/rust-cache` — every run starts cold and recompiles from scratch.

## Root cause

The arm64 build runs `cross` (via `actions-rs/cargo` with `use-cross: ${{ matrix.cross }}`), which compiles inside a Docker container running as **root**. It bind-mounts the host cargo registry (`~/.cargo`) and writes artifacts into `./target` — exactly the paths `rust-cache` caches — so every file it writes ends up owned by `root:root`. `rust-cache`'s post-job **save** step runs as the unprivileged `runner` user and can't prune root-owned files, so the save fails and no cache is ever stored for the cross target. The native builds run as the runner directly, so they're unaffected.

## Fix

After the build, reclaim ownership of the cached paths so `rust-cache`'s save step can prune and persist them:

```yaml
- name: Reclaim cache ownership from cross
  if: ${{ matrix.cross }}
  run: sudo chown -R "$(id -u):$(id -g)" "$HOME/.cargo" target
```

Ports the fix from SierraSoftworks/automate#197. The gate is adapted to this repo's matrix shape — grey selects cross via `matrix.cross` (consistent with the existing `if: ${{ !matrix.cross }}` on the protoc step) rather than `matrix.builder`.

https://claude.ai/code/session_01MsS7yTeVW686QKQcTa3HgW

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsS7yTeVW686QKQcTa3HgW)_