### PR TITLE
chore(deps): upgrade filt-rs to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1311,9 +1311,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filt-rs"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba8a8018aa38b1fdd61f1e0132ae724ba0640c4938b2fc9010396d4adad5b475"
+checksum = "b6b2137f98f1cdb6e92f000d78ff8a094f12d66d0acda26c239d59a2c9675155"
 dependencies = [
  "chrono",
  "human-errors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ boa_runtime = { git = "https://github.com/boa-dev/boa", features = [
 chrono = { version = "0.4.45", features = ["serde"] }
 circular-buffer = "1.2.0"
 clap = { version = "4.6", features = ["derive"] }
-filt-rs = { version = "1.0.1", features = ["regex", "chrono", "serde"] }
+filt-rs = { version = "1.1.0", features = ["regex", "chrono", "serde"] }
 ctrlc = "3.5.2"
 futures = "0.3"
 futures-concurrency = "7.7.1"


### PR DESCRIPTION
## Summary

Upgrades the [`filt-rs`](https://github.com/SierraSoftworks/filters) crate from **1.0.3 → 1.1.0** (workspace constraint `1.0.1` → `1.1.0`).

filt-rs powers the `checks:` expression language used by probes (see [`docs/checks`](docs/checks/README.md)). The 1.1.0 release ([v1.0.3...v1.1.0](https://github.com/SierraSoftworks/filters/compare/v1.0.3...v1.1.0)) is **additive with no breaking changes**:

- Parses Rust hashed raw-string literals (`r#"..."#`) in expressions
- Adds a `trim(string)` built-in function
- Exposes a `Function` trait so custom filter functions can be defined

These land as new capabilities available to probe `checks:` expressions; nothing existing changes.

## Changes

- `Cargo.toml` — workspace `filt-rs` constraint `1.0.1` → `1.1.0`
- `Cargo.lock` — `filt-rs` `1.0.3` → `1.1.0`

The lock change is deliberately scoped to just `filt-rs`. A full `cargo update -p filt-rs` additionally consolidated some unrelated transitive crates (`socket2`, `proc-macro-crate`) onto already-locked newer versions; that churn is left out of this PR so the upgrade stays reviewable and bisectable.

## Compatibility

Grey only consumes filt-rs in the `grey` (agent) crate, via the stable surface — `Filter`/`Filter::new`/`matches`/`raw`, the `Filterable` trait, `FilterValue`, and serde deserialization of `checks`. None of that API changed, so no code changes were needed.

## Verification

```
cargo test --locked -p grey
# 95 passed; 0 failed
```

`--locked` confirms the minimal lock edit is fully consistent. All filt-rs-backed tests pass, including `config::loads_checks_example`, `probe::deserializes_checks_into_filters`, `probe::invalid_check_expression_fails_to_deserialize`, `sample::test_sample_is_filterable`, and `sample::test_sample_value_into_filter_value`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
