### PR TITLE
feat(replication): replicate incidents and crons as global last-writer-wins entities

### DIFF
--- a/agent/src/api/admin.rs
+++ b/agent/src/api/admin.rs
@@ -1,12 +1,19 @@
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result, http::header, web};
-use chrono::Utc;
-use grey_api::{AdminUser, ApiError, CreateIncident, Identifier, IncidentEdit, IncidentUpdate};
+use grey_api::{
+    AdminUser, ApiError, CreateIncident, CreateUpdate, Identifier, IncidentUpdateId, PutIncident,
+    PutUpdate,
+};
 use serde_json::{Map, Value};
 use std::str::FromStr;
 
 use super::AppState;
 use super::auth::Authenticated;
-use crate::state::{CasOutcome, IncidentStore};
+use super::incidents::ListQuery;
+use crate::state::{CasOutcome, DEFAULT_INCIDENT_PAGE, IncidentStore};
+
+/// The maximum length (bytes) of an incident-update message accepted at ingest. Keeps a single
+/// gossiped update snapshot comfortably within the UDP datagram, which is not fragmented per-entity.
+const MAX_MESSAGE_BYTES: usize = 32 * 1024;
 
 fn not_found() -> HttpResponse {
     HttpResponse::NotFound().json(
@@ -19,7 +26,15 @@ fn not_found() -> HttpResponse {
     )
 }
 
-/// The ETag for an incident is simply its version, quoted per RFC 7232.
+fn too_large() -> HttpResponse {
+    HttpResponse::PayloadTooLarge().json(
+        ApiError::new("The update message is too large.")
+            .with_code(413)
+            .with_advice("Shorten the message; very large updates cannot be replicated across the cluster."),
+    )
+}
+
+/// The ETag for an entity is its version, quoted per RFC 7232.
 fn etag(version: u64) -> String {
     format!("\"{version}\"")
 }
@@ -30,8 +45,30 @@ fn if_match_version(req: &HttpRequest) -> Option<u64> {
     raw.trim().trim_start_matches("W/").trim_matches('"').parse::<u64>().ok()
 }
 
+fn precondition_required() -> HttpResponse {
+    HttpResponse::PreconditionRequired().json(
+        ApiError::new("An If-Match version header is required to edit this resource.")
+            .with_code(428)
+            .with_advice("Reload to obtain the current version, then retry."),
+    )
+}
+
+fn version_conflict(current: u64) -> HttpResponse {
+    HttpResponse::PreconditionFailed()
+        .insert_header((header::ETAG, etag(current)))
+        .json(
+            ApiError::new("The resource was modified by someone else.")
+                .with_code(412)
+                .with_advice("Reload to see the latest version, then try again."),
+        )
+}
+
 fn parse_id(raw: &str) -> Option<Identifier> {
     Identifier::from_str(raw).ok()
+}
+
+fn parse_update_id(raw: &str) -> Option<IncidentUpdateId> {
+    IncidentUpdateId::from_str(raw).ok()
 }
 
 /// `GET /api/v1/admin/me` — the signed-in administrator, derived from validated token claims.
@@ -56,10 +93,15 @@ fn admin_user_from_claims(claims: &Map<String, Value>) -> AdminUser {
     }
 }
 
-/// `GET /api/v1/admin/incidents` — every incident, including hidden ones.
-pub async fn list_incidents(data: web::Data<AppState>) -> Result<HttpResponse> {
-    let incidents = data.state.list_incidents(true).await?;
-    Ok(HttpResponse::Ok().json(incidents))
+/// `GET /api/v1/admin/incidents?limit=&cursor=` — every incident (including hidden), paginated.
+pub async fn list_incidents(
+    data: web::Data<AppState>,
+    query: web::Query<ListQuery>,
+) -> Result<HttpResponse> {
+    let limit = query.limit.unwrap_or(DEFAULT_INCIDENT_PAGE).clamp(1, 100);
+    let cursor = query.cursor.as_deref().and_then(Identifier::parse);
+    let page = data.state.list_incidents(true, limit, cursor).await?;
+    Ok(HttpResponse::Ok().json(page))
 }
 
 /// `GET /api/v1/admin/incidents/{id}` — a single incident (including hidden), with its version ETag.
@@ -71,9 +113,9 @@ pub async fn get_incident(
         return Ok(not_found());
     };
     match data.state.get_incident(id).await? {
-        Some(incident) => Ok(HttpResponse::Ok()
-            .insert_header((header::ETAG, etag(incident.version)))
-            .json(incident)),
+        Some(view) => Ok(HttpResponse::Ok()
+            .insert_header((header::ETAG, etag(view.incident.version)))
+            .json(view)),
         None => Ok(not_found()),
     }
 }
@@ -84,65 +126,125 @@ pub async fn create_incident(
     body: web::Json<CreateIncident>,
 ) -> Result<HttpResponse> {
     let input = body.into_inner();
-    let initial = IncidentUpdate {
-        impact: input.impact,
-        timestamp: Utc::now(),
-        message: input.message,
-    };
-
-    let created = data.state.create_incident(input.title, initial).await?;
+    if input.message.len() > MAX_MESSAGE_BYTES {
+        return Ok(too_large());
+    }
+    let view = data.state.create_incident(input.title, input.impact, input.message).await?;
     Ok(HttpResponse::Created()
-        .insert_header((header::ETAG, etag(created.version)))
-        .json(created))
+        .insert_header((header::ETAG, etag(view.incident.version)))
+        .json(view))
 }
 
-/// `PUT /api/v1/admin/incidents/{id}` — replace an incident's title and updates with a check-and-set
-/// against its version (the `If-Match` ETag). Returns 412 on a version mismatch, 428 when no
-/// `If-Match` is supplied.
-pub async fn replace_incident(
+/// `PUT /api/v1/admin/incidents/{id}` — replace an incident's title with a check-and-set against its
+/// version (the `If-Match` ETag). 412 on a version mismatch, 428 when no `If-Match` is supplied.
+pub async fn put_incident(
     req: HttpRequest,
     data: web::Data<AppState>,
     path: web::Path<String>,
-    body: web::Json<IncidentEdit>,
+    body: web::Json<PutIncident>,
 ) -> Result<HttpResponse> {
     let Some(id) = parse_id(&path.into_inner()) else {
         return Ok(not_found());
     };
-    let Some(expected_version) = if_match_version(&req) else {
-        return Ok(HttpResponse::PreconditionRequired().json(
-            ApiError::new("An If-Match version header is required to edit this incident.")
-                .with_code(428)
-                .with_advice("Reload the incident to obtain its current version, then retry."),
-        ));
+    let Some(expected) = if_match_version(&req) else {
+        return Ok(precondition_required());
     };
 
-    match data.state.replace_incident(id, expected_version, body.into_inner()).await? {
-        CasOutcome::Updated(incident) => Ok(HttpResponse::Ok()
-            .insert_header((header::ETAG, etag(incident.version)))
-            .json(incident)),
-        CasOutcome::VersionMismatch(current) => Ok(HttpResponse::PreconditionFailed()
-            .insert_header((header::ETAG, etag(current)))
-            .json(
-                ApiError::new("The incident was modified by someone else.")
-                    .with_code(412)
-                    .with_advice("Reload the incident to see the latest version, then try again."),
-            )),
+    match data.state.put_incident(id, expected, body.into_inner()).await? {
+        CasOutcome::Updated(version, view) => Ok(HttpResponse::Ok()
+            .insert_header((header::ETAG, etag(version)))
+            .json(view)),
+        CasOutcome::VersionMismatch(current) => Ok(version_conflict(current)),
         CasOutcome::NotFound => Ok(not_found()),
     }
 }
 
-/// `DELETE /api/v1/admin/incidents/{id}` — remove an incident.
+/// `DELETE /api/v1/admin/incidents/{id}` — tombstone an incident (check-and-set against its version).
 pub async fn delete_incident(
+    req: HttpRequest,
     data: web::Data<AppState>,
     path: web::Path<String>,
 ) -> Result<HttpResponse> {
     let Some(id) = parse_id(&path.into_inner()) else {
         return Ok(not_found());
     };
-    if data.state.delete_incident(id).await? {
-        Ok(HttpResponse::NoContent().finish())
-    } else {
-        Ok(not_found())
+    let Some(expected) = if_match_version(&req) else {
+        return Ok(precondition_required());
+    };
+    match data.state.delete_incident(id, expected).await? {
+        CasOutcome::Updated(_, ()) => Ok(HttpResponse::NoContent().finish()),
+        CasOutcome::VersionMismatch(current) => Ok(version_conflict(current)),
+        CasOutcome::NotFound => Ok(not_found()),
+    }
+}
+
+/// `POST /api/v1/admin/incidents/{id}/updates` — add a new update to an incident. 404 if the incident
+/// does not exist. The ETag is the new update's version.
+pub async fn create_update(
+    data: web::Data<AppState>,
+    path: web::Path<String>,
+    body: web::Json<CreateUpdate>,
+) -> Result<HttpResponse> {
+    let Some(id) = parse_id(&path.into_inner()) else {
+        return Ok(not_found());
+    };
+    let input = body.into_inner();
+    if input.message.len() > MAX_MESSAGE_BYTES {
+        return Ok(too_large());
+    }
+    match data.state.create_update(id, input).await? {
+        Some((version, view)) => Ok(HttpResponse::Created()
+            .insert_header((header::ETAG, etag(version)))
+            .json(view)),
+        None => Ok(not_found()),
+    }
+}
+
+/// `PUT /api/v1/admin/incidents/{id}/updates/{uid}` — replace an update's message (check-and-set
+/// against the update's version). The update's impact is fixed once posted.
+pub async fn put_update(
+    req: HttpRequest,
+    data: web::Data<AppState>,
+    path: web::Path<(String, String)>,
+    body: web::Json<PutUpdate>,
+) -> Result<HttpResponse> {
+    let (_incident, uid) = path.into_inner();
+    let Some(uid) = parse_update_id(&uid) else {
+        return Ok(not_found());
+    };
+    let Some(expected) = if_match_version(&req) else {
+        return Ok(precondition_required());
+    };
+    let input = body.into_inner();
+    if input.message.len() > MAX_MESSAGE_BYTES {
+        return Ok(too_large());
+    }
+    match data.state.put_update(uid, expected, input).await? {
+        CasOutcome::Updated(version, view) => Ok(HttpResponse::Ok()
+            .insert_header((header::ETAG, etag(version)))
+            .json(view)),
+        CasOutcome::VersionMismatch(current) => Ok(version_conflict(current)),
+        CasOutcome::NotFound => Ok(not_found()),
+    }
+}
+
+/// `DELETE /api/v1/admin/incidents/{id}/updates/{uid}` — tombstone an update (check-and-set).
+pub async fn delete_update(
+    req: HttpRequest,
+    data: web::Data<AppState>,
+    path: web::Path<(String, String)>,
+) -> Result<HttpResponse> {
+    let (_incident, uid) = path.into_inner();
+    let Some(uid) = parse_update_id(&uid) else {
+        return Ok(not_found());
+    };
+    let Some(expected) = if_match_version(&req) else {
+        return Ok(precondition_required());
+    };
+    match data.state.delete_update(uid, expected).await? {
+        CasOutcome::Updated(_, ()) => Ok(HttpResponse::NoContent().finish()),
+        CasOutcome::VersionMismatch(current) => Ok(version_conflict(current)),
+        CasOutcome::NotFound => Ok(not_found()),
     }
 }
 
@@ -150,10 +252,10 @@ pub async fn delete_incident(
 mod tests {
     use super::*;
     use actix_web::{App, body::MessageBody, http::StatusCode, test};
-    use grey_api::{Impact, Incident};
+    use grey_api::{Impact, IncidentView};
 
     #[actix_web::test]
-    async fn admin_incident_cas_lifecycle() {
+    async fn admin_incident_and_update_lifecycle() {
         // The handlers run through a router (real path/json/header extraction) without the auth
         // middleware — that gate is tested separately in the `api` module.
         let dir = tempfile::tempdir().unwrap();
@@ -164,81 +266,86 @@ mod tests {
                 .route("/incidents", web::get().to(list_incidents))
                 .route("/incidents", web::post().to(create_incident))
                 .route("/incidents/{id}", web::get().to(get_incident))
-                .route("/incidents/{id}", web::put().to(replace_incident))
-                .route("/incidents/{id}", web::delete().to(delete_incident)),
+                .route("/incidents/{id}", web::put().to(put_incident))
+                .route("/incidents/{id}", web::delete().to(delete_incident))
+                .route("/incidents/{id}/updates", web::post().to(create_update))
+                .route("/incidents/{id}/updates/{uid}", web::put().to(put_update))
+                .route("/incidents/{id}/updates/{uid}", web::delete().to(delete_update)),
         )
         .await;
 
-        // Create with an opening update -> 201 + ETag, version 1, public.
+        // Create with an opening update -> 201 + ETag, one update, public.
         let req = test::TestRequest::post()
             .uri("/incidents")
             .set_json(serde_json::json!({ "title": "Outage", "impact": "offline", "message": "Investigating" }))
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::CREATED);
-        assert_eq!(resp.headers().get("etag").unwrap(), "\"1\"");
-        let created: Incident =
-            serde_json::from_slice(&test::read_body(resp).await).unwrap();
-        assert_eq!(created.version, 1);
+        let created: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
         assert_eq!(created.updates.len(), 1);
         assert!(created.is_public());
+        let v0 = created.incident.version;
 
-        // The admin list includes it.
-        let req = test::TestRequest::get().uri("/incidents").to_request();
-        let all: Vec<Incident> = test::call_and_read_body_json(&app, req).await;
-        assert_eq!(all.len(), 1);
-
-        // PUT without If-Match -> 428.
-        let edit = serde_json::json!({
-            "title": "Outage (resolved)",
-            "updates": [
-                { "impact": "offline", "timestamp": 1_700_000_000, "message": "down" },
-                { "impact": "none", "timestamp": 1_700_003_600, "message": "fixed" }
-            ]
-        });
+        // PUT title without If-Match -> 428.
         let req = test::TestRequest::put()
-            .uri(&format!("/incidents/{}", created.id))
-            .set_json(edit.clone())
+            .uri(&format!("/incidents/{}", created.id()))
+            .set_json(serde_json::json!({ "title": "Outage (renamed)" }))
             .to_request();
-        assert_eq!(
-            test::call_service(&app, req).await.status(),
-            StatusCode::PRECONDITION_REQUIRED
-        );
+        assert_eq!(test::call_service(&app, req).await.status(), StatusCode::PRECONDITION_REQUIRED);
 
-        // PUT with the right If-Match -> 200, version bumped to 2.
+        // PUT with the right If-Match -> 200, version bumped.
         let req = test::TestRequest::put()
-            .uri(&format!("/incidents/{}", created.id))
-            .insert_header(("If-Match", "\"1\""))
-            .set_json(edit.clone())
+            .uri(&format!("/incidents/{}", created.id()))
+            .insert_header(("If-Match", etag(v0)))
+            .set_json(serde_json::json!({ "title": "Outage (renamed)" }))
             .to_request();
         let resp = test::call_service(&app, req).await;
         assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(resp.headers().get("etag").unwrap(), "\"2\"");
-        let updated: Incident = serde_json::from_slice(&test::read_body(resp).await).unwrap();
-        assert_eq!(updated.version, 2);
-        assert_eq!(updated.title, "Outage (resolved)");
-        assert_eq!(updated.current_impact(), Impact::None);
+        let updated: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(updated.title(), "Outage (renamed)");
+        let v1 = updated.incident.version;
 
         // PUT again with the stale version -> 412.
         let req = test::TestRequest::put()
-            .uri(&format!("/incidents/{}", created.id))
-            .insert_header(("If-Match", "\"1\""))
-            .set_json(edit)
+            .uri(&format!("/incidents/{}", created.id()))
+            .insert_header(("If-Match", etag(v0)))
+            .set_json(serde_json::json!({ "title": "x" }))
             .to_request();
-        assert_eq!(
-            test::call_service(&app, req).await.status(),
-            StatusCode::PRECONDITION_FAILED
+        assert_eq!(test::call_service(&app, req).await.status(), StatusCode::PRECONDITION_FAILED);
+
+        // Add an update -> 201, two updates, current impact follows the new update.
+        let req = test::TestRequest::post()
+            .uri(&format!("/incidents/{}/updates", created.id()))
+            .set_json(serde_json::json!({ "impact": "none", "message": "Resolved" }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let with_update: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(with_update.updates.len(), 2);
+        assert!(
+            with_update.updates.iter().any(|u| u.impact == Impact::Offline)
+                && with_update.updates.iter().any(|u| u.impact == Impact::None)
         );
 
-        // GET single -> 200 + ETag.
-        let req = test::TestRequest::get().uri(&format!("/incidents/{}", created.id)).to_request();
+        // Edit the new (None) update's message via CAS on its own version.
+        let new_update = with_update.updates.iter().find(|u| u.impact == Impact::None).unwrap().clone();
+        let req = test::TestRequest::put()
+            .uri(&format!("/incidents/{}/updates/{}", created.id(), new_update.id))
+            .insert_header(("If-Match", etag(new_update.version)))
+            .set_json(serde_json::json!({ "message": "All clear" }))
+            .to_request();
         let resp = test::call_service(&app, req).await;
-        assert_eq!(resp.headers().get("etag").unwrap(), "\"2\"");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let edited: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(edited.updates.iter().find(|u| u.id == new_update.id).unwrap().message, "All clear");
 
-        // Delete -> 204, then 404.
-        let req = test::TestRequest::delete().uri(&format!("/incidents/{}", created.id)).to_request();
+        // Delete the incident -> 204, then a GET is 404.
+        let req = test::TestRequest::delete()
+            .uri(&format!("/incidents/{}", created.id()))
+            .insert_header(("If-Match", etag(v1)))
+            .to_request();
         assert_eq!(test::call_service(&app, req).await.status(), StatusCode::NO_CONTENT);
-        let req = test::TestRequest::delete().uri(&format!("/incidents/{}", created.id)).to_request();
+        let req = test::TestRequest::get().uri(&format!("/incidents/{}", created.id())).to_request();
         assert_eq!(test::call_service(&app, req).await.status(), StatusCode::NOT_FOUND);
     }
 

--- a/agent/src/api/incidents.rs
+++ b/agent/src/api/incidents.rs
@@ -1,69 +1,81 @@
 use actix_web::{HttpResponse, Result, web};
+use grey_api::Identifier;
+use serde::Deserialize;
 
 use super::AppState;
-use crate::state::IncidentStore;
+use crate::state::{DEFAULT_INCIDENT_PAGE, IncidentStore};
 
-/// `GET /api/v1/incidents` — the publicly visible incidents. Public: only incidents marked visible
-/// are exposed to unauthenticated viewers (administrators use the admin API for the full list).
-pub async fn get_incidents(data: web::Data<AppState>) -> Result<HttpResponse> {
-    let incidents = data.state.list_incidents(false).await?;
-    Ok(HttpResponse::Ok().json(incidents))
+/// Query parameters for the paginated public incident list.
+#[derive(Debug, Deserialize)]
+pub struct ListQuery {
+    /// Page size (clamped to a sane maximum). Defaults to [`DEFAULT_INCIDENT_PAGE`].
+    pub limit: Option<usize>,
+    /// The id returned as `next_cursor` by the previous page; continues with older incidents.
+    pub cursor: Option<String>,
+}
+
+/// `GET /api/v1/incidents?limit=&cursor=` — a page of publicly visible incidents, newest-first, each
+/// with its updates embedded (so the UI needs no follow-up calls). Hidden/draft incidents are
+/// excluded from this unauthenticated view.
+pub async fn get_incidents(
+    data: web::Data<AppState>,
+    query: web::Query<ListQuery>,
+) -> Result<HttpResponse> {
+    let limit = query.limit.unwrap_or(DEFAULT_INCIDENT_PAGE).clamp(1, 100);
+    let cursor = query.cursor.as_deref().and_then(Identifier::parse);
+    let page = data.state.list_incidents(false, limit, cursor).await?;
+    Ok(HttpResponse::Ok().json(page))
 }
 
 #[cfg(test)]
 mod tests {
     use actix_web::body::MessageBody;
     use actix_web::http::StatusCode;
+    use grey_api::{Impact, IncidentsPage};
     use tempfile::tempdir;
 
     use super::*;
 
-    #[actix_web::test]
-    async fn test_get_incidents() {
-        let temp_dir = tempdir().unwrap();
-
-        let app_state = AppState::test(temp_dir.path().to_path_buf()).await;
-        let resp = get_incidents(web::Data::new(app_state)).await;
-
-        let resp = resp.expect("Failed to get incidents");
-        assert_eq!(resp.status(), StatusCode::OK);
-        assert_eq!(resp.headers().get("content-type").and_then(|v| v.to_str().ok()), Some("application/json"));
-        let body_bytes = resp.into_body().try_into_bytes().unwrap();
-        let body = String::from_utf8_lossy(&body_bytes);
-        let incidents: Vec<grey_api::Incident> = serde_json::from_str(&body).unwrap();
-        assert!(incidents.is_empty());
+    fn query(limit: Option<usize>, cursor: Option<String>) -> web::Query<ListQuery> {
+        web::Query(ListQuery { limit, cursor })
     }
 
     #[actix_web::test]
-    async fn test_get_incidents_exposes_only_visible() {
+    async fn empty_when_no_incidents() {
+        let temp_dir = tempdir().unwrap();
+        let app_state = AppState::test(temp_dir.path().to_path_buf()).await;
+        let resp = get_incidents(web::Data::new(app_state), query(None, None)).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().try_into_bytes().unwrap();
+        let page: IncidentsPage = serde_json::from_slice(&body).unwrap();
+        assert!(page.incidents.is_empty());
+        assert!(page.next_cursor.is_none());
+    }
+
+    #[actix_web::test]
+    async fn exposes_only_visible_with_embedded_updates() {
         let temp_dir = tempdir().unwrap();
         let app_state = AppState::test(temp_dir.path().to_path_buf()).await;
 
-        let update = |impact| grey_api::IncidentUpdate {
-            impact,
-            timestamp: chrono::Utc::now(),
-            message: String::new(),
-        };
-        // An offline opening update is public; a hidden one stays a draft.
         let visible = app_state
             .state
-            .create_incident("Visible".into(), update(grey_api::Impact::Offline))
+            .create_incident("Visible".into(), Impact::Offline, "down".into())
             .await
             .unwrap();
         app_state
             .state
-            .create_incident("Hidden".into(), update(grey_api::Impact::Hidden))
+            .create_incident("Hidden".into(), Impact::Hidden, "draft".into())
             .await
             .unwrap();
 
-        let resp = get_incidents(web::Data::new(app_state)).await.expect("Failed to get incidents");
-        let body_bytes = resp.into_body().try_into_bytes().unwrap();
-        let incidents: Vec<grey_api::Incident> =
-            serde_json::from_str(&String::from_utf8_lossy(&body_bytes)).unwrap();
+        let resp = get_incidents(web::Data::new(app_state), query(None, None)).await.unwrap();
+        let body = resp.into_body().try_into_bytes().unwrap();
+        let page: IncidentsPage = serde_json::from_slice(&body).unwrap();
         assert_eq!(
-            incidents.iter().map(|i| i.id).collect::<Vec<_>>(),
-            vec![visible.id],
-            "the public endpoint must hide draft incidents from unauthenticated viewers"
+            page.incidents.iter().map(|v| v.id()).collect::<Vec<_>>(),
+            vec![visible.id()],
+            "the public endpoint hides draft incidents"
         );
+        assert_eq!(page.incidents[0].updates.len(), 1, "updates are embedded in the response");
     }
 }

--- a/agent/src/api/mod.rs
+++ b/agent/src/api/mod.rs
@@ -113,8 +113,11 @@ pub fn create_app() -> App<
                 .route("/incidents", web::get().to(admin::list_incidents))
                 .route("/incidents", web::post().to(admin::create_incident))
                 .route("/incidents/{id}", web::get().to(admin::get_incident))
-                .route("/incidents/{id}", web::put().to(admin::replace_incident))
-                .route("/incidents/{id}", web::delete().to(admin::delete_incident)),
+                .route("/incidents/{id}", web::put().to(admin::put_incident))
+                .route("/incidents/{id}", web::delete().to(admin::delete_incident))
+                .route("/incidents/{id}/updates", web::post().to(admin::create_update))
+                .route("/incidents/{id}/updates/{uid}", web::put().to(admin::put_update))
+                .route("/incidents/{id}/updates/{uid}", web::delete().to(admin::delete_update)),
         )
         .route("/static/{filename:.*}", web::get().to(serve_static))
 }

--- a/agent/src/api/page.rs
+++ b/agent/src/api/page.rs
@@ -21,8 +21,14 @@ pub async fn index(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpRe
         .collect();
     crons.sort_by_key(|c| c.name.clone());
 
-    // Only the publicly visible incidents are server-rendered for unauthenticated viewers.
-    let incidents = data.state.list_incidents(false).await.unwrap_or_default();
+    // Only the first page of publicly visible incidents is server-rendered for unauthenticated
+    // viewers; the client paginates for older ones.
+    let incidents = data
+        .state
+        .list_incidents(false, crate::state::DEFAULT_INCIDENT_PAGE, None)
+        .await
+        .map(|page| page.incidents)
+        .unwrap_or_default();
 
     // Read the embedded HTML template
     let html_template = ASSETS_DIR
@@ -120,11 +126,8 @@ mod tests {
             .state
             .create_incident(
                 "Database outage".into(),
-                grey_api::IncidentUpdate {
-                    impact: grey_api::Impact::Offline,
-                    timestamp: chrono::Utc::now(),
-                    message: String::new(),
-                },
+                grey_api::Impact::Offline,
+                "Investigating".into(),
             )
             .await
             .unwrap();

--- a/agent/src/state/crons.rs
+++ b/agent/src/state/crons.rs
@@ -1,17 +1,23 @@
 //! Cron-state storage: the [`CronStore`] trait and its implementation over the [`State`] redb store,
-//! plus the cluster [`Versioned`] implementation for crons. Kept separate from the underlying store,
-//! mirroring the probe and incident storage splits.
+//! plus the cluster [`Versioned`] / [`GlobalLwwEntity`] implementations for crons.
+//!
+//! Unlike probes (a per-observer record per node), a cron's check-in state is a **single global
+//! record** keyed by the cron's name and resolved by whole-record last-writer-wins. A check-in
+//! appends a run to the latest record this node holds and re-stamps the wall-clock version, so the
+//! history accumulates on the node a cron checks in to; the rare case of the same cron checking in on
+//! two nodes before gossip converges resolves by LWW (the later write wins, the other's run is
+//! dropped) rather than being unioned.
 
 use std::collections::HashMap;
 use std::error::Error;
 
-use grey_api::{Cron, Mergeable};
-use redb::{ReadableDatabase, ReadableTable};
+use grey_api::Cron;
+use redb::{ReadableDatabase, ReadableTable, TableDefinition};
 
 use crate::cluster::Versioned;
 use crate::cron::CronCheckin;
 
-use super::{CRON_FIELDS_TABLE, State};
+use super::{CRON_TABLE, GlobalLwwEntity, LwwFieldValue, State};
 
 impl Versioned for Cron {
     type Diff = Cron;
@@ -23,8 +29,7 @@ impl Versioned for Cron {
     }
 
     fn diff(&self, version: u64) -> Option<Self::Diff> {
-        // `runs` is already bounded, so unlike probes there is no history to trim — the whole record
-        // is the catch-up state.
+        // The whole record is the catch-up state under whole-record LWW.
         if self.version() > version {
             Some(self.clone())
         } else {
@@ -33,18 +38,32 @@ impl Versioned for Cron {
     }
 
     fn apply(&mut self, diff: &Self::Diff) {
-        self.merge(diff);
+        // Whole-record last-writer-wins by version. The authoritative `(version, last_writer)`
+        // tiebreak for equal versions is applied by the gossip store (`State::apply`), which knows the
+        // incoming writer; this version-only form is the defensive fallback for the generic path.
+        if diff.version() > self.version() {
+            *self = diff.clone();
+        }
+    }
+}
+
+impl GlobalLwwEntity for Cron {
+    type Key = &'static str;
+    const TABLE: TableDefinition<'static, &'static str, LwwFieldValue> = CRON_TABLE;
+
+    fn id_field(&self) -> String {
+        self.name.clone()
     }
 }
 
 /// Storage operations for cron state (the cluster-replicated, gossiped check-in records).
 #[allow(async_fn_in_trait)]
 pub trait CronStore {
-    /// The pooled, cluster-merged cron states keyed by cron name, with configuration echo fields
-    /// re-stamped from local config.
+    /// The cluster-wide cron states keyed by cron name, with configuration echo fields re-stamped
+    /// from local config.
     async fn get_cron_states(&self) -> Result<HashMap<String, Cron>, Box<dyn Error>>;
 
-    /// Folds a check-in into this node's record for the named cron. Returns `Ok(false)` when the cron
+    /// Folds a check-in into the global record for the named cron. Returns `Ok(false)` when the cron
     /// is not present in the local configuration (a 404 for the caller).
     async fn record_cron_checkin(
         &self,
@@ -67,16 +86,14 @@ impl CronStore for State {
         let txn = self.database.begin_read()?;
         // The table only exists once something has been written to it; treat its absence as "no
         // cron state yet" rather than an error.
-        if let Ok(table) = txn.open_table(CRON_FIELDS_TABLE) {
+        if let Ok(table) = txn.open_table(CRON_TABLE) {
             for entry in table.iter()?.filter_map(|r| r.ok()) {
                 let (key, value) = entry;
-                let (_node_id, name) = key.value();
-                let (_version, data) = value.value();
+                let name = key.value();
+                let (_version, _last_writer, data) = value.value();
                 if let Ok(snapshot) = rmp_serde::from_slice::<Cron>(data) {
-                    crons
-                        .entry(name.clone())
-                        .and_modify(|existing| existing.merge(&snapshot))
-                        .or_insert_with(|| snapshot.clone());
+                    // A single global record per cron — take it directly (no per-node pooling).
+                    crons.insert(name.to_string(), snapshot);
                 }
             }
         }
@@ -104,12 +121,14 @@ impl CronStore for State {
 
         let txn = self.database.begin_write()?;
         {
-            let mut table = txn.open_table(CRON_FIELDS_TABLE)?;
+            let mut table = txn.open_table(CRON_TABLE)?;
 
+            // Append to the latest global record this node holds (so history accumulates), falling
+            // back to a fresh config-seeded record.
             let mut cron = table
-                .get((self.node_id.into(), name.to_string()))?
+                .get(name)?
                 .and_then(|existing| {
-                    let (_version, data) = existing.value();
+                    let (_version, _last_writer, data) = existing.value();
                     rmp_serde::from_slice::<Cron>(data).ok()
                 })
                 .unwrap_or_else(|| cfg.to_cron());
@@ -119,8 +138,8 @@ impl CronStore for State {
             checkin.apply(&mut cron);
 
             table.insert(
-                (self.node_id.into(), name.to_string()),
-                (cron.version(), rmp_serde::to_vec_named(&cron)?.as_slice()),
+                name,
+                (cron.version(), self.node_id.into(), rmp_serde::to_vec_named(&cron)?.as_slice()),
             )?;
         }
         txn.commit()?;
@@ -197,8 +216,8 @@ mod tests {
         assert_eq!(backup.last_checkin.as_ref().unwrap().message, "done");
     }
 
-    /// A cron record received from a peer through the gossip apply path is stored and surfaces in the
-    /// pooled view even on a node that has no local check-ins for it.
+    /// A cron record received from a peer through the gossip apply path is stored as the global record
+    /// and surfaces in the cluster view even on a node that has no local check-ins for it.
     #[tokio::test]
     async fn cron_replicates_through_gossip_apply() {
         use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
@@ -226,5 +245,42 @@ mod tests {
         let backup = pooled.get("backup").expect("the gossiped cron is pooled");
         assert_eq!(backup.runs.len(), 1);
         assert_eq!(backup.last_checkin.as_ref().unwrap().message, "from-peer");
+    }
+
+    /// Whole-record last-writer-wins: a higher-versioned record replaces a lower-versioned one
+    /// regardless of run contents (no union), and a stale incoming record is ignored.
+    #[tokio::test]
+    async fn cron_apply_is_last_writer_wins() {
+        use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
+        use crate::state::ReplicatedEntity;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_cron(dir.path()).await;
+
+        // Establish a local record by recording a check-in.
+        state
+            .record_cron_checkin("backup", checkin(CronStatus::Succeeded, "local"))
+            .await
+            .unwrap();
+        let local_version = state.get_cron_states().await.unwrap()["backup"].version();
+
+        // A stale peer record (older version) must not overwrite the local one.
+        let mut stale = grey_api::Cron::from_config(
+            "backup",
+            HashMap::new(),
+            grey_api::CronSchedule::Every(Duration::from_secs(60)),
+            None,
+            None,
+        );
+        stale.last_updated = chrono::DateTime::from_timestamp_millis(local_version as i64 - 1_000).unwrap();
+        stale.last_checkin = Some(grey_api::CheckIn { at: stale.last_updated, status: CronStatus::Failed, message: "stale".into() });
+        let mut diff = ClusterStateDiff::new();
+        diff.update(NodeID::new(), "backup".to_string(), ReplicatedEntity::Cron(stale));
+        state.apply(diff).await.unwrap();
+        assert_eq!(
+            state.get_cron_states().await.unwrap()["backup"].last_checkin.as_ref().unwrap().message,
+            "local",
+            "a stale (lower-version) record must not win"
+        );
     }
 }

--- a/agent/src/state/incidents.rs
+++ b/agent/src/state/incidents.rs
@@ -1,152 +1,400 @@
-//! Incident storage: the [`IncidentStore`] trait and its implementation over the [`State`] redb
-//! store, kept separate from the underlying store itself. Incidents are keyed by the numeric value of
-//! their [`Identifier`] and serialized as JSON. Edits are applied as optimistic check-and-set
-//! operations against the incident's `version`.
+//! Incident storage: the [`IncidentStore`] trait and its implementation over the [`State`] redb store.
+//!
+//! Incidents and incident updates are **two separate gossip-replicated entities**, each stored as a
+//! single global row keyed by its own snowflake id (incidents by `u64`, updates by `u128` whose high
+//! 64 bits are the parent incident id, so an incident's updates are a contiguous key range). Both
+//! resolve by whole-entity last-writer-wins (see [`super::GlobalLwwEntity`] and the gossip apply path).
+//! Edits are optimistic check-and-set against each entity's `version` (its wall-clock last-modified
+//! time in milliseconds, surfaced as the HTTP ETag); deletes are propagating tombstones filtered from
+//! all reads.
 
 use std::error::Error;
 
-use grey_api::{Identifier, Incident, IncidentEdit, IncidentUpdate};
+use chrono::{DateTime, Utc};
+use grey_api::{
+    CreateUpdate, Identifier, Impact, Incident, IncidentUpdate, IncidentUpdateId, IncidentView,
+    IncidentsPage, PutIncident, PutUpdate,
+};
 use redb::{ReadableDatabase, ReadableTable, TableDefinition};
 use tracing_batteries::prelude::*;
 
-use super::State;
+use crate::cluster::Versioned;
 
-const INCIDENTS_TABLE: TableDefinition<u64, &[u8]> = TableDefinition::new("incidents");
+use super::{GlobalLwwEntity, INCIDENTS_TABLE, INCIDENT_UPDATES_TABLE, LwwFieldValue, State};
 
-/// The result of a check-and-set [`IncidentStore::replace_incident`].
-pub enum CasOutcome {
-    /// The incident was replaced; carries the new incident (with its bumped version).
-    Updated(Incident),
+/// The default page size for incident listings.
+pub const DEFAULT_INCIDENT_PAGE: usize = 20;
+
+/// The maximum serialized size of a single incident-update snapshot. A gossip datagram is not
+/// fragmented per-entity, so an update larger than this could fail to replicate; reject it at ingest.
+/// Comfortably below the UDP `MAX_DATAGRAM_SIZE` (65507) to leave room for encryption + framing.
+pub const MAX_UPDATE_BYTES: usize = 48 * 1024;
+
+/// Builds a snowflake half: the low 32 bits of the unix-second timestamp in the high half, 32 random
+/// bits in the low half. Time-ordered (to the second) and collision-resistant without coordination.
+fn snowflake_half(now: DateTime<Utc>) -> u64 {
+    let secs = (now.timestamp() as u64) & 0xFFFF_FFFF;
+    (secs << 32) | (rand::random::<u32>() as u64)
+}
+
+/// The result of a check-and-set mutation. `Updated` carries the mutated entity's new `version` (for
+/// the response ETag) and a payload (the refreshed [`IncidentView`], or `()` for deletes).
+pub enum CasOutcome<T> {
+    Updated(u64, T),
     /// The supplied version did not match; carries the current stored version.
     VersionMismatch(u64),
-    /// No incident exists with the given id.
+    /// No (live) entity exists with the given id.
     NotFound,
 }
 
-/// Storage operations for incidents.
+impl Versioned for Incident {
+    type Diff = Incident;
+
+    fn version(&self) -> u64 {
+        self.version
+    }
+
+    fn diff(&self, version: u64) -> Option<Self::Diff> {
+        if self.version() > version {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
+
+    fn apply(&mut self, diff: &Self::Diff) {
+        if diff.version() > self.version() {
+            *self = diff.clone();
+        }
+    }
+}
+
+impl GlobalLwwEntity for Incident {
+    type Key = u64;
+    const TABLE: TableDefinition<'static, u64, LwwFieldValue> = INCIDENTS_TABLE;
+
+    fn id_field(&self) -> String {
+        self.id.to_string()
+    }
+}
+
+impl Versioned for IncidentUpdate {
+    type Diff = IncidentUpdate;
+
+    fn version(&self) -> u64 {
+        self.version
+    }
+
+    fn diff(&self, version: u64) -> Option<Self::Diff> {
+        if self.version() > version {
+            Some(self.clone())
+        } else {
+            None
+        }
+    }
+
+    fn apply(&mut self, diff: &Self::Diff) {
+        if diff.version() > self.version() {
+            *self = diff.clone();
+        }
+    }
+}
+
+impl GlobalLwwEntity for IncidentUpdate {
+    type Key = u128;
+    const TABLE: TableDefinition<'static, u128, LwwFieldValue> = INCIDENT_UPDATES_TABLE;
+
+    fn id_field(&self) -> String {
+        self.id.to_string()
+    }
+}
+
+/// Storage operations for incidents and their updates (cluster-replicated, gossiped global records).
 #[allow(async_fn_in_trait)]
 pub trait IncidentStore {
-    /// Lists stored incidents, most recently started first. When `include_hidden` is false, incidents
-    /// whose current impact is hidden are omitted — the public, unauthenticated view.
-    async fn list_incidents(&self, include_hidden: bool) -> Result<Vec<Incident>, Box<dyn Error>>;
+    /// A page of incidents, newest-first by id, each joined with its visible updates. When
+    /// `include_hidden` is false, incidents whose current impact is hidden are omitted (the public
+    /// view). `cursor` continues a previous page (incidents with an id strictly below it).
+    async fn list_incidents(
+        &self,
+        include_hidden: bool,
+        limit: usize,
+        cursor: Option<Identifier>,
+    ) -> Result<IncidentsPage, Box<dyn Error>>;
 
-    /// Fetches a single incident by id.
-    async fn get_incident(&self, id: Identifier) -> Result<Option<Incident>, Box<dyn Error>>;
+    /// Fetches a single (live) incident with its visible updates.
+    async fn get_incident(&self, id: Identifier) -> Result<Option<IncidentView>, Box<dyn Error>>;
 
-    /// Creates an incident with a single opening update, assigning a fresh unused id and version 1.
+    /// Creates an incident with a single opening update, minting snowflake ids for both.
     async fn create_incident(
         &self,
         title: String,
-        initial: IncidentUpdate,
-    ) -> Result<Incident, Box<dyn Error>>;
+        impact: Impact,
+        message: String,
+    ) -> Result<IncidentView, Box<dyn Error>>;
 
-    /// Replaces an incident's title and updates if `expected_version` matches the stored version,
-    /// bumping the version on success (optimistic concurrency).
-    async fn replace_incident(
+    /// Replaces an incident's editable header fields (its title) if `expected_version` matches.
+    async fn put_incident(
         &self,
         id: Identifier,
         expected_version: u64,
-        edit: IncidentEdit,
-    ) -> Result<CasOutcome, Box<dyn Error>>;
+        edit: PutIncident,
+    ) -> Result<CasOutcome<IncidentView>, Box<dyn Error>>;
 
-    /// Deletes an incident, returning whether a record was actually removed.
-    async fn delete_incident(&self, id: Identifier) -> Result<bool, Box<dyn Error>>;
+    /// Tombstones an incident if `expected_version` matches.
+    async fn delete_incident(
+        &self,
+        id: Identifier,
+        expected_version: u64,
+    ) -> Result<CasOutcome<()>, Box<dyn Error>>;
+
+    /// Adds a new update to an existing incident. `None` when the incident does not exist (a 404). The
+    /// returned tuple is `(new update version, refreshed view)`.
+    async fn create_update(
+        &self,
+        incident_id: Identifier,
+        update: CreateUpdate,
+    ) -> Result<Option<(u64, IncidentView)>, Box<dyn Error>>;
+
+    /// Replaces an update's editable field (its message) if `expected_version` matches.
+    async fn put_update(
+        &self,
+        update_id: IncidentUpdateId,
+        expected_version: u64,
+        edit: PutUpdate,
+    ) -> Result<CasOutcome<IncidentView>, Box<dyn Error>>;
+
+    /// Tombstones an update if `expected_version` matches.
+    async fn delete_update(
+        &self,
+        update_id: IncidentUpdateId,
+        expected_version: u64,
+    ) -> Result<CasOutcome<()>, Box<dyn Error>>;
+}
+
+/// Loads a live incident and its visible (non-tombstoned) updates within a read transaction.
+fn read_view(
+    txn: &redb::ReadTransaction,
+    id: Identifier,
+) -> Result<Option<IncidentView>, Box<dyn Error>> {
+    let key = u64::from(id);
+    let incident = match txn.open_table(INCIDENTS_TABLE) {
+        Ok(table) => match table.get(key)? {
+            Some(value) => {
+                let (_v, _w, data) = value.value();
+                let incident: Incident = rmp_serde::from_slice(data)?;
+                if incident.deleted {
+                    return Ok(None);
+                }
+                incident
+            }
+            None => return Ok(None),
+        },
+        Err(_) => return Ok(None),
+    };
+
+    let mut updates = Vec::new();
+    if let Ok(table) = txn.open_table(INCIDENT_UPDATES_TABLE) {
+        // Every update for this incident shares the high 64 bits of its u128 id.
+        let lo = (key as u128) << 64;
+        let hi = ((key as u128) + 1) << 64;
+        for entry in table.range(lo..hi)?.filter_map(|r| r.ok()) {
+            let (_k, value) = entry;
+            let (_v, _w, data) = value.value();
+            if let Ok(update) = rmp_serde::from_slice::<IncidentUpdate>(data) {
+                if !update.deleted {
+                    updates.push(update);
+                }
+            }
+        }
+    }
+
+    Ok(Some(IncidentView::new(incident, updates)))
+}
+
+impl State {
+    /// Reads the stored incident (including a tombstoned one) for a CAS, returning its current version.
+    fn load_incident(
+        table: &impl ReadableTable<u64, LwwFieldValue>,
+        id: Identifier,
+    ) -> Result<Option<Incident>, Box<dyn Error>> {
+        Ok(table
+            .get(u64::from(id))?
+            .map(|value| {
+                let (_v, _w, data) = value.value();
+                rmp_serde::from_slice::<Incident>(data)
+            })
+            .transpose()?)
+    }
+
+    fn load_update(
+        table: &impl ReadableTable<u128, LwwFieldValue>,
+        id: IncidentUpdateId,
+    ) -> Result<Option<IncidentUpdate>, Box<dyn Error>> {
+        Ok(table
+            .get(u128::from(id))?
+            .map(|value| {
+                let (_v, _w, data) = value.value();
+                rmp_serde::from_slice::<IncidentUpdate>(data)
+            })
+            .transpose()?)
+    }
 }
 
 impl IncidentStore for State {
-    async fn list_incidents(&self, include_hidden: bool) -> Result<Vec<Incident>, Box<dyn Error>> {
+    async fn list_incidents(
+        &self,
+        include_hidden: bool,
+        limit: usize,
+        cursor: Option<Identifier>,
+    ) -> Result<IncidentsPage, Box<dyn Error>> {
+        let limit = limit.max(1);
         let txn = self.database.begin_read()?;
-        let mut incidents = Vec::new();
+
+        let mut incidents: Vec<IncidentView> = Vec::new();
+        let mut next_cursor = None;
+
         if let Ok(table) = txn.open_table(INCIDENTS_TABLE) {
-            for entry in table.iter()?.filter_map(|r| r.ok()) {
-                let (_key, value) = entry;
-                match serde_json::from_slice::<Incident>(value.value()) {
-                    Ok(incident) if include_hidden || incident.is_public() => {
-                        incidents.push(incident)
-                    }
-                    Ok(_) => {}
+            // Newest-first = descending id. A cursor continues with ids strictly below it.
+            let upper = cursor.map(u64::from);
+            let iter = match upper {
+                Some(c) => table.range(..c)?,
+                None => table.range::<u64>(..)?,
+            };
+            for entry in iter.rev().filter_map(|r| r.ok()) {
+                let (key, value) = entry;
+                let id = Identifier::from(key.value());
+                let (_v, _w, data) = value.value();
+                let incident: Incident = match rmp_serde::from_slice(data) {
+                    Ok(i) => i,
                     Err(err) => {
-                        warn!("Skipping an incident record that failed to deserialize: {err:?}")
+                        warn!("Skipping an incident that failed to deserialize: {err:?}");
+                        continue;
                     }
+                };
+                if incident.deleted {
+                    continue;
                 }
+                let Some(view) = read_view(&txn, id)? else { continue };
+                if !include_hidden && !view.is_public() {
+                    continue;
+                }
+                if incidents.len() == limit {
+                    // We already have a full page and found one more match — there is a next page.
+                    next_cursor = incidents.last().map(|v| v.id());
+                    break;
+                }
+                incidents.push(view);
             }
         }
-        // Most recently active first; incidents with no updates sort last.
-        incidents.sort_by(|a, b| b.last_updated().cmp(&a.last_updated()));
-        Ok(incidents)
+
+        Ok(IncidentsPage { incidents, next_cursor })
     }
 
-    async fn get_incident(&self, id: Identifier) -> Result<Option<Incident>, Box<dyn Error>> {
+    async fn get_incident(&self, id: Identifier) -> Result<Option<IncidentView>, Box<dyn Error>> {
         let txn = self.database.begin_read()?;
-        if let Ok(table) = txn.open_table(INCIDENTS_TABLE)
-            && let Some(value) = table.get(u64::from(id))?
-        {
-            return Ok(Some(serde_json::from_slice::<Incident>(value.value())?));
-        }
-        Ok(None)
+        read_view(&txn, id)
     }
 
     async fn create_incident(
         &self,
         title: String,
-        initial: IncidentUpdate,
-    ) -> Result<Incident, Box<dyn Error>> {
-        let txn = self.database.begin_write()?;
-        let incident = {
-            let mut table = txn.open_table(INCIDENTS_TABLE)?;
-
-            let mut key = rand::random::<u64>();
-            let mut attempts = 0;
-            while table.get(key)?.is_some() {
-                key = rand::random::<u64>();
-                attempts += 1;
-                if attempts > 1000 {
-                    return Err("could not allocate a unique incident id".into());
-                }
-            }
-
-            let incident = Incident {
-                id: Identifier::from(key),
-                title,
-                version: 1,
-                updates: vec![initial],
-            };
-            table.insert(key, serde_json::to_vec(&incident)?.as_slice())?;
-            incident
+        impact: Impact,
+        message: String,
+    ) -> Result<IncidentView, Box<dyn Error>> {
+        let now = Utc::now();
+        let version = now.timestamp_millis() as u64;
+        let incident_id = Identifier::from(snowflake_half(now));
+        let update = IncidentUpdate {
+            id: IncidentUpdateId::compose(incident_id, snowflake_half(now)),
+            impact,
+            timestamp: now,
+            message,
+            version,
+            deleted: false,
         };
+        let incident = Incident { id: incident_id, title, version, deleted: false };
+
+        let update_bytes = rmp_serde::to_vec_named(&update)?;
+        if update_bytes.len() > MAX_UPDATE_BYTES {
+            return Err("incident update message is too large".into());
+        }
+        let own: u128 = self.node_id.into();
+
+        let txn = self.database.begin_write()?;
+        {
+            let mut incidents = txn.open_table(INCIDENTS_TABLE)?;
+            incidents.insert(u64::from(incident_id), (version, own, rmp_serde::to_vec_named(&incident)?.as_slice()))?;
+        }
+        {
+            let mut updates = txn.open_table(INCIDENT_UPDATES_TABLE)?;
+            updates.insert(u128::from(update.id), (version, own, update_bytes.as_slice()))?;
+        }
         txn.commit()?;
-        Ok(incident)
+
+        Ok(IncidentView::new(incident, vec![update]))
     }
 
-    async fn replace_incident(
+    async fn put_incident(
         &self,
         id: Identifier,
         expected_version: u64,
-        edit: IncidentEdit,
-    ) -> Result<CasOutcome, Box<dyn Error>> {
-        let key = u64::from(id);
+        edit: PutIncident,
+    ) -> Result<CasOutcome<IncidentView>, Box<dyn Error>> {
+        let own: u128 = self.node_id.into();
+        let new_version = Utc::now().timestamp_millis() as u64;
+
         let txn = self.database.begin_write()?;
         let outcome = {
-            let mut table = txn.open_table(INCIDENTS_TABLE)?;
-            let existing: Option<Incident> = table
-                .get(key)?
-                .map(|value| serde_json::from_slice::<Incident>(value.value()))
-                .transpose()?;
-
-            match existing {
+            let mut incidents = txn.open_table(INCIDENTS_TABLE)?;
+            match Self::load_incident(&incidents, id)? {
                 None => CasOutcome::NotFound,
+                Some(existing) if existing.deleted => CasOutcome::NotFound,
                 Some(existing) if existing.version != expected_version => {
                     CasOutcome::VersionMismatch(existing.version)
                 }
                 Some(existing) => {
-                    let updated = Incident {
-                        id,
-                        title: edit.title,
-                        version: existing.version + 1,
-                        updates: edit.updates,
-                    };
-                    table.insert(key, serde_json::to_vec(&updated)?.as_slice())?;
-                    CasOutcome::Updated(updated)
+                    let updated = Incident { id, title: edit.title, version: new_version, deleted: false };
+                    incidents.insert(u64::from(id), (new_version, own, rmp_serde::to_vec_named(&updated)?.as_slice()))?;
+                    let _ = existing;
+                    CasOutcome::Updated(new_version, ())
+                }
+            }
+        };
+        txn.commit()?;
+
+        match outcome {
+            CasOutcome::Updated(version, ()) => {
+                let view = self.get_incident(id).await?.ok_or("incident vanished after update")?;
+                Ok(CasOutcome::Updated(version, view))
+            }
+            CasOutcome::VersionMismatch(v) => Ok(CasOutcome::VersionMismatch(v)),
+            CasOutcome::NotFound => Ok(CasOutcome::NotFound),
+        }
+    }
+
+    async fn delete_incident(
+        &self,
+        id: Identifier,
+        expected_version: u64,
+    ) -> Result<CasOutcome<()>, Box<dyn Error>> {
+        let own: u128 = self.node_id.into();
+        let new_version = Utc::now().timestamp_millis() as u64;
+
+        let txn = self.database.begin_write()?;
+        let outcome = {
+            let mut incidents = txn.open_table(INCIDENTS_TABLE)?;
+            match Self::load_incident(&incidents, id)? {
+                None => CasOutcome::NotFound,
+                Some(existing) if existing.deleted => CasOutcome::NotFound,
+                Some(existing) if existing.version != expected_version => {
+                    CasOutcome::VersionMismatch(existing.version)
+                }
+                Some(mut existing) => {
+                    existing.deleted = true;
+                    existing.version = new_version;
+                    incidents.insert(u64::from(id), (new_version, own, rmp_serde::to_vec_named(&existing)?.as_slice()))?;
+                    CasOutcome::Updated(new_version, ())
                 }
             }
         };
@@ -154,85 +402,407 @@ impl IncidentStore for State {
         Ok(outcome)
     }
 
-    async fn delete_incident(&self, id: Identifier) -> Result<bool, Box<dyn Error>> {
+    async fn create_update(
+        &self,
+        incident_id: Identifier,
+        update: CreateUpdate,
+    ) -> Result<Option<(u64, IncidentView)>, Box<dyn Error>> {
+        let now = Utc::now();
+        let version = now.timestamp_millis() as u64;
+        let new_update = IncidentUpdate {
+            id: IncidentUpdateId::compose(incident_id, snowflake_half(now)),
+            impact: update.impact,
+            timestamp: now,
+            message: update.message,
+            version,
+            deleted: false,
+        };
+        let update_bytes = rmp_serde::to_vec_named(&new_update)?;
+        if update_bytes.len() > MAX_UPDATE_BYTES {
+            return Err("incident update message is too large".into());
+        }
+        let own: u128 = self.node_id.into();
+
         let txn = self.database.begin_write()?;
-        let existed = {
-            let mut table = txn.open_table(INCIDENTS_TABLE)?;
-            table.remove(u64::from(id))?.is_some()
+        {
+            // The incident must exist and be live.
+            let incidents = txn.open_table(INCIDENTS_TABLE)?;
+            match Self::load_incident(&incidents, incident_id)? {
+                Some(incident) if !incident.deleted => {}
+                _ => {
+                    drop(incidents);
+                    txn.abort()?;
+                    return Ok(None);
+                }
+            }
+        }
+        {
+            let mut updates = txn.open_table(INCIDENT_UPDATES_TABLE)?;
+            updates.insert(u128::from(new_update.id), (version, own, update_bytes.as_slice()))?;
+        }
+        txn.commit()?;
+
+        let view = self.get_incident(incident_id).await?.ok_or("incident vanished after adding update")?;
+        Ok(Some((version, view)))
+    }
+
+    async fn put_update(
+        &self,
+        update_id: IncidentUpdateId,
+        expected_version: u64,
+        edit: PutUpdate,
+    ) -> Result<CasOutcome<IncidentView>, Box<dyn Error>> {
+        let own: u128 = self.node_id.into();
+        let new_version = Utc::now().timestamp_millis() as u64;
+
+        let txn = self.database.begin_write()?;
+        let outcome = {
+            let mut updates = txn.open_table(INCIDENT_UPDATES_TABLE)?;
+            match Self::load_update(&updates, update_id)? {
+                None => CasOutcome::NotFound,
+                Some(existing) if existing.deleted => CasOutcome::NotFound,
+                Some(existing) if existing.version != expected_version => {
+                    CasOutcome::VersionMismatch(existing.version)
+                }
+                Some(mut existing) => {
+                    // `impact` and `timestamp` are fixed once posted; only the message is editable.
+                    existing.message = edit.message;
+                    existing.version = new_version;
+                    updates.insert(u128::from(update_id), (new_version, own, rmp_serde::to_vec_named(&existing)?.as_slice()))?;
+                    CasOutcome::Updated(new_version, ())
+                }
+            }
         };
         txn.commit()?;
-        Ok(existed)
+
+        match outcome {
+            CasOutcome::Updated(version, ()) => {
+                match self.get_incident(update_id.incident_id()).await? {
+                    Some(view) => Ok(CasOutcome::Updated(version, view)),
+                    // The parent incident was deleted concurrently; the update edit still applied.
+                    None => Ok(CasOutcome::NotFound),
+                }
+            }
+            CasOutcome::VersionMismatch(v) => Ok(CasOutcome::VersionMismatch(v)),
+            CasOutcome::NotFound => Ok(CasOutcome::NotFound),
+        }
+    }
+
+    async fn delete_update(
+        &self,
+        update_id: IncidentUpdateId,
+        expected_version: u64,
+    ) -> Result<CasOutcome<()>, Box<dyn Error>> {
+        let own: u128 = self.node_id.into();
+        let new_version = Utc::now().timestamp_millis() as u64;
+
+        let txn = self.database.begin_write()?;
+        let outcome = {
+            let mut updates = txn.open_table(INCIDENT_UPDATES_TABLE)?;
+            match Self::load_update(&updates, update_id)? {
+                None => CasOutcome::NotFound,
+                Some(existing) if existing.deleted => CasOutcome::NotFound,
+                Some(existing) if existing.version != expected_version => {
+                    CasOutcome::VersionMismatch(existing.version)
+                }
+                Some(mut existing) => {
+                    existing.deleted = true;
+                    existing.version = new_version;
+                    updates.insert(u128::from(update_id), (new_version, own, rmp_serde::to_vec_named(&existing)?.as_slice()))?;
+                    CasOutcome::Updated(new_version, ())
+                }
+            }
+        };
+        txn.commit()?;
+        Ok(outcome)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use grey_api::{IncidentEdit, Impact};
 
-    fn update(impact: Impact, secs: i64) -> IncidentUpdate {
-        IncidentUpdate {
-            impact,
-            timestamp: chrono::DateTime::from_timestamp(secs, 0).unwrap(),
-            message: "update".into(),
+    async fn test_state(dir: &std::path::Path) -> State {
+        State::test(dir.to_path_buf()).await
+    }
+
+    #[tokio::test]
+    async fn create_get_list_and_visibility() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        let public = state.create_incident("Public".into(), Impact::Offline, "down".into()).await.unwrap();
+        let hidden = state.create_incident("Hidden".into(), Impact::Hidden, "draft".into()).await.unwrap();
+
+        assert_ne!(public.id(), hidden.id());
+        assert_eq!(public.updates.len(), 1);
+        assert!(public.is_public());
+        assert!(!hidden.is_public());
+
+        // Round-trips by id (admin get returns hidden too).
+        assert_eq!(state.get_incident(public.id()).await.unwrap().unwrap().title(), "Public");
+
+        // The public view hides the hidden incident; the admin view shows both.
+        let visible = state.list_incidents(false, 10, None).await.unwrap();
+        assert_eq!(visible.incidents.iter().map(|v| v.title().to_string()).collect::<Vec<_>>(), vec!["Public"]);
+        assert_eq!(state.list_incidents(true, 10, None).await.unwrap().incidents.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn put_and_delete_are_check_and_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        let created = state.create_incident("Outage".into(), Impact::Offline, "down".into()).await.unwrap();
+        let v0 = created.incident.version;
+
+        // Correct version -> updated + bumped version.
+        let outcome = state.put_incident(created.id(), v0, PutIncident { title: "Outage (edited)".into() }).await.unwrap();
+        let v1 = match outcome { CasOutcome::Updated(v, view) => { assert_eq!(view.title(), "Outage (edited)"); v }, _ => panic!("expected Updated") };
+        assert!(v1 >= v0);
+
+        // Stale version -> conflict reporting the current version.
+        assert!(matches!(
+            state.put_incident(created.id(), v0, PutIncident { title: "x".into() }).await.unwrap(),
+            CasOutcome::VersionMismatch(v) if v == v1
+        ));
+
+        // Delete tombstones it: it disappears from reads and a re-delete is NotFound.
+        assert!(matches!(state.delete_incident(created.id(), v1).await.unwrap(), CasOutcome::Updated(_, ())));
+        assert!(state.get_incident(created.id()).await.unwrap().is_none());
+        assert!(matches!(state.delete_incident(created.id(), v1).await.unwrap(), CasOutcome::NotFound));
+    }
+
+    #[tokio::test]
+    async fn updates_are_independent_entities() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        let created = state.create_incident("Outage".into(), Impact::Offline, "down".into()).await.unwrap();
+        let incident_version = created.incident.version;
+
+        // Adding an update does NOT bump the incident entity's version (they are separate entities).
+        let (uv, view) = state.create_update(created.id(), CreateUpdate { impact: Impact::None, message: "fixed".into() }).await.unwrap().unwrap();
+        assert_eq!(view.updates.len(), 2);
+        assert!(
+            view.updates.iter().any(|u| u.impact == Impact::Offline)
+                && view.updates.iter().any(|u| u.impact == Impact::None),
+            "both updates present"
+        );
+        assert_eq!(view.incident.version, incident_version, "incident version unchanged by an added update");
+
+        // The new (None) update has its own version and is editable by CAS.
+        let new_update = view.updates.iter().find(|u| u.impact == Impact::None).unwrap().clone();
+        assert_eq!(new_update.version, uv);
+        let edited = state.put_update(new_update.id, uv, PutUpdate { message: "resolved".into() }).await.unwrap();
+        match edited {
+            CasOutcome::Updated(_, v) => {
+                let msg = v.updates.iter().find(|u| u.id == new_update.id).unwrap().message.clone();
+                assert_eq!(msg, "resolved");
+            }
+            _ => panic!("expected Updated"),
+        }
+
+        // Removing an update tombstones it: it drops out of the view.
+        assert!(matches!(state.delete_update(new_update.id, _latest_version(&state, created.id(), new_update.id).await).await.unwrap(), CasOutcome::Updated(_, ())));
+        let after = state.get_incident(created.id()).await.unwrap().unwrap();
+        assert_eq!(after.updates.len(), 1);
+        assert_eq!(after.current_impact(), Impact::Offline);
+
+        // Adding an update to a missing incident is a 404 (None).
+        assert!(state.create_update(Identifier::from(424242u64), CreateUpdate { impact: Impact::None, message: "x".into() }).await.unwrap().is_none());
+    }
+
+    // Helper: the current stored version of an update (it bumps on each edit).
+    async fn _latest_version(state: &State, incident: Identifier, update: IncidentUpdateId) -> u64 {
+        state.get_incident(incident).await.unwrap().unwrap()
+            .updates.iter().find(|u| u.id == update).unwrap().version
+    }
+
+    #[tokio::test]
+    async fn pagination_walks_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        // Create several incidents; their snowflake ids are time-ordered.
+        let mut ids = Vec::new();
+        for i in 0..5 {
+            let v = state.create_incident(format!("Incident {i}"), Impact::Offline, "x".into()).await.unwrap();
+            ids.push(v.id());
+        }
+
+        let page1 = state.list_incidents(true, 2, None).await.unwrap();
+        assert_eq!(page1.incidents.len(), 2);
+        assert!(page1.next_cursor.is_some());
+
+        let page2 = state.list_incidents(true, 2, page1.next_cursor).await.unwrap();
+        assert_eq!(page2.incidents.len(), 2);
+
+        // No overlap between pages, and ids descend across the boundary.
+        let p1_last = page1.incidents.last().unwrap().id();
+        let p2_first = page2.incidents.first().unwrap().id();
+        assert!(u64::from(p2_first) < u64::from(p1_last));
+    }
+
+    /// An incident and its update received from a peer through the gossip apply path surface in the
+    /// view even on a node with no local writes.
+    #[tokio::test]
+    async fn incident_replicates_through_gossip_apply() {
+        use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
+        use crate::state::ReplicatedEntity;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        let now = Utc::now();
+        let version = now.timestamp_millis() as u64;
+        let id = Identifier::from(0x6000_0000_0000_0001u64);
+        let incident = Incident { id, title: "Replicated".into(), version, deleted: false };
+        let update = IncidentUpdate {
+            id: IncidentUpdateId::compose(id, 1),
+            impact: Impact::Degraded,
+            timestamp: now,
+            message: "from-peer".into(),
+            version,
+            deleted: false,
+        };
+
+        let peer = NodeID::new();
+        let mut diff = ClusterStateDiff::new();
+        diff.update(peer, incident.id_field(), ReplicatedEntity::Incident(incident));
+        diff.update(peer, update.id_field(), ReplicatedEntity::IncidentUpdate(update));
+        state.apply(diff).await.unwrap();
+
+        let view = state.get_incident(id).await.unwrap().expect("the gossiped incident surfaces");
+        assert_eq!(view.title(), "Replicated");
+        assert_eq!(view.updates.len(), 1);
+        assert_eq!(view.current_impact(), Impact::Degraded);
+    }
+
+    /// Last-writer-wins on apply: a higher-versioned record replaces, a stale one is ignored.
+    #[tokio::test]
+    async fn apply_is_last_writer_wins() {
+        use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
+        use crate::state::ReplicatedEntity;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        let created = state.create_incident("Original".into(), Impact::Offline, "x".into()).await.unwrap();
+        let id = created.id();
+        let base = created.incident.version;
+
+        // A stale peer edit (older version) must not win.
+        let stale = Incident { id, title: "Stale".into(), version: base - 1_000, deleted: false };
+        let mut diff = ClusterStateDiff::new();
+        diff.update(NodeID::new(), stale.id_field(), ReplicatedEntity::Incident(stale));
+        state.apply(diff).await.unwrap();
+        assert_eq!(state.get_incident(id).await.unwrap().unwrap().title(), "Original");
+
+        // A newer peer edit wins.
+        let newer = Incident { id, title: "Newer".into(), version: base + 1_000, deleted: false };
+        let mut diff = ClusterStateDiff::new();
+        diff.update(NodeID::new(), newer.id_field(), ReplicatedEntity::Incident(newer));
+        state.apply(diff).await.unwrap();
+        assert_eq!(state.get_incident(id).await.unwrap().unwrap().title(), "Newer");
+    }
+
+    /// Equal-version writes from two nodes converge on the same record regardless of apply order: the
+    /// `(version, last_writer)` total order breaks the tie deterministically (higher node id wins).
+    #[tokio::test]
+    async fn apply_breaks_version_ties_by_writer() {
+        use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
+        use crate::state::ReplicatedEntity;
+
+        let id = Identifier::from(0x7000_0000_0000_0001u64);
+        let version = 1_700_000_000_000u64;
+        let low = NodeID::from(1u128);
+        let high = NodeID::from(2u128);
+        let from_low = Incident { id, title: "low".into(), version, deleted: false };
+        let from_high = Incident { id, title: "high".into(), version, deleted: false };
+
+        // Apply low-then-high on one node and high-then-low on another: both converge on the higher
+        // writer's record.
+        for order in [[low, high], [high, low]] {
+            let dir = tempfile::tempdir().unwrap();
+            let state = test_state(dir.path()).await;
+            for writer in order {
+                let incident = if writer == high { from_high.clone() } else { from_low.clone() };
+                let mut diff = ClusterStateDiff::new();
+                diff.update(writer, incident.id_field(), ReplicatedEntity::Incident(incident));
+                state.apply(diff).await.unwrap();
+            }
+            assert_eq!(
+                state.get_incident(id).await.unwrap().unwrap().title(),
+                "high",
+                "the higher writer id wins an equal-version tie regardless of order"
+            );
         }
     }
 
+    /// A full gossip round (digest → diff → apply) carries an incident and its update from the node
+    /// that authored them to a peer, and that peer relays them onward to a third node under the
+    /// original writer's partition (the masking-regression guard).
     #[tokio::test]
-    async fn create_get_list_delete_and_visibility() {
-        let dir = tempfile::tempdir().unwrap();
-        let state = State::test(dir.path().to_path_buf()).await;
+    async fn incident_syncs_through_a_full_gossip_round() {
+        use crate::cluster::GossipStore;
 
-        let public = state.create_incident("Public".into(), update(Impact::Offline, 200)).await.unwrap();
-        let hidden = state.create_incident("Hidden".into(), update(Impact::Hidden, 100)).await.unwrap();
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        let a = test_state(dir_a.path()).await;
+        let b = test_state(dir_b.path()).await;
 
-        // Fresh ids are distinct and version starts at 1.
-        assert_ne!(public.id, hidden.id);
-        assert_eq!(public.version, 1);
+        let created = a.create_incident("Round".into(), Impact::Offline, "down".into()).await.unwrap();
+        a.create_update(created.id(), CreateUpdate { impact: Impact::None, message: "up".into() }).await.unwrap();
 
-        // Round-trips by id.
-        assert_eq!(state.get_incident(public.id).await.unwrap().unwrap().title, "Public");
+        // B pulls from A: A diffs against B's digest, B applies the delta.
+        let delta = a.diff(b.digest().await.unwrap()).await.unwrap();
+        b.apply(delta).await.unwrap();
 
-        // The public view hides the hidden incident; the admin view shows both.
-        let visible = state.list_incidents(false).await.unwrap();
-        assert_eq!(visible.iter().map(|i| i.title.as_str()).collect::<Vec<_>>(), vec!["Public"]);
-        assert_eq!(state.list_incidents(true).await.unwrap().len(), 2);
+        let view = b.get_incident(created.id()).await.unwrap().expect("incident replicated to B");
+        assert_eq!(view.title(), "Round");
+        assert_eq!(view.updates.len(), 2);
 
-        assert!(state.delete_incident(public.id).await.unwrap());
-        assert!(!state.delete_incident(public.id).await.unwrap());
-        assert!(state.get_incident(public.id).await.unwrap().is_none());
+        // B relays A's records onward to a fresh node C (advertised under A's partition), so anti-
+        // entropy completes transitively rather than only between the original author and a peer.
+        let dir_c = tempfile::tempdir().unwrap();
+        let c = test_state(dir_c.path()).await;
+        let delta = b.diff(c.digest().await.unwrap()).await.unwrap();
+        c.apply(delta).await.unwrap();
+        assert_eq!(
+            c.get_incident(created.id()).await.unwrap().unwrap().updates.len(),
+            2,
+            "B relays A's incident + update to C"
+        );
     }
 
+    /// GC reaps incident rows (including delete tombstones) once their version ages past the expiry,
+    /// while leaving fresh ones in place.
     #[tokio::test]
-    async fn replace_is_check_and_set() {
+    async fn gc_reaps_aged_incident_rows() {
+        use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
+        use crate::state::{ProbeStore, ReplicatedEntity};
+
         let dir = tempfile::tempdir().unwrap();
-        let state = State::test(dir.path().to_path_buf()).await;
+        let state = test_state(dir.path()).await;
 
-        let incident = state.create_incident("Outage".into(), update(Impact::Offline, 100)).await.unwrap();
-        let edit = IncidentEdit {
-            title: "Outage (resolved)".into(),
-            updates: vec![update(Impact::Offline, 100), update(Impact::None, 200)],
-        };
+        // A fresh, locally-created incident.
+        let fresh = state.create_incident("Fresh".into(), Impact::Offline, "x".into()).await.unwrap();
 
-        // Correct version -> updated, version bumped, content replaced.
-        let outcome = state.replace_incident(incident.id, incident.version, edit.clone()).await.unwrap();
-        let updated = match outcome {
-            CasOutcome::Updated(i) => i,
-            _ => panic!("expected Updated"),
-        };
-        assert_eq!(updated.version, 2);
-        assert_eq!(updated.title, "Outage (resolved)");
-        assert_eq!(updated.current_impact(), Impact::None);
+        // An aged incident delivered via gossip (its version is ~8 days old, well past the 7-day
+        // default expiry).
+        let aged_id = Identifier::from(0x7000_0000_0000_0002u64);
+        let aged_version = (chrono::Utc::now() - chrono::Duration::days(8)).timestamp_millis() as u64;
+        let aged = Incident { id: aged_id, title: "Aged".into(), version: aged_version, deleted: false };
+        let mut diff = ClusterStateDiff::new();
+        diff.update(NodeID::new(), aged.id_field(), ReplicatedEntity::Incident(aged));
+        state.apply(diff).await.unwrap();
 
-        // Stale version -> conflict reporting the current version; the store is unchanged.
-        let stale = state.replace_incident(incident.id, incident.version, edit).await.unwrap();
-        assert!(matches!(stale, CasOutcome::VersionMismatch(2)));
-        assert_eq!(state.get_incident(incident.id).await.unwrap().unwrap().version, 2);
+        assert!(state.get_incident(aged_id).await.unwrap().is_some(), "aged row present before GC");
 
-        // Unknown id -> not found.
-        assert!(matches!(
-            state.replace_incident(Identifier::from(424242u64), 1, IncidentEdit { title: "x".into(), updates: vec![] }).await.unwrap(),
-            CasOutcome::NotFound
-        ));
+        state.gc().await.unwrap();
+
+        assert!(state.get_incident(aged_id).await.unwrap().is_none(), "GC reaps the aged row");
+        assert!(state.get_incident(fresh.id()).await.unwrap().is_some(), "GC keeps the fresh row");
     }
 }

--- a/agent/src/state/incidents.rs
+++ b/agent/src/state/incidents.rs
@@ -776,10 +776,10 @@ mod tests {
         );
     }
 
-    /// GC reaps incident rows (including delete tombstones) once their version ages past the expiry,
-    /// while leaving fresh ones in place.
+    /// Incidents are persistent records: unlike probes and crons, GC never ages them out, so the
+    /// outage history survives indefinitely no matter how old a record is.
     #[tokio::test]
-    async fn gc_reaps_aged_incident_rows() {
+    async fn gc_keeps_incidents_indefinitely() {
         use crate::cluster::{ClusterStateDiff, GossipStore, NodeID};
         use crate::state::{ProbeStore, ReplicatedEntity};
 
@@ -789,20 +789,22 @@ mod tests {
         // A fresh, locally-created incident.
         let fresh = state.create_incident("Fresh".into(), Impact::Offline, "x".into()).await.unwrap();
 
-        // An aged incident delivered via gossip (its version is ~8 days old, well past the 7-day
-        // default expiry).
+        // An incident whose version is far older than any probe/cron expiry, delivered via gossip.
         let aged_id = Identifier::from(0x7000_0000_0000_0002u64);
-        let aged_version = (chrono::Utc::now() - chrono::Duration::days(8)).timestamp_millis() as u64;
+        let aged_version = (chrono::Utc::now() - chrono::Duration::days(400)).timestamp_millis() as u64;
         let aged = Incident { id: aged_id, title: "Aged".into(), version: aged_version, deleted: false };
         let mut diff = ClusterStateDiff::new();
         diff.update(NodeID::new(), aged.id_field(), ReplicatedEntity::Incident(aged));
         state.apply(diff).await.unwrap();
 
-        assert!(state.get_incident(aged_id).await.unwrap().is_some(), "aged row present before GC");
-
         state.gc().await.unwrap();
 
-        assert!(state.get_incident(aged_id).await.unwrap().is_none(), "GC reaps the aged row");
-        assert!(state.get_incident(fresh.id()).await.unwrap().is_some(), "GC keeps the fresh row");
+        // Both survive: GC does not age out incident records (a non-deleted aged row remaining proves
+        // the incident table is left untouched by the sweep).
+        assert!(state.get_incident(fresh.id()).await.unwrap().is_some(), "GC keeps the fresh incident");
+        assert!(
+            state.get_incident(aged_id).await.unwrap().is_some(),
+            "GC keeps an arbitrarily old incident (persistent record)"
+        );
     }
 }

--- a/agent/src/state/mod.rs
+++ b/agent/src/state/mod.rs
@@ -535,6 +535,56 @@ mod tests {
         assert_eq!(own_record.streak.covered_since, Some(streak_start));
     }
 
+    /// `digest` summarises both entity tables, and `diff` against an empty digest emits this node's
+    /// probe *and* cron records — exercising the gossip read path for both entity types.
+    #[tokio::test]
+    async fn digest_and_diff_cover_both_probe_and_cron_tables() {
+        use crate::config::CronConfig;
+        use crate::cron::CronCheckin;
+        use grey_api::CronStatus;
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let state = State::test(dir.path().to_path_buf()).await;
+
+        // `State::test` already recorded a probe sample for this node; add a configured cron + a
+        // check-in so both tables hold state for the local node.
+        let mut config = Config::test(&dir.path().to_path_buf());
+        config.crons = vec![CronConfig {
+            name: "backup".into(),
+            interval: Some(std::time::Duration::from_secs(60)),
+            schedule: None,
+            max_duration: None,
+            grace: None,
+            token: None,
+            tags: HashMap::new(),
+        }];
+        *state.config.write().unwrap() = Arc::new(config);
+        state
+            .record_cron_checkin(
+                "backup",
+                CronCheckin::new(CronStatus::Succeeded, "ok".into(), chrono::Utc::now()),
+            )
+            .await
+            .unwrap();
+
+        // The digest summarises this node with a non-zero max version (across both tables).
+        let digest = state.digest().await.unwrap();
+        assert!(digest.get_max_version(&state.node_id).unwrap_or(0) > 0);
+
+        // Diffing against an empty digest emits both the probe and the cron record for this node.
+        let mut delta = state.diff(ClusterStateDigest::new()).await.unwrap().into_inner();
+        let node_diff = delta.remove(&state.node_id).expect("our node's state in the diff");
+        assert!(
+            node_diff.values().any(|e| matches!(e, ReplicatedEntity::Probe(_))),
+            "the probe diff should be emitted"
+        );
+        assert!(
+            node_diff.values().any(|e| matches!(e, ReplicatedEntity::Cron(_))),
+            "the cron diff should be emitted"
+        );
+    }
+
     fn b64_key(byte: u8) -> String {
         BASE64_STANDARD.encode([byte; 32])
     }

--- a/agent/src/state/mod.rs
+++ b/agent/src/state/mod.rs
@@ -4,7 +4,7 @@ use std::{
     sync::{Arc, Mutex, RwLock},
 };
 use std::error::Error;
-use grey_api::{Cron, Probe};
+use grey_api::{Cron, Incident, IncidentUpdate, Probe};
 use redb::{Database, ReadableDatabase, ReadableTable, TableDefinition};
 use tracing::info;
 use tracing_batteries::prelude::*;
@@ -23,22 +23,34 @@ mod probes;
 mod replicated;
 
 pub use crons::CronStore;
-pub use incidents::{CasOutcome, IncidentStore};
+pub use incidents::{CasOutcome, DEFAULT_INCIDENT_PAGE, IncidentStore};
 pub use probes::ProbeStore;
-pub use replicated::ReplicatedEntity;
+pub use replicated::{GlobalLwwEntity, LwwFieldValue, ReplicatedEntity};
 
 // Maps a (NodeID, Probe Name) to a tuple of (Version, MsgPack Snapshot). Shared with the probe and
-// gossip sub-modules.
-const CLUSTER_FIELDS_TABLE: TableDefinition<(u128, String), (u64, &[u8])> =
-    TableDefinition::new("cluster_fields");
-// Maps a (NodeID, Cron Name) to a tuple of (Version, MsgPack Snapshot). A dedicated table for cron
-// state, replicated alongside probe state through the generalised gossip path.
-const CRON_FIELDS_TABLE: TableDefinition<(u128, String), (u64, &[u8])> =
-    TableDefinition::new("cron_fields");
+// gossip sub-modules. Probes are the one per-observer entity: every node keeps its own observation of
+// each probe under this key, and the gossip partition is the node component of the key.
+const PROBES_TABLE: TableDefinition<(u128, String), (u64, &[u8])> =
+    TableDefinition::new("probes");
+
+// The global last-writer-wins entity tables: one row per entity id, valued by `(version, last_writer,
+// msgpack)` (see `LwwFieldValue`). Unlike probes these are *not* per-observer — a single global
+// record per cron / incident / incident-update, advertised under the `last_writer` partition. New
+// table names (the legacy per-node `cron_fields` and JSON `incidents` tables are abandoned, not
+// migrated).
+pub(crate) const CRON_TABLE: TableDefinition<&str, LwwFieldValue> =
+    TableDefinition::new("crons");
+
+
+pub(crate) const INCIDENTS_TABLE: TableDefinition<u64, LwwFieldValue> =
+    TableDefinition::new("incidents");
+pub(crate) const INCIDENT_UPDATES_TABLE: TableDefinition<u128, LwwFieldValue> =
+    TableDefinition::new("incidents.updates");
+
 // Stores this instance's persistent identity so that a restart resumes the same NodeID (and keeps
 // advertising its existing probe state) rather than appearing as a brand-new node.
-const CLUSTER_IDENTITY_TABLE: TableDefinition<&str, u128> =
-    TableDefinition::new("cluster_identity");
+const INSTANCE_METADATA_TABLE: TableDefinition<&str, u128> =
+    TableDefinition::new("instance_metadata");
 const NODE_ID_KEY: &str = "node_id";
 const GENERATION_KEY: &str = "generation";
 
@@ -141,7 +153,7 @@ impl State {
         let read = database.begin_read()?;
         // `open_table` errors on a read transaction if the table has never been created, which is
         // the expected first-run case — fall through to generating a new identity.
-        if let Ok(table) = read.open_table(CLUSTER_IDENTITY_TABLE)
+        if let Ok(table) = read.open_table(INSTANCE_METADATA_TABLE)
             && let Some(existing) = table.get(NODE_ID_KEY)?
         {
             return Ok(NodeID::from(existing.value()));
@@ -152,7 +164,7 @@ impl State {
         let id: u128 = node_id.into();
         let write = database.begin_write()?;
         {
-            let mut table = write.open_table(CLUSTER_IDENTITY_TABLE)?;
+            let mut table = write.open_table(INSTANCE_METADATA_TABLE)?;
             table.insert(NODE_ID_KEY, id)?;
         }
         write.commit()?;
@@ -169,7 +181,7 @@ impl State {
         // generations.
         let write = database.begin_write()?;
         let next = {
-            let mut table = write.open_table(CLUSTER_IDENTITY_TABLE)?;
+            let mut table = write.open_table(INSTANCE_METADATA_TABLE)?;
             let current: u128 = table.get(GENERATION_KEY)?.map(|v| v.value()).unwrap_or(0);
             let next = current.saturating_add(1);
             table.insert(GENERATION_KEY, next)?;
@@ -367,6 +379,92 @@ where
     Ok(())
 }
 
+// --- Global last-writer-wins gossip helpers --------------------------------------------------------
+//
+// These mirror the probe helpers above for the [`GlobalLwwEntity`] family. The read-path helpers
+// (`digest_lww`/`emit_lww_table_diffs`) are generic over the entity's [`GlobalLwwEntity::Key`]: they
+// only iterate the table and read the `(version, last_writer, snapshot)` value, taking the gossip
+// partition from `last_writer` (in the value) and the field key from the deserialized entity's id —
+// they never build or look up a key, so they need no redb key-borrow gymnastics. The write path
+// (`apply`) builds keys concretely per entity type and shares only [`lww_supersedes`].
+
+/// Whether an incoming `(version, last_writer)` supersedes the stored one under the LWW total order.
+/// The `last_writer` tiebreaker makes equal-millisecond writes converge deterministically across
+/// nodes; a freshly-seen entity (no existing row) is always accepted.
+fn lww_supersedes(existing: Option<(u64, u128)>, incoming: (u64, u128)) -> bool {
+    match existing {
+        Some(current) => incoming > current,
+        None => true,
+    }
+}
+
+/// Drops rows from a global-LWW table whose `version` (a `last_modified` in ms) has aged past
+/// `threshold`, reaping both stale records and converged delete tombstones. Returns the count dropped.
+/// Generic over the key type, since it only retains by the value's version and never inspects the key.
+pub(crate) fn gc_lww_table<K: redb::Key + 'static>(
+    txn: &redb::WriteTransaction,
+    def: TableDefinition<K, LwwFieldValue>,
+    threshold: chrono::DateTime<chrono::Utc>,
+) -> Result<u64, Box<dyn Error>> {
+    let mut table = txn.open_table(def)?;
+    let mut dropped = 0u64;
+    table.retain(|_key, (version, _writer, _data)| {
+        let last_updated =
+            chrono::DateTime::from_timestamp_millis(version as i64).unwrap_or_default();
+        if last_updated >= threshold {
+            true
+        } else {
+            dropped += 1;
+            false
+        }
+    })?;
+    Ok(dropped)
+}
+
+/// Folds each row of one global-LWW table into `digest` under its `last_writer` partition.
+fn digest_lww<E: GlobalLwwEntity>(
+    txn: &redb::ReadTransaction,
+    digest: &mut ClusterStateDigest<NodeID>,
+) -> Result<(), Box<dyn Error>> {
+    if let Ok(table) = txn.open_table(E::TABLE) {
+        for (_key, value) in table.iter()?.filter_map(|r| r.ok()) {
+            let (version, last_writer, _data) = value.value();
+            digest.update(NodeID::from(last_writer), version);
+        }
+    }
+    Ok(())
+}
+
+/// Emits the diffs for one global-LWW table: every row newer than the peer's advertised version for
+/// that row's `last_writer` partition, keyed by the entity's own id field.
+fn emit_lww_table_diffs<E: GlobalLwwEntity>(
+    txn: &redb::ReadTransaction,
+    digest: &ClusterStateDigest<NodeID>,
+    delta: &mut cluster::ClusterStateDiff<NodeID, ReplicatedEntity>,
+    wrap: impl Fn(E) -> ReplicatedEntity,
+) -> Result<(), Box<dyn Error>> {
+    let Ok(table) = txn.open_table(E::TABLE) else {
+        return Ok(());
+    };
+    for (_key, value) in table.iter()?.filter_map(|r| r.ok()) {
+        let (version, last_writer, data) = value.value();
+
+        let peer = NodeID::from(last_writer);
+        let remote_version = digest.get_max_version(&peer).unwrap_or_default();
+        if version <= remote_version {
+            continue;
+        }
+
+        let entity: E = rmp_serde::from_slice(data)
+            .map_err(|e| format!("Failed to parse global-LWW state for diff: {e:?}"))?;
+        if let Some(diff) = entity.diff(remote_version) {
+            let field = diff.id_field();
+            delta.update(peer, field, wrap(diff));
+        }
+    }
+    Ok(())
+}
+
 impl GossipStore for State {
     type Id = NodeID;
     type State = ReplicatedEntity;
@@ -381,17 +479,19 @@ impl GossipStore for State {
         let mut digest = ClusterStateDigest::new();
 
         let txn = self.database.begin_read()?;
-        // Both entity tables share the per-peer version space (the scuttlebutt digest is a single
-        // max-version per node); iterate each, treating a not-yet-created table as empty.
-        for table_def in [CLUSTER_FIELDS_TABLE, CRON_FIELDS_TABLE] {
-            if let Ok(table) = txn.open_table(table_def) {
-                for (key, value) in table.iter()?.filter_map(|r| r.ok()) {
-                    let (node_id, _field) = key.value();
-                    let (version, _data) = value.value();
-                    digest.update(node_id.into(), version);
-                }
+        // Every entity table shares the per-peer version space (the scuttlebutt digest is a single
+        // max-version per node). Probes are per-observer (partition = the node component of the key);
+        // the global-LWW entities take their partition from each row's `last_writer`.
+        if let Ok(table) = txn.open_table(PROBES_TABLE) {
+            for (key, value) in table.iter()?.filter_map(|r| r.ok()) {
+                let (node_id, _field) = key.value();
+                let (version, _data) = value.value();
+                digest.update(node_id.into(), version);
             }
         }
+        digest_lww::<Cron>(&txn, &mut digest)?;
+        digest_lww::<Incident>(&txn, &mut digest)?;
+        digest_lww::<IncidentUpdate>(&txn, &mut digest)?;
 
         trace!(name: "state.digest", { host.node_id = %self.node_id, digest = %digest }, "Composed new cluster state digest.");
 
@@ -408,8 +508,10 @@ impl GossipStore for State {
         let mut delta = cluster::ClusterStateDiff::new();
 
         let txn = self.database.begin_read()?;
-        emit_table_diffs::<Probe>(&txn, CLUSTER_FIELDS_TABLE, &digest, &mut delta, ReplicatedEntity::Probe)?;
-        emit_table_diffs::<Cron>(&txn, CRON_FIELDS_TABLE, &digest, &mut delta, ReplicatedEntity::Cron)?;
+        emit_table_diffs::<Probe>(&txn, PROBES_TABLE, &digest, &mut delta, ReplicatedEntity::Probe)?;
+        emit_lww_table_diffs::<Cron>(&txn, &digest, &mut delta, ReplicatedEntity::Cron)?;
+        emit_lww_table_diffs::<Incident>(&txn, &digest, &mut delta, ReplicatedEntity::Incident)?;
+        emit_lww_table_diffs::<IncidentUpdate>(&txn, &digest, &mut delta, ReplicatedEntity::IncidentUpdate)?;
 
         trace!(name: "state.diff", { host.node_id = %self.node_id, digest = %digest, delta = ?delta }, "Composed new cluster state diff.");
 
@@ -423,8 +525,10 @@ impl GossipStore for State {
         trace!(name: "state.apply", { host.node_id = %self.node_id, diff = ?diff }, "Applying cluster state diff.");
         let txn = self.database.begin_write()?;
         {
-            let mut probe_table = txn.open_table(CLUSTER_FIELDS_TABLE)?;
-            let mut cron_table = txn.open_table(CRON_FIELDS_TABLE)?;
+            let mut probe_table = txn.open_table(PROBES_TABLE)?;
+            let mut cron_table = txn.open_table(CRON_TABLE)?;
+            let mut incident_table = txn.open_table(INCIDENTS_TABLE)?;
+            let mut update_table = txn.open_table(INCIDENT_UPDATES_TABLE)?;
 
             let own_id: u128 = self.node_id.into();
 
@@ -432,9 +536,11 @@ impl GossipStore for State {
                 let peer_id: u128 = peer.into();
 
                 for (field, entity) in node_diff {
-                    // The `ReplicatedEntity` variant routes the update to the right table; the field
-                    // key is just the bare entity name (probe and cron names are kept distinct by
-                    // config validation, so there is no cross-table collision to disambiguate).
+                    // The `ReplicatedEntity` variant routes the update to the right table. Probes are
+                    // per-observer (folded via the CRDT `merge_into_table` and keyed by the diff's
+                    // node); the global-LWW entities are keyed by their own id and resolved by the
+                    // `(version, last_writer)` total order, where the diff's partition (`peer_id`) is
+                    // the incoming `last_writer`.
                     match entity {
                         ReplicatedEntity::Probe(incoming) => {
                             merge_into_table(&mut probe_table, peer_id, &field, &incoming)?;
@@ -462,7 +568,36 @@ impl GossipStore for State {
                             }
                         }
                         ReplicatedEntity::Cron(incoming) => {
-                            merge_into_table(&mut cron_table, peer_id, &field, &incoming)?;
+                            let existing = cron_table
+                                .get(incoming.name.as_str())?
+                                .map(|g| { let (v, w, _) = g.value(); (v, w) });
+                            if lww_supersedes(existing, (incoming.version(), peer_id)) {
+                                let bytes = rmp_serde::to_vec_named(&incoming)
+                                    .map_err(|e| format!("Failed to serialize cron for update: {e:?}"))?;
+                                cron_table.insert(incoming.name.as_str(), (incoming.version(), peer_id, bytes.as_slice()))?;
+                            }
+                        }
+                        ReplicatedEntity::Incident(incoming) => {
+                            let key: u64 = incoming.id.into();
+                            let existing = incident_table
+                                .get(key)?
+                                .map(|g| { let (v, w, _) = g.value(); (v, w) });
+                            if lww_supersedes(existing, (incoming.version(), peer_id)) {
+                                let bytes = rmp_serde::to_vec_named(&incoming)
+                                    .map_err(|e| format!("Failed to serialize incident for update: {e:?}"))?;
+                                incident_table.insert(key, (incoming.version(), peer_id, bytes.as_slice()))?;
+                            }
+                        }
+                        ReplicatedEntity::IncidentUpdate(incoming) => {
+                            let key: u128 = incoming.id.into();
+                            let existing = update_table
+                                .get(key)?
+                                .map(|g| { let (v, w, _) = g.value(); (v, w) });
+                            if lww_supersedes(existing, (incoming.version(), peer_id)) {
+                                let bytes = rmp_serde::to_vec_named(&incoming)
+                                    .map_err(|e| format!("Failed to serialize incident update for update: {e:?}"))?;
+                                update_table.insert(key, (incoming.version(), peer_id, bytes.as_slice()))?;
+                            }
                         }
                     }
                 }
@@ -528,7 +663,7 @@ mod tests {
         // record, so the claim survives even if the peer's record is eventually
         // garbage-collected.
         let txn = state.database.begin_read().unwrap();
-        let table = txn.open_table(CLUSTER_FIELDS_TABLE).unwrap();
+        let table = txn.open_table(PROBES_TABLE).unwrap();
         let entry = table.get((state.node_id.into(), probe.name.clone())).unwrap().unwrap();
         let (_version, data) = entry.value();
         let own_record: ProbeState = rmp_serde::from_slice(data).unwrap();

--- a/agent/src/state/probes.rs
+++ b/agent/src/state/probes.rs
@@ -13,7 +13,10 @@ use tracing_batteries::prelude::*;
 use crate::cluster::Versioned;
 use crate::result::ProbeResult;
 
-use super::{CLUSTER_FIELDS_TABLE, CRON_FIELDS_TABLE, ProbeState, State};
+use super::{
+    PROBES_TABLE, CRON_TABLE, ProbeState, State,
+    gc_lww_table,
+};
 
 /// Storage operations for probe state (the cluster-replicated, gossiped records).
 #[allow(async_fn_in_trait)]
@@ -46,7 +49,7 @@ impl ProbeStore for State {
         }
 
         let txn = self.database.begin_read()?;
-        let table = txn.open_table(CLUSTER_FIELDS_TABLE)?;
+        let table = txn.open_table(PROBES_TABLE)?;
         let iter = table.iter()?;
         for entry in iter.filter_map(|r| r.ok()) {
             let (key, value) = entry;
@@ -68,7 +71,7 @@ impl ProbeStore for State {
     async fn update_probe_config(&self, probe: &crate::Probe) -> Result<(), Box<dyn Error>> {
         let txn = self.database.begin_write()?;
         {
-            let mut table = txn.open_table(CLUSTER_FIELDS_TABLE)?;
+            let mut table = txn.open_table(PROBES_TABLE)?;
 
             let mut snapshot = table
                 .get((self.node_id.into(), probe.name.clone()))?
@@ -103,7 +106,7 @@ impl ProbeStore for State {
 
         if let Some(probe) = self.get_config().probes.iter().find(|p| p.name == probe_name) {
             let result = {
-                let mut table = txn.open_table(CLUSTER_FIELDS_TABLE)?;
+                let mut table = txn.open_table(PROBES_TABLE)?;
 
                 let (mut snapshot, _version) = table
                     .get((self.node_id.into(), probe.name.clone()))?
@@ -142,7 +145,7 @@ impl ProbeStore for State {
     async fn gc(&self) -> Result<(), Box<dyn Error>> {
         let txn = self.database.begin_write()?;
         {
-            let mut table_fields = txn.open_table(CLUSTER_FIELDS_TABLE)?;
+            let mut table_fields = txn.open_table(PROBES_TABLE)?;
 
             let history_expiry_threshold =
                 chrono::Utc::now() - self.get_config().cluster.gc_probe_expiry;
@@ -166,23 +169,15 @@ impl ProbeStore for State {
                 info!(name: "state.gc.summary", { dropped_probe_records = %dropped_probe_records }, "Dropped stale probe records");
             }
 
-            // Cron records age out on the same expiry; a cron whose checks-ins (and re-gossip) have
-            // stopped for long enough is dropped just like a stale probe record.
-            let mut cron_table = txn.open_table(CRON_FIELDS_TABLE)?;
-            let mut dropped_cron_records = 0;
-            cron_table.retain(|(_, cron_name), (version, _data)| {
-                let last_updated = chrono::DateTime::from_timestamp_millis(version as i64).unwrap_or_default();
-                if last_updated >= history_expiry_threshold {
-                    true
-                } else {
-                    info!(name: "state.gc.cron", { cron.name = %cron_name, %last_updated, expired_at=%history_expiry_threshold }, "Dropping stale cron record");
-                    dropped_cron_records += 1;
-                    false
-                }
-            })?;
+            // Crons age out on the same expiry as probes: a record whose writes (and re-gossip)
+            // have stopped for long enough is dropped, which is also what eventually reaps converged
+            // delete tombstones. Incidents and incident updates are deliberately *not* swept here —
+            // they form the historical record of outages and are retained indefinitely (their delete
+            // tombstones likewise persist rather than being reaped on the probe-expiry cadence).
+            let dropped_crons = gc_lww_table(&txn, CRON_TABLE, history_expiry_threshold)?;
 
-            if dropped_cron_records > 0 {
-                info!(name: "state.gc.summary", { dropped_cron_records = %dropped_cron_records }, "Dropped stale cron records");
+            if dropped_crons > 0 {
+                info!(name: "state.gc.summary", { dropped_crons = %dropped_crons }, "Dropped stale cron records");
             }
         }
 
@@ -288,7 +283,7 @@ mod tests {
         {
             let txn = state.database.begin_write().unwrap();
             {
-                let mut table = txn.open_table(CLUSTER_FIELDS_TABLE).unwrap();
+                let mut table = txn.open_table(PROBES_TABLE).unwrap();
                 let stale = rmp_serde::to_vec_named(&probe_at("stale", chrono::Utc::now())).unwrap();
                 let fresh = rmp_serde::to_vec_named(&probe_at("fresh", chrono::Utc::now())).unwrap();
                 table.insert((node.into(), "stale".to_string()), (stale_ms, stale.as_slice())).unwrap();
@@ -300,7 +295,7 @@ mod tests {
         state.gc().await.unwrap();
 
         let txn = state.database.begin_read().unwrap();
-        let table = txn.open_table(CLUSTER_FIELDS_TABLE).unwrap();
+        let table = txn.open_table(PROBES_TABLE).unwrap();
         assert!(
             table.get((node.into(), "fresh".to_string())).unwrap().is_some(),
             "a recent probe must be retained"

--- a/agent/src/state/replicated.rs
+++ b/agent/src/state/replicated.rs
@@ -1,14 +1,50 @@
 //! The extensible set of state entities replicated through the cluster gossip protocol.
 //!
 //! Generalising the gossip `Value` from a bare [`grey_api::Probe`] to [`ReplicatedEntity`] is what
-//! lets crons (and, later, other entities such as incidents) ride the same scuttlebutt anti-entropy
-//! path. Each diff entry self-describes its type via the enum variant, so a node knows which store to
-//! route an incoming update to; the per-peer digest and the oldest-first diff ordering are unchanged.
+//! lets crons and incidents ride the same scuttlebutt anti-entropy path. Each diff entry
+//! self-describes its type via the enum variant, so a node knows which store to route an incoming
+//! update to; the per-peer digest and the oldest-first diff ordering are unchanged.
+//!
+//! Two families share this enum but are keyed and merged differently:
+//! - **Per-observer** ([`Probe`]): stored under `(node_id, name)`, the gossip partition is the node
+//!   component of that key, and records merge via their CRDT [`Versioned::apply`].
+//! - **Global last-writer-wins** ([`GlobalLwwEntity`]: [`Cron`], [`Incident`], [`IncidentUpdate`]):
+//!   stored as a single row keyed by the entity id alone, the gossip partition is the entity's
+//!   `last_writer` (carried in the redb value, not the key), and conflicts resolve by the total order
+//!   `(version, last_writer)`.
 
-use grey_api::{Cron, Probe};
+use grey_api::{Cron, Incident, IncidentUpdate, Probe};
+use redb::TableDefinition;
 use serde::{Deserialize, Serialize};
 
 use crate::cluster::Versioned;
+
+/// The redb value shared by every global-LWW entity table: `(version, last_writer, msgpack snapshot)`.
+/// `version` is the entity's wall-clock last-modified time in milliseconds; `last_writer` is the node
+/// that produced this version — the gossip partition the row is advertised under, and the LWW
+/// tiebreaker. (Probes keep the older `(version, snapshot)` value shape; their partition is in the
+/// key.)
+pub type LwwFieldValue = (u64, u128, &'static [u8]);
+
+/// An entity replicated under the entity-keyed, last-writer-wins model: exactly one redb row per
+/// entity id, the gossip partition is `last_writer`, and conflicts resolve by `(version,
+/// last_writer)`. The associated [`GlobalLwwEntity::Key`] + [`GlobalLwwEntity::TABLE`] let the
+/// generic read-path gossip helpers (`digest_lww`/`emit_lww_table_diffs`) iterate any of the tables
+/// regardless of key type (`String` for crons, `u64` for incidents, `u128` for incident updates);
+/// the write path (`apply` + the stores) builds keys concretely from each entity's own id.
+pub trait GlobalLwwEntity:
+    Versioned<Diff = Self> + Serialize + serde::de::DeserializeOwned + Clone + Sized
+{
+    /// The redb primary key for this entity's own table.
+    type Key: redb::Key + 'static;
+
+    /// This entity's table, keyed by [`GlobalLwwEntity::Key`], valued by [`LwwFieldValue`].
+    const TABLE: TableDefinition<'static, Self::Key, LwwFieldValue>;
+
+    /// The gossip field string for this entity (its own id rendered as text) — the second coordinate
+    /// of the `(partition, field)` diff entry.
+    fn id_field(&self) -> String;
+}
 
 /// A single replicated state entity. The gossip layer is generic over `Value: Versioned`; this enum
 /// is the concrete `Value` for the agent's [`super::State`], replacing the former bare `Probe`.
@@ -16,6 +52,8 @@ use crate::cluster::Versioned;
 pub enum ReplicatedEntity {
     Probe(Probe),
     Cron(Cron),
+    Incident(Incident),
+    IncidentUpdate(IncidentUpdate),
 }
 
 impl Versioned for ReplicatedEntity {
@@ -27,6 +65,8 @@ impl Versioned for ReplicatedEntity {
         match self {
             ReplicatedEntity::Probe(probe) => probe.version(),
             ReplicatedEntity::Cron(cron) => cron.version(),
+            ReplicatedEntity::Incident(incident) => incident.version(),
+            ReplicatedEntity::IncidentUpdate(update) => update.version(),
         }
     }
 
@@ -34,6 +74,12 @@ impl Versioned for ReplicatedEntity {
         match self {
             ReplicatedEntity::Probe(probe) => probe.diff(version).map(ReplicatedEntity::Probe),
             ReplicatedEntity::Cron(cron) => cron.diff(version).map(ReplicatedEntity::Cron),
+            ReplicatedEntity::Incident(incident) => {
+                incident.diff(version).map(ReplicatedEntity::Incident)
+            }
+            ReplicatedEntity::IncidentUpdate(update) => {
+                update.diff(version).map(ReplicatedEntity::IncidentUpdate)
+            }
         }
     }
 
@@ -43,6 +89,13 @@ impl Versioned for ReplicatedEntity {
                 probe.apply(incoming)
             }
             (ReplicatedEntity::Cron(cron), ReplicatedEntity::Cron(incoming)) => cron.apply(incoming),
+            (ReplicatedEntity::Incident(incident), ReplicatedEntity::Incident(incoming)) => {
+                incident.apply(incoming)
+            }
+            (
+                ReplicatedEntity::IncidentUpdate(update),
+                ReplicatedEntity::IncidentUpdate(incoming),
+            ) => update.apply(incoming),
             // A single (node, field) entry never changes entity type, so a mismatched pair cannot
             // occur in practice; ignore it defensively rather than panicking on malformed input.
             _ => {}
@@ -97,7 +150,7 @@ mod tests {
 
     #[test]
     fn apply_merges_matching_variants_and_ignores_mismatches() {
-        // Matching variants merge (a newer record advances `last_updated`).
+        // Matching variants resolve by LWW (a newer record advances `last_updated`/version).
         let mut p = ReplicatedEntity::Probe(probe(1_000));
         p.apply(&ReplicatedEntity::Probe(probe(2_000)));
         assert_eq!(p.version(), probe(2_000).version());

--- a/agent/src/state/replicated.rs
+++ b/agent/src/state/replicated.rs
@@ -49,3 +49,66 @@ impl Versioned for ReplicatedEntity {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::time::Duration;
+
+    fn at(secs: i64) -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::from_timestamp(secs, 0).unwrap()
+    }
+
+    fn probe(updated: i64) -> Probe {
+        Probe {
+            name: "p".into(),
+            tags: HashMap::new(),
+            last_updated: at(updated),
+            history: vec![],
+            observations: HashMap::new(),
+            streak: Default::default(),
+        }
+    }
+
+    fn cron(updated: i64) -> Cron {
+        let mut c = Cron::from_config(
+            "c",
+            HashMap::new(),
+            grey_api::CronSchedule::Every(Duration::from_secs(60)),
+            None,
+            None,
+        );
+        c.last_updated = at(updated);
+        c
+    }
+
+    #[test]
+    fn version_and_diff_delegate_to_the_inner_entity() {
+        let p = ReplicatedEntity::Probe(probe(1_700));
+        assert_eq!(p.version(), probe(1_700).version());
+        assert!(matches!(p.diff(0), Some(ReplicatedEntity::Probe(_))));
+        assert!(p.diff(p.version()).is_none(), "no diff when not newer than the request");
+
+        let c = ReplicatedEntity::Cron(cron(1_700));
+        assert_eq!(c.version(), cron(1_700).version());
+        assert!(matches!(c.diff(0), Some(ReplicatedEntity::Cron(_))));
+    }
+
+    #[test]
+    fn apply_merges_matching_variants_and_ignores_mismatches() {
+        // Matching variants merge (a newer record advances `last_updated`).
+        let mut p = ReplicatedEntity::Probe(probe(1_000));
+        p.apply(&ReplicatedEntity::Probe(probe(2_000)));
+        assert_eq!(p.version(), probe(2_000).version());
+
+        let mut c = ReplicatedEntity::Cron(cron(1_000));
+        c.apply(&ReplicatedEntity::Cron(cron(2_000)));
+        assert_eq!(c.version(), cron(2_000).version());
+
+        // A mismatched pair is a defensive no-op: a cron diff never touches a probe.
+        let mut p = ReplicatedEntity::Probe(probe(1_000));
+        p.apply(&ReplicatedEntity::Cron(cron(9_999)));
+        assert_eq!(p.version(), probe(1_000).version());
+    }
+}

--- a/api/src/cron.rs
+++ b/api/src/cron.rs
@@ -4,8 +4,6 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::Mergeable;
-
 /// How many recent runs are retained per cron. This bounded list is both the displayed history and
 /// the input the detectors read (for the last run's start time).
 pub const MAX_RUNS: usize = 20;
@@ -245,29 +243,6 @@ impl Cron {
         }
     }
 
-    /// Merges another record's run set into this one: a union keyed by `started_at` (so the same run
-    /// observed by two nodes collapses into one), taking the higher-precedence status and bounded to
-    /// the most recent [`MAX_RUNS`].
-    fn merge_runs(&mut self, other: &[CronRun]) {
-        for run in other {
-            if let Some(existing) = self
-                .runs
-                .iter_mut()
-                .find(|r| r.started_at == run.started_at)
-            {
-                if run.status > existing.status {
-                    existing.status = run.status;
-                    existing.duration = run.duration.or(existing.duration);
-                } else if run.status == existing.status {
-                    existing.duration = existing.duration.or(run.duration);
-                }
-            } else {
-                self.runs.push(run.clone());
-            }
-        }
-        self.trim_runs();
-    }
-
     // --- Detection (deterministic, derived queries) ----------------------------------------------
 
     /// The start time of the most recent run.
@@ -360,23 +335,6 @@ impl Cron {
             // Passing since the latest run started (the most recent on-time milestone).
             CronHealth::Running | CronHealth::Succeeded => self.last_start(),
         }
-    }
-}
-
-impl Mergeable for Cron {
-    fn merge(&mut self, other: &Self) {
-        // Identity/labels follow the most recently updated record; configuration echo fields are
-        // intentionally left to the local copy (the store re-stamps them from local config).
-        if other.last_updated > self.last_updated {
-            self.name = other.name.clone();
-            self.tags = other.tags.clone();
-        }
-        self.last_updated = self.last_updated.max(other.last_updated);
-        self.merge_runs(&other.runs);
-        self.last_checkin = match (self.last_checkin.take(), other.last_checkin.clone()) {
-            (Some(mine), Some(theirs)) => Some(if theirs.at > mine.at { theirs } else { mine }),
-            (mine, theirs) => mine.or(theirs),
-        };
     }
 }
 
@@ -570,77 +528,6 @@ mod tests {
         assert!(every(60).is_valid());
         assert!(CronSchedule::Cron("* * * * *".into()).is_valid());
         assert!(!CronSchedule::Cron("not a cron".into()).is_valid());
-    }
-
-    fn merge(a: &Cron, b: &Cron) -> Cron {
-        let mut j = a.clone();
-        j.merge(b);
-        j
-    }
-
-    fn with_runs(runs: Vec<CronRun>, last_updated: i64, checkin: Option<CheckIn>) -> Cron {
-        let mut c = cron_with(every(60), runs, None, None);
-        c.last_updated = ts(last_updated);
-        c.last_checkin = checkin;
-        c
-    }
-
-    /// The merge must be idempotent, commutative and associative so every node converges on the same
-    /// record regardless of the order gossip delivers updates.
-    #[test]
-    fn merge_is_a_semilattice() {
-        let registers = [
-            with_runs(vec![], 0, None),
-            with_runs(vec![run(100, CronStatus::Running, None)], 100, None),
-            with_runs(vec![run(100, CronStatus::Succeeded, Some(10))], 110, None),
-            with_runs(
-                vec![run(100, CronStatus::Failed, Some(5)), run(200, CronStatus::Succeeded, Some(8))],
-                208,
-                Some(CheckIn { at: ts(208), status: CronStatus::Succeeded, message: "x".into() }),
-            ),
-        ];
-
-        for a in &registers {
-            assert_eq!(merge(a, a), *a, "idempotent: {a:?}");
-            for b in &registers {
-                assert_eq!(merge(a, b), merge(b, a), "commutative");
-                for c in &registers {
-                    assert_eq!(merge(&merge(a, b), c), merge(a, &merge(b, c)), "associative");
-                }
-            }
-        }
-    }
-
-    #[test]
-    fn merge_takes_terminal_status_for_the_same_run() {
-        // Node A saw the run start; node B saw it fail. Merging either way yields the failure.
-        let a = with_runs(vec![run(100, CronStatus::Running, None)], 100, None);
-        let b = with_runs(vec![run(100, CronStatus::Failed, Some(7))], 107, None);
-
-        let ab = merge(&a, &b);
-        assert_eq!(ab, merge(&b, &a));
-        assert_eq!(ab.runs.len(), 1);
-        assert_eq!(ab.runs[0].status, CronStatus::Failed);
-        assert_eq!(ab.runs[0].duration, Some(Duration::from_secs(7)));
-    }
-
-    #[test]
-    fn merge_keeps_latest_checkin() {
-        let a = with_runs(vec![], 100, Some(CheckIn { at: ts(100), status: CronStatus::Running, message: "a".into() }));
-        let b = with_runs(vec![], 200, Some(CheckIn { at: ts(200), status: CronStatus::Succeeded, message: "b".into() }));
-        assert_eq!(merge(&a, &b).last_checkin.unwrap().message, "b");
-        assert_eq!(merge(&b, &a).last_checkin.unwrap().message, "b");
-    }
-
-    #[test]
-    fn merge_bounds_runs() {
-        let many: Vec<CronRun> = (0..(MAX_RUNS as i64 + 10))
-            .map(|i| run(1_000 + i * 60, CronStatus::Succeeded, Some(1)))
-            .collect();
-        let a = with_runs(many, 99_999, None);
-        let merged = merge(&a, &with_runs(vec![], 0, None));
-        assert_eq!(merged.runs.len(), MAX_RUNS);
-        assert_eq!(merged.runs.last().unwrap().started_at, ts(1_000 + (MAX_RUNS as i64 + 9) * 60));
     }
 
     #[test]

--- a/api/src/cron.rs
+++ b/api/src/cron.rs
@@ -497,6 +497,57 @@ mod tests {
     }
 
     #[test]
+    fn since_reports_failure_and_stuck_onsets() {
+        // A failed terminal run reads as failing since the run finished (start + duration).
+        let c = cron_with(every(60), vec![run(1_000, CronStatus::Failed, Some(5))], None, None);
+        assert_eq!(c.health(ts(1_006)), CronHealth::Failed);
+        assert_eq!(c.since(c.health(ts(1_006))), Some(ts(1_005)));
+
+        // A stuck in-flight run reads as overrunning since start + max_duration.
+        let c = cron_with(
+            every(3600),
+            vec![run(1_000, CronStatus::Running, None)],
+            Some(Duration::from_secs(60)),
+            None,
+        );
+        let now = ts(2_000);
+        assert_eq!(c.health(now), CronHealth::Stuck);
+        assert_eq!(c.since(c.health(now)), Some(ts(1_060)));
+    }
+
+    #[test]
+    fn next_due_is_one_interval_after_the_last_run() {
+        let c = cron_with(every(60), vec![run(1_000, CronStatus::Succeeded, Some(5))], None, None);
+        assert_eq!(c.next_due(), Some(ts(1_060)));
+
+        // With no runs there is no next-due time.
+        let empty = Cron::from_config("c", HashMap::new(), every(60), None, None);
+        assert_eq!(empty.next_due(), None);
+    }
+
+    #[test]
+    fn cron_health_labels_and_tokens_cover_every_variant() {
+        let all = [
+            CronHealth::Pending,
+            CronHealth::Running,
+            CronHealth::Succeeded,
+            CronHealth::Failed,
+            CronHealth::Missing,
+            CronHealth::Stuck,
+        ];
+        for health in all {
+            assert!(!health.label().is_empty());
+            assert!(!health.as_str().is_empty());
+        }
+        assert!(CronHealth::Pending.passing());
+        assert!(CronHealth::Running.passing());
+        assert!(!CronHealth::Missing.passing());
+        assert!(!CronHealth::Stuck.passing());
+        assert_eq!(CronHealth::Stuck.label(), "Overrunning");
+        assert_eq!(CronHealth::Missing.as_str(), "missing");
+    }
+
+    #[test]
     fn crontab_schedule_detects_a_missed_minute() {
         // "every minute"; default grace for a crontab is 5 minutes.
         let start = DateTime::parse_from_rfc3339("2026-01-01T12:00:00Z").unwrap().with_timezone(&Utc);

--- a/api/src/identifier.rs
+++ b/api/src/identifier.rs
@@ -66,6 +66,88 @@ impl FromStr for Identifier {
     }
 }
 
+/// The identifier of a single incident update, backed by a `u128` whose high 64 bits are the parent
+/// [`Identifier`] (incident id) and whose low 64 bits are the update's own snowflake. Embedding the
+/// incident id lets every update for an incident be found as a contiguous key range
+/// `[incident<<64, (incident+1)<<64)`, and keeps updates globally unique without coordination.
+/// Serialized/displayed as base64url of its 16 big-endian bytes, mirroring [`Identifier`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
+pub struct IncidentUpdateId(u128);
+
+impl IncidentUpdateId {
+    pub const fn new(value: u128) -> Self {
+        Self(value)
+    }
+
+    /// Composes an update id from its parent incident and the update's own snowflake half.
+    pub fn compose(incident: Identifier, update_snowflake: u64) -> Self {
+        Self(((u64::from(incident) as u128) << 64) | update_snowflake as u128)
+    }
+
+    /// The parent incident id (the high 64 bits).
+    pub fn incident_id(self) -> Identifier {
+        Identifier::new((self.0 >> 64) as u64)
+    }
+
+    /// The update's own snowflake half (the low 64 bits).
+    pub fn update_part(self) -> u64 {
+        self.0 as u64
+    }
+
+    /// Parses the base64url-of-16-bytes form back into an id; `None` for malformed input.
+    pub fn parse(text: &str) -> Option<Self> {
+        BASE64_URL_SAFE_NO_PAD.decode(text).ok().and_then(|bytes| {
+            if bytes.len() != 16 {
+                return None;
+            }
+            let mut value = 0u128;
+            for &byte in &bytes {
+                value = (value << 8) | byte as u128;
+            }
+            Some(Self(value))
+        })
+    }
+}
+
+impl fmt::Display for IncidentUpdateId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", BASE64_URL_SAFE_NO_PAD.encode(self.0.to_be_bytes()))
+    }
+}
+
+impl From<u128> for IncidentUpdateId {
+    fn from(value: u128) -> Self {
+        Self(value)
+    }
+}
+
+impl From<IncidentUpdateId> for u128 {
+    fn from(id: IncidentUpdateId) -> u128 {
+        id.0
+    }
+}
+
+impl FromStr for IncidentUpdateId {
+    type Err = InvalidIdentifier;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s).ok_or(InvalidIdentifier)
+    }
+}
+
+impl Serialize for IncidentUpdateId {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for IncidentUpdateId {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let text = String::deserialize(deserializer)?;
+        Self::parse(&text).ok_or_else(|| D::Error::custom(format!("invalid update id: {text}")))
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InvalidIdentifier;
 
@@ -123,5 +205,25 @@ mod tests {
     fn serializes_as_a_json_string() {
         assert_eq!(serde_json::to_string(&Identifier::from(0u64)).unwrap(), "\"AAAAAAAAAAA\"");
         assert!(serde_json::from_str::<Identifier>("\"//\"").is_err());
+    }
+
+    #[test]
+    fn update_id_composes_and_decomposes() {
+        let incident = Identifier::from(0x1234_5678_9abc_def0u64);
+        let snowflake = 0x0fed_cba9_8765_4321u64;
+        let id = IncidentUpdateId::compose(incident, snowflake);
+
+        // High 64 bits recover the incident, low 64 the update half.
+        assert_eq!(id.incident_id(), incident);
+        assert_eq!(id.update_part(), snowflake);
+
+        // Updates for the same incident share the high-bits prefix, so they form a contiguous range.
+        let other = IncidentUpdateId::compose(incident, 1);
+        assert_eq!(u128::from(other) >> 64, u128::from(id) >> 64);
+
+        // serde + Display round-trip through the base64url form.
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(serde_json::from_str::<IncidentUpdateId>(&json).unwrap(), id);
+        assert_eq!(IncidentUpdateId::parse(&id.to_string()), Some(id));
     }
 }

--- a/api/src/incident.rs
+++ b/api/src/incident.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::Identifier;
+use crate::{Identifier, IncidentUpdateId};
 
 /// The impact an incident update reports. An incident's current impact is that of its most recent
 /// update (defaulting to `Hidden` when it has none). `Hidden` keeps the incident from unauthenticated
@@ -69,20 +69,38 @@ impl std::str::FromStr for Impact {
     }
 }
 
-/// A single update posted against an incident, identified by its position in the incident's `updates`
-/// list. `message` is markdown; `impact` drives the incident's status from this point on the timeline.
+/// A single update posted against an incident — a **standalone, gossip-replicated entity** in its own
+/// right (so adding/editing different updates never conflicts across the cluster). `message` is
+/// markdown; `impact` drives the incident's status from this update's `timestamp` onward and is fixed
+/// once posted. `version` is the wall-clock last-modified time in milliseconds — the gossip LWW clock
+/// and the HTTP ETag — and `deleted` is a propagating tombstone (filtered from API responses).
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct IncidentUpdate {
+    pub id: IncidentUpdateId,
     pub impact: Impact,
     #[serde(with = "chrono::serde::ts_seconds")]
     pub timestamp: DateTime<Utc>,
     pub message: String,
+    /// Last-modified wall-clock time in milliseconds: the gossip version and the HTTP ETag.
+    #[serde(default)]
+    pub version: u64,
+    /// A propagating delete tombstone. Tombstoned updates are filtered from API responses and reaped
+    /// by GC once aged out.
+    #[serde(default)]
+    pub deleted: bool,
 }
 
-/// An operator-recorded incident/event. Everything beyond its `id`, `title` and `version` is derived
-/// from its `updates`: the start/end times, the current impact, and the created/updated times. The
-/// `version` is a monotonically increasing counter used for optimistic concurrency (check-and-set via
-/// the API's `If-Match`/`ETag`).
+impl IncidentUpdate {
+    /// The parent incident this update belongs to (the high bits of its id).
+    pub fn incident_id(&self) -> Identifier {
+        self.id.incident_id()
+    }
+}
+
+/// An operator-recorded incident/event header — a **standalone, gossip-replicated entity** holding
+/// only its own mutable fields (`title`, the `deleted` tombstone). Its updates are separate entities
+/// joined into an [`IncidentView`] for display. `version` is the wall-clock last-modified time in
+/// milliseconds: the gossip LWW clock and the HTTP ETag.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Incident {
     pub id: Identifier,
@@ -90,23 +108,43 @@ pub struct Incident {
     #[serde(default)]
     pub version: u64,
     #[serde(default)]
+    pub deleted: bool,
+}
+
+/// An incident joined with its (visible, sorted-oldest-first) updates — the shape the API returns and
+/// the UI renders. Everything beyond the incident's `id`/`title` is derived from `updates`.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct IncidentView {
+    #[serde(flatten)]
+    pub incident: Incident,
+    #[serde(default)]
     pub updates: Vec<IncidentUpdate>,
 }
 
-impl Incident {
-    /// The updates sorted oldest-first by timestamp.
-    pub fn sorted_updates(&self) -> Vec<&IncidentUpdate> {
-        let mut updates: Vec<&IncidentUpdate> = self.updates.iter().collect();
-        updates.sort_by_key(|u| u.timestamp);
-        updates
+impl IncidentView {
+    pub fn new(incident: Incident, mut updates: Vec<IncidentUpdate>) -> Self {
+        updates.sort_by_key(|u| (u.timestamp, u.id));
+        Self { incident, updates }
     }
 
-    /// The incident's current impact: that of its most recent update, or `Hidden` when it has no
-    /// updates (a freshly created, not-yet-published incident).
+    pub fn id(&self) -> Identifier {
+        self.incident.id
+    }
+
+    pub fn title(&self) -> &str {
+        &self.incident.title
+    }
+
+    /// The updates sorted oldest-first (already maintained by [`IncidentView::new`]).
+    pub fn sorted_updates(&self) -> &[IncidentUpdate] {
+        &self.updates
+    }
+
+    /// The incident's current impact: that of its most recent update, or `Hidden` when it has none.
     pub fn current_impact(&self) -> Impact {
         self.updates
             .iter()
-            .max_by_key(|u| u.timestamp)
+            .max_by_key(|u| (u.timestamp, u.id))
             .map(|u| u.impact)
             .unwrap_or(Impact::Hidden)
     }
@@ -146,7 +184,7 @@ impl Incident {
     pub fn impact_since(&self) -> Option<DateTime<Utc>> {
         let current = self.current_impact();
         let mut since = None;
-        for update in self.sorted_updates().into_iter().rev() {
+        for update in self.updates.iter().rev() {
             if update.impact == current {
                 since = Some(update.timestamp);
             } else {
@@ -158,7 +196,7 @@ impl Incident {
 }
 
 /// The body for creating an incident: a title plus its first update (impact + markdown message). The
-/// server assigns the id, the update's timestamp, and the initial version.
+/// server assigns the ids and timestamps.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateIncident {
     pub title: String,
@@ -166,14 +204,34 @@ pub struct CreateIncident {
     pub message: String,
 }
 
-/// The body for replacing an incident (title + the full updates list). Applied as a check-and-set
-/// against the incident's current `version` (sent as an `If-Match` header), so concurrent edits don't
-/// silently clobber one another.
+/// The body for replacing an incident's editable header fields (its title). Applied as a check-and-set
+/// against the incident's `version` (sent as an `If-Match` header).
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct IncidentEdit {
+pub struct PutIncident {
     pub title: String,
-    #[serde(default)]
-    pub updates: Vec<IncidentUpdate>,
+}
+
+/// The body for adding a new update to an incident (the server assigns the id and timestamp).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct CreateUpdate {
+    pub impact: Impact,
+    pub message: String,
+}
+
+/// The body for replacing an existing update's editable field (its message). Applied as a
+/// check-and-set against the update's `version`; the `impact` is fixed once posted.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct PutUpdate {
+    pub message: String,
+}
+
+/// A page of incidents, newest-first, each carrying its updates. `next_cursor` is the id to pass as
+/// `?cursor=` for the following page, or `None` when the last page has been returned.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct IncidentsPage {
+    pub incidents: Vec<IncidentView>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<Identifier>,
 }
 
 /// The signed-in administrator, derived from validated token claims, returned by `/api/v1/admin/me`.
@@ -194,21 +252,22 @@ mod tests {
         DateTime::from_timestamp(secs, 0).unwrap()
     }
 
-    fn update(impact: Impact, secs: i64) -> IncidentUpdate {
+    fn update(incident: Identifier, snow: u64, impact: Impact, secs: i64) -> IncidentUpdate {
         IncidentUpdate {
+            id: IncidentUpdateId::compose(incident, snow),
             impact,
             timestamp: ts(secs),
             message: format!("update at {secs}"),
+            version: (secs * 1000) as u64,
+            deleted: false,
         }
     }
 
-    fn sample(updates: Vec<IncidentUpdate>) -> Incident {
-        Incident {
-            id: Identifier::from(1_234_567u64),
-            title: "Database outage".into(),
-            version: 1,
+    fn view(updates: Vec<IncidentUpdate>) -> IncidentView {
+        IncidentView::new(
+            Incident { id: Identifier::from(1_234_567u64), title: "Database outage".into(), version: 1, deleted: false },
             updates,
-        }
+        )
     }
 
     #[test]
@@ -222,57 +281,56 @@ mod tests {
     }
 
     #[test]
-    fn incident_round_trips_with_id_as_string_and_epoch_updates() {
-        let incident = sample(vec![update(Impact::Offline, 1_700_000_100)]);
-        let json = serde_json::to_value(&incident).unwrap();
-        // id serializes as a grouped base36 string; updates carry epoch-second timestamps.
-        assert_eq!(json["id"], serde_json::Value::String(incident.id.to_string()));
-        assert_eq!(json["version"], 1);
+    fn view_flattens_incident_and_carries_updates() {
+        let id = Identifier::from(1_234_567u64);
+        let v = view(vec![update(id, 1, Impact::Offline, 1_700_000_100)]);
+        let json = serde_json::to_value(&v).unwrap();
+        // The incident fields are flattened alongside the updates array.
+        assert_eq!(json["id"], serde_json::Value::String(id.to_string()));
+        assert_eq!(json["title"], "Database outage");
         assert_eq!(json["updates"][0]["impact"], "offline");
         assert_eq!(json["updates"][0]["timestamp"], 1_700_000_100);
-        // No removed fields linger.
-        assert!(json.get("description").is_none());
-        assert!(json.get("start_time").is_none());
-        assert!(json.get("affected_services").is_none());
 
-        let decoded: Incident = serde_json::from_value(json).unwrap();
-        assert_eq!(decoded, incident);
+        let decoded: IncidentView = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded, v);
     }
 
     #[test]
     fn derived_times_and_impact_follow_updates() {
-        let incident = sample(vec![
-            update(Impact::Offline, 1_700_000_100),
-            update(Impact::None, 1_700_000_500),
+        let id = Identifier::from(1_234_567u64);
+        let v = view(vec![
+            update(id, 1, Impact::Offline, 1_700_000_100),
+            update(id, 2, Impact::None, 1_700_000_500),
         ]);
-        assert_eq!(incident.current_impact(), Impact::None);
-        assert_eq!(incident.started_at(), Some(ts(1_700_000_100)));
-        assert_eq!(incident.last_updated(), Some(ts(1_700_000_500)));
-        assert_eq!(incident.ended_at(), Some(ts(1_700_000_500)), "a 'none' impact resolves it");
-        assert!(incident.is_public());
-        assert!(!incident.is_active());
+        assert_eq!(v.current_impact(), Impact::None);
+        assert_eq!(v.started_at(), Some(ts(1_700_000_100)));
+        assert_eq!(v.last_updated(), Some(ts(1_700_000_500)));
+        assert_eq!(v.ended_at(), Some(ts(1_700_000_500)), "a 'none' impact resolves it");
+        assert!(v.is_public());
+        assert!(!v.is_active());
     }
 
     #[test]
     fn no_updates_means_hidden_and_inactive() {
-        let incident = sample(vec![]);
-        assert_eq!(incident.current_impact(), Impact::Hidden);
-        assert!(!incident.is_public(), "an incident with no updates is a hidden draft");
-        assert!(!incident.is_active());
-        assert_eq!(incident.started_at(), None);
-        assert_eq!(incident.ended_at(), None);
-        assert_eq!(incident.impact_since(), None);
+        let v = view(vec![]);
+        assert_eq!(v.current_impact(), Impact::Hidden);
+        assert!(!v.is_public(), "an incident with no updates is a hidden draft");
+        assert!(!v.is_active());
+        assert_eq!(v.started_at(), None);
+        assert_eq!(v.ended_at(), None);
+        assert_eq!(v.impact_since(), None);
     }
 
     #[test]
     fn impact_since_is_the_start_of_the_trailing_run() {
-        let incident = sample(vec![
-            update(Impact::Offline, 100),
-            update(Impact::Offline, 200),
-            update(Impact::Degraded, 300),
+        let id = Identifier::from(1_234_567u64);
+        let v = view(vec![
+            update(id, 1, Impact::Offline, 100),
+            update(id, 2, Impact::Offline, 200),
+            update(id, 3, Impact::Degraded, 300),
         ]);
-        assert_eq!(incident.current_impact(), Impact::Degraded);
-        assert_eq!(incident.impact_since(), Some(ts(300)));
-        assert!(incident.is_active());
+        assert_eq!(v.current_impact(), Impact::Degraded);
+        assert_eq!(v.impact_since(), Some(ts(300)));
+        assert!(v.is_active());
     }
 }

--- a/ui/src/api.rs
+++ b/ui/src/api.rs
@@ -1,15 +1,18 @@
 //! The SPA's single API client.
 //!
-//! [`ApiClient`] exposes one method per entity (`probes`, `notices`, `incidents`, `peers`, the
-//! incident CRUD calls and `me`), so callers never hand-build requests. Every failure surfaces as a
-//! [`grey_api::ApiError`], whose `code` mirrors the HTTP status so callers can classify problems.
+//! [`ApiClient`] exposes one method per entity operation, so callers never hand-build requests. Every
+//! failure surfaces as a [`grey_api::ApiError`], whose `code` mirrors the HTTP status so callers can
+//! classify problems.
 //!
 //! Authenticated calls attach the stored ID token as an `Authorization: Bearer` header. When the
 //! agent rejects a token as expired (HTTP 401), the client transparently renews it from the stored
 //! refresh token (see [`crate::auth`]) and retries the request once; interactive sign-in is handled
 //! separately via a popup (see [`crate::auth::begin_login`]). Browser-only; the SSR build gets stubs.
 
-use grey_api::{AdminUser, ApiError, CreateIncident, Incident, IncidentEdit, Peer, UiAuthConfig};
+use grey_api::{
+    AdminUser, ApiError, CreateIncident, CreateUpdate, IncidentUpdateId, IncidentView,
+    IncidentsPage, Peer, PutIncident, PutUpdate, UiAuthConfig,
+};
 
 /// A client for the agent's HTTP API. Cheap to clone; holds only the public OIDC config it needs to
 /// renew sessions on the caller's behalf.
@@ -49,11 +52,8 @@ mod browser {
         format!("Bearer {token}")
     }
 
-    /// The advice we fall back to when nothing more specific applies: reloading the page re-runs the
-    /// whole bootstrap (config, session, data) and clears most transient client-side faults.
     const REFRESH_ADVICE: &str = "Refresh the page to try again.";
 
-    /// Guarantees an error carries at least one actionable suggestion, defaulting to a page refresh.
     fn with_fallback_advice(mut error: ApiError) -> ApiError {
         if error.advice.is_empty() {
             error.advice.push(REFRESH_ADVICE.to_string());
@@ -61,35 +61,22 @@ mod browser {
         error
     }
 
-    /// Coerces a transport-level failure (a browser/JS error raised before any HTTP response) into a
-    /// friendly [`ApiError`] with tailored advice. These are the connectivity and serialization
-    /// faults the client can hit on the way to (or back from) the agent, none of which carry an HTTP
-    /// status of their own.
     fn net(err: gloo::net::Error) -> ApiError {
         use gloo::net::Error;
 
         match err {
-            // A `JsError` here almost always means the request never reached the server: the network
-            // dropped, the host is unreachable, or the browser aborted the fetch ("Failed to fetch"
-            // is the canonical message). Treat it as a connectivity problem.
             Error::JsError(_) => ApiError::new("We couldn't reach the server.").with_advice_lines([
                 "Check that your device is still connected to the internet.",
                 "The service may be briefly unavailable — wait a moment, then refresh the page.",
             ]),
-            // The server answered, but its body wasn't the JSON we expected — usually a transient
-            // proxy/error page or a version skew between the UI and the agent.
             Error::SerdeError(_) => ApiError::new("The server returned an unexpected response.")
                 .with_advice(REFRESH_ADVICE),
-            // Anything else gloo surfaces; keep the detail but still point at a recovery step.
             other => {
                 ApiError::new(format!("Something went wrong: {other}")).with_advice(REFRESH_ADVICE)
             }
         }
     }
 
-    /// Builds an [`ApiError`] from a non-success response, preferring the agent's structured error
-    /// body and falling back to a generic message stamped with the HTTP status. Either way the
-    /// result is guaranteed to carry advice so the banner always has something actionable to show.
     async fn error_from(response: Response) -> ApiError {
         let status = response.status();
         let error = match response.json::<ApiError>().await {
@@ -104,7 +91,6 @@ mod browser {
         with_fallback_advice(error)
     }
 
-    /// Decodes a JSON success body, or surfaces the structured error on a non-success response.
     async fn read_json<T: DeserializeOwned>(response: Response) -> Result<T, ApiError> {
         if response.ok() {
             response.json::<T>().await.map_err(net)
@@ -113,8 +99,6 @@ mod browser {
         }
     }
 
-    /// Builds a request for the given verb, attaching the bearer token, `If-Match` ETag and JSON
-    /// body when supplied.
     fn build<B: Serialize>(
         verb: &Verb,
         url: &str,
@@ -143,68 +127,118 @@ mod browser {
     impl ApiClient {
         // --- Public endpoints -------------------------------------------------------------------
 
-        /// Every probe's current state.
         pub async fn probes(&self) -> Result<Vec<grey_api::Probe>, ApiError> {
             self.get_json(&format!("{BASE}/probes")).await
         }
 
-        /// Every cron's current state.
         pub async fn crons(&self) -> Result<Vec<grey_api::Cron>, ApiError> {
             self.get_json(&format!("{BASE}/crons")).await
         }
 
-        /// The configured UI notices.
         pub async fn notices(&self) -> Result<Vec<grey_api::UiNotice>, ApiError> {
             self.get_json(&format!("{BASE}/notices")).await
         }
 
-        /// The publicly visible incidents (hidden drafts are excluded).
-        pub async fn incidents(&self) -> Result<Vec<Incident>, ApiError> {
-            self.get_json(&format!("{BASE}/incidents")).await
+        /// The first page of publicly visible incidents (hidden drafts excluded), each with its
+        /// updates embedded.
+        pub async fn incidents(&self) -> Result<Vec<IncidentView>, ApiError> {
+            let page: IncidentsPage = self.get_json(&format!("{BASE}/incidents")).await?;
+            Ok(page.incidents)
+        }
+
+        /// A page of publicly visible incidents continuing from `cursor` (for "load more").
+        pub async fn incidents_page(
+            &self,
+            cursor: Option<&str>,
+        ) -> Result<IncidentsPage, ApiError> {
+            let url = match cursor {
+                Some(c) => format!("{BASE}/incidents?cursor={c}"),
+                None => format!("{BASE}/incidents"),
+            };
+            self.get_json(&url).await
         }
 
         // --- Admin endpoints --------------------------------------------------------------------
 
-        /// The signed-in administrator, derived from the bearer token's claims.
         pub async fn me(&self) -> Result<AdminUser, ApiError> {
             self.get_json(&format!("{ADMIN}/me")).await
         }
 
-        /// The cluster's peers as seen by this node (operator-only).
         pub async fn peers(&self) -> Result<Vec<Peer>, ApiError> {
             self.get_json(&format!("{ADMIN}/cluster/peers")).await
         }
 
-        /// Every incident, including hidden drafts (admin view).
-        pub async fn admin_incidents(&self) -> Result<Vec<Incident>, ApiError> {
-            self.get_json(&format!("{ADMIN}/incidents")).await
+        /// The first page of incidents including hidden drafts (admin view).
+        pub async fn admin_incidents(&self) -> Result<Vec<IncidentView>, ApiError> {
+            let page: IncidentsPage = self.get_json(&format!("{ADMIN}/incidents")).await?;
+            Ok(page.incidents)
         }
 
         /// A single incident (including hidden), by id.
-        pub async fn incident(&self, id: &str) -> Result<Incident, ApiError> {
+        pub async fn incident(&self, id: &str) -> Result<IncidentView, ApiError> {
             self.get_json(&format!("{ADMIN}/incidents/{id}")).await
         }
 
         /// Creates an incident from a title and its opening update.
-        pub async fn create_incident(&self, input: &CreateIncident) -> Result<Incident, ApiError> {
+        pub async fn create_incident(
+            &self,
+            input: &CreateIncident,
+        ) -> Result<IncidentView, ApiError> {
             let response = self
                 .send(Verb::Post, &format!("{ADMIN}/incidents"), None, Some(input))
                 .await?;
             read_json(response).await
         }
 
-        /// Replaces an incident via check-and-set: `version` is sent as the `If-Match` ETag, so a
-        /// concurrent change surfaces as a 412 [`ApiError`].
-        pub async fn replace_incident(
+        /// Replaces an incident's title via check-and-set on its `version` (the `If-Match` ETag).
+        pub async fn put_incident(
             &self,
             id: &str,
             version: u64,
-            edit: &IncidentEdit,
-        ) -> Result<Incident, ApiError> {
+            edit: &PutIncident,
+        ) -> Result<IncidentView, ApiError> {
+            let response = self
+                .send(Verb::Put, &format!("{ADMIN}/incidents/{id}"), Some(version), Some(edit))
+                .await?;
+            read_json(response).await
+        }
+
+        /// Deletes an incident via check-and-set on its `version`.
+        pub async fn delete_incident(&self, id: &str, version: u64) -> Result<(), ApiError> {
+            let response = self
+                .send::<()>(Verb::Delete, &format!("{ADMIN}/incidents/{id}"), Some(version), None)
+                .await?;
+            if response.ok() {
+                Ok(())
+            } else {
+                Err(error_from(response).await)
+            }
+        }
+
+        /// Adds a new update to an incident.
+        pub async fn create_update(
+            &self,
+            incident_id: &str,
+            input: &CreateUpdate,
+        ) -> Result<IncidentView, ApiError> {
+            let response = self
+                .send(Verb::Post, &format!("{ADMIN}/incidents/{incident_id}/updates"), None, Some(input))
+                .await?;
+            read_json(response).await
+        }
+
+        /// Replaces an update's message via check-and-set on the update's `version`.
+        pub async fn put_update(
+            &self,
+            update_id: IncidentUpdateId,
+            version: u64,
+            edit: &PutUpdate,
+        ) -> Result<IncidentView, ApiError> {
+            let incident = update_id.incident_id();
             let response = self
                 .send(
                     Verb::Put,
-                    &format!("{ADMIN}/incidents/{id}"),
+                    &format!("{ADMIN}/incidents/{incident}/updates/{update_id}"),
                     Some(version),
                     Some(edit),
                 )
@@ -212,10 +246,20 @@ mod browser {
             read_json(response).await
         }
 
-        /// Deletes an incident.
-        pub async fn delete_incident(&self, id: &str) -> Result<(), ApiError> {
+        /// Deletes an update via check-and-set on its `version`.
+        pub async fn delete_update(
+            &self,
+            update_id: IncidentUpdateId,
+            version: u64,
+        ) -> Result<(), ApiError> {
+            let incident = update_id.incident_id();
             let response = self
-                .send::<()>(Verb::Delete, &format!("{ADMIN}/incidents/{id}"), None, None)
+                .send::<()>(
+                    Verb::Delete,
+                    &format!("{ADMIN}/incidents/{incident}/updates/{update_id}"),
+                    Some(version),
+                    None,
+                )
                 .await?;
             if response.ok() {
                 Ok(())
@@ -226,15 +270,11 @@ mod browser {
 
         // --- Request orchestration --------------------------------------------------------------
 
-        /// Sends a GET and decodes a JSON success body, surfacing any error response.
         async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T, ApiError> {
             let response = self.send::<()>(Verb::Get, url, None, None).await?;
             read_json(response).await
         }
 
-        /// Sends a request, attaching the stored bearer when one is available. On a 401 it renews
-        /// the session from the refresh token and retries once; a renewal failure drops the dead
-        /// session so the UI can re-prompt for sign-in.
         async fn send<B: Serialize>(
             &self,
             verb: Verb,
@@ -252,7 +292,6 @@ mod browser {
                 return Ok(response);
             }
 
-            // The token was rejected as expired/invalid: try a silent refresh, then retry once.
             if self.auth.is_some()
                 && let Ok(fresh) = crate::auth::refresh_session().await
             {
@@ -262,7 +301,6 @@ mod browser {
                     .map_err(net);
             }
 
-            // Renewal isn't possible — drop the session so the UI prompts for an interactive login.
             crate::auth::clear_token();
             Ok(response)
         }
@@ -284,7 +322,10 @@ impl ApiClient {
     pub async fn notices(&self) -> Result<Vec<grey_api::UiNotice>, ApiError> {
         Self::unavailable()
     }
-    pub async fn incidents(&self) -> Result<Vec<Incident>, ApiError> {
+    pub async fn incidents(&self) -> Result<Vec<IncidentView>, ApiError> {
+        Self::unavailable()
+    }
+    pub async fn incidents_page(&self, _cursor: Option<&str>) -> Result<IncidentsPage, ApiError> {
         Self::unavailable()
     }
     pub async fn me(&self) -> Result<AdminUser, ApiError> {
@@ -293,24 +334,46 @@ impl ApiClient {
     pub async fn peers(&self) -> Result<Vec<Peer>, ApiError> {
         Self::unavailable()
     }
-    pub async fn admin_incidents(&self) -> Result<Vec<Incident>, ApiError> {
+    pub async fn admin_incidents(&self) -> Result<Vec<IncidentView>, ApiError> {
         Self::unavailable()
     }
-    pub async fn incident(&self, _id: &str) -> Result<Incident, ApiError> {
+    pub async fn incident(&self, _id: &str) -> Result<IncidentView, ApiError> {
         Self::unavailable()
     }
-    pub async fn create_incident(&self, _input: &CreateIncident) -> Result<Incident, ApiError> {
+    pub async fn create_incident(&self, _input: &CreateIncident) -> Result<IncidentView, ApiError> {
         Self::unavailable()
     }
-    pub async fn replace_incident(
+    pub async fn put_incident(
         &self,
         _id: &str,
         _version: u64,
-        _edit: &IncidentEdit,
-    ) -> Result<Incident, ApiError> {
+        _edit: &PutIncident,
+    ) -> Result<IncidentView, ApiError> {
         Self::unavailable()
     }
-    pub async fn delete_incident(&self, _id: &str) -> Result<(), ApiError> {
+    pub async fn delete_incident(&self, _id: &str, _version: u64) -> Result<(), ApiError> {
+        Self::unavailable()
+    }
+    pub async fn create_update(
+        &self,
+        _incident_id: &str,
+        _input: &CreateUpdate,
+    ) -> Result<IncidentView, ApiError> {
+        Self::unavailable()
+    }
+    pub async fn put_update(
+        &self,
+        _update_id: IncidentUpdateId,
+        _version: u64,
+        _edit: &PutUpdate,
+    ) -> Result<IncidentView, ApiError> {
+        Self::unavailable()
+    }
+    pub async fn delete_update(
+        &self,
+        _update_id: IncidentUpdateId,
+        _version: u64,
+    ) -> Result<(), ApiError> {
         Self::unavailable()
     }
 }

--- a/ui/src/client.rs
+++ b/ui/src/client.rs
@@ -26,7 +26,7 @@ pub struct AppProps {
     #[prop_or_default]
     pub crons: Vec<grey_api::Cron>,
     #[prop_or_default]
-    pub incidents: Vec<grey_api::Incident>,
+    pub incidents: Vec<grey_api::IncidentView>,
     /// The request path, used to seed the router during server-side rendering so a deep link to a
     /// non-home route renders the right page (and hydrates cleanly). Unused on the client, where the
     /// browser's location drives the router.
@@ -82,7 +82,7 @@ impl AppProps {
         let config: UiConfig = serde_json::from_str(&config_data)?;
         let notices: Vec<grey_api::UiNotice> = serde_json::from_str(&notices_data)?;
         let probes: Vec<grey_api::Probe> = serde_json::from_str(&probes_data)?;
-        let incidents: Vec<grey_api::Incident> = incidents_data
+        let incidents: Vec<grey_api::IncidentView> = incidents_data
             .and_then(|data| serde_json::from_str(&data).ok())
             .unwrap_or_default();
         let crons: Vec<grey_api::Cron> = crons_data

--- a/ui/src/components/_incident_timeline.scss
+++ b/ui/src/components/_incident_timeline.scss
@@ -24,6 +24,7 @@
     background-color: $color-status-offline;
     white-space: nowrap;
     margin: 0 0.5rem;
+    vertical-align: text-bottom;
 }
 
 // Horizontal event timeline (summary): impact-coloured dots on a connecting line, each revealing an
@@ -178,8 +179,13 @@
     }
 
     .incident-timeline__time {
-        font-size: 0.78rem;
+        font-size: 0.8rem;
         color: $color-text-muted;
+
+        time {
+            vertical-align: text-bottom;
+            line-height: 1.25rem;
+        }
     }
 
     .incident-timeline__keydate {

--- a/ui/src/components/_incidents.scss
+++ b/ui/src/components/_incidents.scss
@@ -284,7 +284,7 @@
         cursor: pointer;
         border: none;
         background: none;
-        padding: 0;
+        padding: 0.2rem;
         color: $color-text-muted;
         display: inline-flex;
         align-items: center;
@@ -296,6 +296,10 @@
 
         &:hover {
             color: $color-text;
+        }
+
+        &.danger:hover {
+            color: $color-status-error;
         }
     }
 
@@ -313,9 +317,9 @@
     }
 
     // Each new (unposted) update's controls: impact select + timestamp + remove, above its message.
-    .incident-timeline__edit-row {
+    .incident-timeline__item--new .incident-timeline__time {
         display: flex;
-        align-items: center;
+        align-items: flex-start;
         flex-wrap: wrap;
         gap: 0.6rem;
         margin-bottom: 0.4rem;

--- a/ui/src/components/icons.rs
+++ b/ui/src/components/icons.rs
@@ -16,10 +16,18 @@ pub fn save_icon() -> Html {
     )
 }
 
-/// A pencil "edit" glyph.
+/// A pencil "edit" glyph. The viewBox is padded so the diagonal pencil renders a touch smaller,
+/// matching the visual footprint of the sparser [`check_icon`].
 pub fn edit_icon() -> Html {
     icon(
-        r#"<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>"#,
+        r#"<svg class="icon" viewBox="-3 -3 30 30" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path></svg>"#,
+    )
+}
+
+/// A trash-can "remove" glyph, used to delete a posted update.
+pub fn trash_icon() -> Html {
+    icon(
+        r#"<svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"></polyline><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path><line x1="10" y1="11" x2="10" y2="17"></line><line x1="14" y1="11" x2="14" y2="17"></line></svg>"#,
     )
 }
 

--- a/ui/src/components/incident_timeline.rs
+++ b/ui/src/components/incident_timeline.rs
@@ -7,7 +7,7 @@ use crate::components::markdown::render_markdown;
 use crate::components::{Popover, PopoverAlign};
 use crate::formatters::time_format;
 use crate::styles::impact_class;
-use grey_api::{Incident, IncidentUpdate};
+use grey_api::{IncidentUpdate, IncidentView};
 use yew::prelude::*;
 
 /// The horizontal timeline used in summaries: a lead-in tail in the first update's colour runs in
@@ -17,7 +17,7 @@ use yew::prelude::*;
 /// on-screen.
 #[derive(Properties, PartialEq)]
 pub struct HorizontalTimelineProps {
-    pub incident: Incident,
+    pub incident: IncidentView,
 }
 
 #[function_component(HorizontalTimeline)]
@@ -103,7 +103,7 @@ pub fn vertical_timeline(props: &VerticalTimelineProps) -> Html {
                         <div class="incident-timeline__body">
                             <div class="incident-timeline__time">
                                 <span class={classes!("incident-status-pill", class)}>{update.impact.label()}</span>
-                                {time_format(update.timestamp)}
+                                <time datetime={update.timestamp.to_rfc3339()}>{time_format(update.timestamp)}</time>
                             </div>
                             <div class={classes!("incident-timeline__card", class)}>
                                 <div class="incident-timeline__card-message markdown">{ render_markdown(&update.message) }</div>

--- a/ui/src/components/incidents.rs
+++ b/ui/src/components/incidents.rs
@@ -10,12 +10,12 @@ use crate::components::markdown::render_markdown;
 use crate::formatters::{date_format, incident_status};
 use crate::routes::Route;
 use chrono::Utc;
-use grey_api::{Impact, Incident};
+use grey_api::{Impact, IncidentView};
 use yew::prelude::*;
 use yew_router::prelude::*;
 
 /// The worst impact among the incidents (used for the landing-page top-line status).
-pub fn worst_impact(incidents: &[Incident]) -> Option<Impact> {
+pub fn worst_impact(incidents: &[IncidentView]) -> Option<Impact> {
     incidents
         .iter()
         .filter(|i| i.is_active())
@@ -27,7 +27,7 @@ pub fn worst_impact(incidents: &[Incident]) -> Option<Impact> {
 /// nothing when there are no incidents to show.
 #[derive(Properties, PartialEq)]
 pub struct IncidentsSectionProps {
-    pub incidents: Vec<Incident>,
+    pub incidents: Vec<IncidentView>,
 }
 
 #[function_component(IncidentsSection)]
@@ -40,7 +40,7 @@ pub fn incidents_section(props: &IncidentsSectionProps) -> Html {
         <div class="incidents-section">
             <div class="incidents-section__summaries">
                 { for props.incidents.iter().map(|incident| html! {
-                    <IncidentSummary key={incident.id.to_string()} incident={incident.clone()} />
+                    <IncidentSummary key={incident.id().to_string()} incident={incident.clone()} />
                 }) }
             </div>
         </div>
@@ -51,7 +51,7 @@ pub fn incidents_section(props: &IncidentsSectionProps) -> Html {
 /// impact-coloured markers, each revealing its update in a popover on hover.
 #[derive(Properties, PartialEq)]
 pub struct IncidentSummaryProps {
-    pub incident: Incident,
+    pub incident: IncidentView,
 }
 
 #[function_component(IncidentSummary)]
@@ -67,8 +67,8 @@ pub fn incident_summary(props: &IncidentSummaryProps) -> Html {
                 <h3 class="incident-summary__title">
                     <span class="incident-summary__timestamp">{date_format(incident.started_at().unwrap_or_else(Utc::now))}</span>
 
-                    <Link<Route> to={Route::Incident { id: incident.id.to_string() }} classes="incident-link">
-                        {&incident.title}
+                    <Link<Route> to={Route::Incident { id: incident.id().to_string() }} classes="incident-link">
+                        {incident.title()}
                     </Link<Route>>
                 </h3>
                 <span class={classes!("incident-streak", status_class)}>{status_text}</span>
@@ -85,7 +85,7 @@ pub fn incident_summary(props: &IncidentSummaryProps) -> Html {
 /// (no card chrome); the update entries themselves are the cards.
 #[derive(Properties, PartialEq)]
 pub struct IncidentBlockProps {
-    pub incident: Incident,
+    pub incident: IncidentView,
 }
 
 #[function_component(IncidentBlock)]
@@ -100,11 +100,11 @@ pub fn incident_block(props: &IncidentBlockProps) -> Html {
                     <h3 class="incident-block__title">
                         <span class="incident-summary__timestamp">{date_format(incident.started_at().unwrap_or_else(Utc::now))}</span>
 
-                        <Link<Route> to={Route::Incident { id: incident.id.to_string() }} classes="incident-link">
-                            {&incident.title}
+                        <Link<Route> to={Route::Incident { id: incident.id().to_string() }} classes="incident-link">
+                            {incident.title()}
                         </Link<Route>>
                     </h3>
-                    // <span class="incident-id">{format!("{}", incident.id)}</span>
+                    // <span class="incident-id">{format!("{}", incident.id())}</span>
                 </div>
                 <span class={classes!("incident-streak", status_class)}>{status_text}</span>
             </div>
@@ -117,21 +117,31 @@ pub fn incident_block(props: &IncidentBlockProps) -> Html {
 mod tests {
     use super::*;
     use chrono::DateTime;
-    use grey_api::{Identifier, IncidentUpdate};
+    use grey_api::{Identifier, Incident, IncidentUpdate, IncidentUpdateId};
 
     fn ts(secs: i64) -> DateTime<Utc> {
         DateTime::from_timestamp(secs, 0).unwrap()
     }
 
     fn update(impact: Impact, secs: i64) -> IncidentUpdate {
-        IncidentUpdate { impact, timestamp: ts(secs), message: format!("update at {secs}") }
+        IncidentUpdate {
+            id: IncidentUpdateId::compose(Identifier::from(1_234_567u64), secs as u64),
+            impact,
+            timestamp: ts(secs),
+            message: format!("update at {secs}"),
+            version: (secs * 1000) as u64,
+            deleted: false,
+        }
     }
 
-    fn incident(updates: Vec<IncidentUpdate>) -> Incident {
-        Incident { id: Identifier::from(1_234_567u64), title: "DB outage".into(), version: 1, updates }
+    fn incident(updates: Vec<IncidentUpdate>) -> IncidentView {
+        IncidentView::new(
+            Incident { id: Identifier::from(1_234_567u64), title: "DB outage".into(), version: 1, deleted: false },
+            updates,
+        )
     }
 
-    async fn render_block(incident: Incident) -> String {
+    async fn render_block(incident: IncidentView) -> String {
         #[function_component(Harness)]
         fn harness(props: &IncidentBlockProps) -> Html {
             use yew_router::history::{AnyHistory, MemoryHistory};

--- a/ui/src/contexts/store.rs
+++ b/ui/src/contexts/store.rs
@@ -12,23 +12,23 @@
 use std::rc::Rc;
 
 use grey_api::{
-    AdminUser, ApiError, CreateIncident, Cron, Identifier, Incident, IncidentEdit, Peer, Probe,
-    UiConfig, UiNotice,
+    AdminUser, ApiError, CreateIncident, CreateUpdate, Cron, Identifier, IncidentUpdateId,
+    IncidentView, Peer, Probe, PutIncident, PutUpdate, UiConfig, UiNotice,
 };
 use yew::prelude::*;
 
 use crate::api::ApiClient;
 
-/// Sorts incidents most-recently-updated first (those with no updates sort last), mirroring the
-/// server's ordering so optimistic insertions land in the right place.
-fn sort_incidents(incidents: &mut [Incident]) {
-    incidents.sort_by(|a, b| b.last_updated().cmp(&a.last_updated()));
+/// Sorts incidents newest-first by id (snowflake ids are time-ordered), mirroring the server's
+/// ordering so optimistic insertions land in the right place.
+fn sort_incidents(incidents: &mut [IncidentView]) {
+    incidents.sort_by(|a, b| b.id().cmp(&a.id()));
 }
 
 /// Inserts or replaces an incident in the shared (public) list. The list mirrors the unauthenticated
 /// view, so an incident that is now hidden is dropped rather than shown.
-fn apply_incident_upsert(incidents: &mut Vec<Incident>, incident: Incident) {
-    incidents.retain(|i| i.id != incident.id);
+fn apply_incident_upsert(incidents: &mut Vec<IncidentView>, incident: IncidentView) {
+    incidents.retain(|i| i.id() != incident.id());
     if incident.is_public() {
         incidents.push(incident);
     }
@@ -46,7 +46,7 @@ pub struct StoreState {
     pub token: Option<String>,
     pub peers: Vec<Peer>,
     pub notices: Vec<UiNotice>,
-    pub incidents: Vec<Incident>,
+    pub incidents: Vec<IncidentView>,
     pub probes: Vec<Probe>,
     pub crons: Vec<Cron>,
     /// The most recent background-fetch failure, surfaced to the user as a dismissible banner.
@@ -60,10 +60,10 @@ pub enum Action {
     SetCrons(Vec<Cron>),
     SetNotices(Vec<UiNotice>),
     SetPeers(Vec<Peer>),
-    SetIncidents(Vec<Incident>),
+    SetIncidents(Vec<IncidentView>),
     /// Insert or replace a single incident (after an admin create or edit), without waiting for the
     /// next poll.
-    UpsertIncident(Incident),
+    UpsertIncident(IncidentView),
     /// Remove a single incident (after an admin delete).
     RemoveIncident(Identifier),
     /// Record an established session (the validated administrator and their ID token).
@@ -96,7 +96,7 @@ impl Reducible for StoreState {
             Action::UpsertIncident(incident) => {
                 apply_incident_upsert(&mut next.incidents, incident)
             }
-            Action::RemoveIncident(id) => next.incidents.retain(|incident| incident.id != id),
+            Action::RemoveIncident(id) => next.incidents.retain(|incident| incident.id() != id),
             Action::SetSession { user, token } => {
                 next.user = Some(user);
                 next.token = token;
@@ -150,7 +150,7 @@ impl Store {
         &self.state.peers
     }
 
-    pub fn incidents(&self) -> &[Incident] {
+    pub fn incidents(&self) -> &[IncidentView] {
         &self.state.incidents
     }
 
@@ -186,27 +186,64 @@ impl Store {
     // --- Mutations ------------------------------------------------------------------------------
 
     /// Creates an incident and reflects it in the shared list immediately.
-    pub async fn create_incident(&self, input: CreateIncident) -> Result<Incident, ApiError> {
+    pub async fn create_incident(&self, input: CreateIncident) -> Result<IncidentView, ApiError> {
         let created = self.client.create_incident(&input).await?;
         self.state.dispatch(Action::UpsertIncident(created.clone()));
         Ok(created)
     }
 
-    /// Saves an incident (check-and-set on `version`) and folds the authoritative result back in.
-    pub async fn save_incident(
+    /// Replaces an incident's title (check-and-set on the incident's `version`).
+    pub async fn put_incident(
         &self,
         id: String,
         version: u64,
-        edit: IncidentEdit,
-    ) -> Result<Incident, ApiError> {
-        let saved = self.client.replace_incident(&id, version, &edit).await?;
+        edit: PutIncident,
+    ) -> Result<IncidentView, ApiError> {
+        let saved = self.client.put_incident(&id, version, &edit).await?;
         self.state.dispatch(Action::UpsertIncident(saved.clone()));
         Ok(saved)
     }
 
-    /// Deletes an incident and drops it from the shared list.
-    pub async fn delete_incident(&self, id: Identifier) -> Result<(), ApiError> {
-        self.client.delete_incident(&id.to_string()).await?;
+    /// Adds a new update to an incident and folds the refreshed incident back in.
+    pub async fn create_update(
+        &self,
+        incident_id: String,
+        input: CreateUpdate,
+    ) -> Result<IncidentView, ApiError> {
+        let saved = self.client.create_update(&incident_id, &input).await?;
+        self.state.dispatch(Action::UpsertIncident(saved.clone()));
+        Ok(saved)
+    }
+
+    /// Replaces an update's message (check-and-set on the update's `version`).
+    pub async fn put_update(
+        &self,
+        update_id: IncidentUpdateId,
+        version: u64,
+        edit: PutUpdate,
+    ) -> Result<IncidentView, ApiError> {
+        let saved = self.client.put_update(update_id, version, &edit).await?;
+        self.state.dispatch(Action::UpsertIncident(saved.clone()));
+        Ok(saved)
+    }
+
+    /// Deletes an update (check-and-set on its `version`) and folds the refreshed incident back in.
+    pub async fn delete_update(
+        &self,
+        update_id: IncidentUpdateId,
+        version: u64,
+    ) -> Result<(), ApiError> {
+        self.client.delete_update(update_id, version).await?;
+        // Re-fetch the parent incident so the removed update drops out of the view.
+        if let Ok(view) = self.client.incident(&update_id.incident_id().to_string()).await {
+            self.state.dispatch(Action::UpsertIncident(view));
+        }
+        Ok(())
+    }
+
+    /// Deletes an incident (check-and-set on its `version`) and drops it from the shared list.
+    pub async fn delete_incident(&self, id: Identifier, version: u64) -> Result<(), ApiError> {
+        self.client.delete_incident(&id.to_string(), version).await?;
         self.state.dispatch(Action::RemoveIncident(id));
         Ok(())
     }
@@ -232,7 +269,7 @@ pub struct StoreProviderProps {
     #[prop_or_default]
     pub peers: Vec<Peer>,
     #[prop_or_default]
-    pub incidents: Vec<Incident>,
+    pub incidents: Vec<IncidentView>,
     pub children: Children,
 }
 

--- a/ui/src/formatters/incident.rs
+++ b/ui/src/formatters/incident.rs
@@ -1,5 +1,5 @@
 use chrono::Utc;
-use grey_api::{Impact, Incident};
+use grey_api::{Impact, IncidentView};
 
 use crate::formatters::compact_duration;
 use crate::styles::impact_class;
@@ -7,7 +7,7 @@ use crate::styles::impact_class;
 /// The status text shown alongside an incident, paired with its colour class: the current impact and
 /// how long it has held (like a probe's streak), "Resolved" once it returns to operational, or
 /// "Draft" while hidden.
-pub fn incident_status(incident: &Incident) -> (String, &'static str) {
+pub fn incident_status(incident: &IncidentView) -> (String, &'static str) {
     match incident.current_impact() {
         Impact::Hidden => ("Draft".to_string(), impact_class(Impact::Hidden)),
         Impact::None => {

--- a/ui/src/styles/cron.rs
+++ b/ui/src/styles/cron.rs
@@ -19,3 +19,22 @@ pub fn cron_run_class(status: CronStatus) -> &'static str {
         CronStatus::Failed => "error",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classes_map_every_variant() {
+        assert_eq!(cron_class(CronHealth::Succeeded), "ok");
+        assert_eq!(cron_class(CronHealth::Running), "ok");
+        assert_eq!(cron_class(CronHealth::Stuck), "warn");
+        assert_eq!(cron_class(CronHealth::Failed), "error");
+        assert_eq!(cron_class(CronHealth::Missing), "error");
+        assert_eq!(cron_class(CronHealth::Pending), "unknown");
+
+        assert_eq!(cron_run_class(CronStatus::Succeeded), "ok");
+        assert_eq!(cron_run_class(CronStatus::Running), "warn");
+        assert_eq!(cron_run_class(CronStatus::Failed), "error");
+    }
+}

--- a/ui/src/views/home.rs
+++ b/ui/src/views/home.rs
@@ -33,7 +33,7 @@ pub fn home_view() -> Html {
 
     // Show incidents that are active or were updated recently (the probe-history window).
     let cutoff = Utc::now() - chrono::Duration::days(14);
-    let recent_incidents: Vec<grey_api::Incident> = store
+    let recent_incidents: Vec<grey_api::IncidentView> = store
         .incidents()
         .iter()
         .filter(|incident| {

--- a/ui/src/views/incident_detail.rs
+++ b/ui/src/views/incident_detail.rs
@@ -3,10 +3,11 @@ use yew::prelude::*;
 
 use crate::components::{IncidentBlock, StatusDot};
 use crate::contexts::use_store;
+use crate::formatters::time_format;
 
 /// The `/incidents/{id}` page. Public visitors see the read-only incident; signed-in administrators
-/// get an inline editor (click any field to change it; a save control appears once there are
-/// unsaved changes) plus controls to add/remove updates and delete the incident.
+/// get an inline editor: edit the title, add updates, edit an update's message, remove updates, and
+/// delete the incident. Each action is its own check-and-set API call against that entity's version.
 #[derive(Properties, PartialEq)]
 pub struct IncidentDetailProps {
     pub id: String,
@@ -26,7 +27,7 @@ pub fn incident_detail(props: &IncidentDetailProps) -> Html {
     let _ = &store;
 
     let wanted = Identifier::parse(&props.id);
-    let incident = store.incidents().iter().find(|i| Some(i.id) == wanted).cloned();
+    let incident = store.incidents().iter().find(|i| Some(i.id()) == wanted).cloned();
 
     html! {
         <div class="page">
@@ -51,42 +52,42 @@ struct AdminIncidentDetailProps {
 #[cfg(feature = "wasm")]
 #[function_component(AdminIncidentDetail)]
 fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
-    use crate::components::icons::{check_icon, edit_icon, save_icon};
+    use crate::components::icons::{check_icon, edit_icon, save_icon, trash_icon};
     use crate::components::markdown::render_markdown;
     use crate::routes::Route;
     use crate::styles::impact_class;
-    use chrono::Utc;
-    use grey_api::{Impact, IncidentEdit, IncidentUpdate};
+    use grey_api::{CreateUpdate, Impact, IncidentUpdateId, IncidentView, PutIncident, PutUpdate};
     use web_sys::{HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement};
     use yew_router::prelude::*;
 
-    // The canonical incident (with its version) plus the editable draft fields.
-    let loaded = use_state(|| Option::<grey_api::Incident>::None);
+    // The canonical incident (with its updates + versions) plus the editable draft fields.
+    let loaded = use_state(|| Option::<IncidentView>::None);
     let title = use_state(String::new);
-    let updates = use_state(Vec::<IncidentUpdate>::new);
+    // The update whose message is open in a textarea (by id), plus that textarea's draft.
+    let editing = use_state(|| Option::<IncidentUpdateId>::None);
+    let message_draft = use_state(String::new);
+    // The "add update" form.
+    let new_impact = use_state(|| "offline".to_string());
+    let new_message = use_state(String::new);
     let saving = use_state(|| false);
-    // Which posted update (by index) currently has its message open in a textarea; the rest render
-    // their message as markdown.
-    let editing = use_state(|| Option::<usize>::None);
     let navigator = use_navigator();
-    // The shared store, whose save/delete helpers reflect changes everywhere without a refetch.
     let store = use_store();
     let client = store.client().clone();
 
     // Load the incident (including hidden) once.
     {
         let id = props.id.clone();
+        let new_impact = new_impact.clone();
         let loaded = loaded.clone();
         let title = title.clone();
-        let updates = updates.clone();
         let store = store.clone();
         let client = client.clone();
         use_effect_with((props.token.clone(), props.id.clone()), move |_| {
             wasm_bindgen_futures::spawn_local(async move {
                 match client.incident(&id).await {
                     Ok(incident) => {
-                        title.set(incident.title.clone());
-                        updates.set(incident.sorted_updates().into_iter().cloned().collect());
+                        title.set(incident.title().to_string());
+                        new_impact.set(incident.current_impact().as_str().to_string());
                         loaded.set(Some(incident));
                     }
                     Err(e) => store.set_error(e),
@@ -104,10 +105,8 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
         };
     };
 
-    // The unchanged baseline, in the same (sorted) order as the editable list, so reordering by the
-    // server's storage order never reads as a spurious change.
-    let baseline: Vec<IncidentUpdate> = current.sorted_updates().into_iter().cloned().collect();
-    let dirty = current.title != *title || baseline != *updates;
+    let incident_version = current.incident.version;
+    let title_dirty = current.title() != *title;
 
     let on_title = {
         let title = title.clone();
@@ -117,104 +116,108 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
         })
     };
 
-    let on_update_impact = |index: usize| {
-        let updates = updates.clone();
-        Callback::from(move |e: Event| {
-            let el: HtmlSelectElement = e.target_unchecked_into();
-            let mut next = (*updates).clone();
-            if let Some(u) = next.get_mut(index) {
-                u.impact = el.value().parse().unwrap_or_default();
-            }
-            updates.set(next);
-        })
+    // Replaces the just-saved incident everywhere and refreshes the local draft state.
+    let apply_saved = {
+        let loaded = loaded.clone();
+        let title = title.clone();
+        move |view: IncidentView| {
+            title.set(view.title().to_string());
+            loaded.set(Some(view));
+        }
     };
-    let on_update_message = |index: usize| {
-        let updates = updates.clone();
-        Callback::from(move |e: InputEvent| {
-            let el: HtmlTextAreaElement = e.target_unchecked_into();
-            let mut next = (*updates).clone();
-            if let Some(u) = next.get_mut(index) {
-                u.message = el.value();
-            }
-            updates.set(next);
-        })
-    };
-    let on_remove_update = |index: usize| {
-        let updates = updates.clone();
+
+    let on_save_title = {
+        let id = current.id().to_string();
+        let title = title.clone();
+        let saving = saving.clone();
+        let store = store.clone();
+        let apply_saved = apply_saved.clone();
         Callback::from(move |_| {
-            let mut next = (*updates).clone();
-            if index < next.len() {
-                next.remove(index);
-            }
-            updates.set(next);
-        })
-    };
-    let on_add_update = {
-        let updates = updates.clone();
-        Callback::from(move |_| {
-            let mut next = (*updates).clone();
-            next.push(IncidentUpdate {
-                impact: Impact::Offline,
-                timestamp: Utc::now(),
-                message: String::new(),
+            let edit = PutIncident { title: (*title).trim().to_string() };
+            let (id, saving, store, apply_saved) = (id.clone(), saving.clone(), store.clone(), apply_saved.clone());
+            saving.set(true);
+            wasm_bindgen_futures::spawn_local(async move {
+                match store.put_incident(id, incident_version, edit).await {
+                    Ok(view) => apply_saved(view),
+                    Err(e) => store.set_error(e),
+                }
+                saving.set(false);
             });
-            updates.set(next);
         })
     };
 
-    let on_save = {
-        let token = props.token.clone();
-        let id = current.id.to_string();
-        let version = current.version;
-        let title = title.clone();
-        let updates = updates.clone();
-        let loaded = loaded.clone();
+    let on_add_update = {
+        let id = current.id().to_string();
+        let new_impact = new_impact.clone();
+        let new_message = new_message.clone();
         let saving = saving.clone();
-        let editing = editing.clone();
         let store = store.clone();
+        let apply_saved = apply_saved.clone();
         Callback::from(move |_| {
-            let edit = IncidentEdit {
-                title: (*title).trim().to_string(),
-                updates: (*updates).clone(),
-            };
-            let _ = &token;
-            let id = id.clone();
-            let loaded = loaded.clone();
-            let title = title.clone();
-            let updates = updates.clone();
-            let saving = saving.clone();
-            let editing = editing.clone();
-            let store = store.clone();
+            let message = (*new_message).trim().to_string();
+            if message.is_empty() {
+                store.set_error(grey_api::ApiError::new("An update message is required."));
+                return;
+            }
+            let input = CreateUpdate { impact: new_impact.parse().unwrap_or_default(), message };
+            let (id, new_message, saving, store, apply_saved) =
+                (id.clone(), new_message.clone(), saving.clone(), store.clone(), apply_saved.clone());
             saving.set(true);
             wasm_bindgen_futures::spawn_local(async move {
-                let result = store.save_incident(id, version, edit).await;
-                saving.set(false);
-                match result {
-                    Ok(incident) => {
-                        title.set(incident.title.clone());
-                        updates.set(incident.sorted_updates().into_iter().cloned().collect());
-                        loaded.set(Some(incident));
-                        editing.set(None);
-                    }
+                match store.create_update(id, input).await {
+                    Ok(view) => { apply_saved(view); new_message.set(String::new()); }
                     Err(e) => store.set_error(e),
                 }
+                saving.set(false);
+            });
+        })
+    };
+
+    let on_save_update = |uid: IncidentUpdateId, version: u64| {
+        let message_draft = message_draft.clone();
+        let editing = editing.clone();
+        let saving = saving.clone();
+        let store = store.clone();
+        let apply_saved = apply_saved.clone();
+        Callback::from(move |_| {
+            let edit = PutUpdate { message: (*message_draft).clone() };
+            let (editing, saving, store, apply_saved) =
+                (editing.clone(), saving.clone(), store.clone(), apply_saved.clone());
+            saving.set(true);
+            wasm_bindgen_futures::spawn_local(async move {
+                match store.put_update(uid, version, edit).await {
+                    Ok(view) => { apply_saved(view); editing.set(None); }
+                    Err(e) => store.set_error(e),
+                }
+                saving.set(false);
+            });
+        })
+    };
+
+    let on_remove_update = |uid: IncidentUpdateId, version: u64| {
+        let saving = saving.clone();
+        let store = store.clone();
+        Callback::from(move |_| {
+            let (saving, store) = (saving.clone(), store.clone());
+            saving.set(true);
+            wasm_bindgen_futures::spawn_local(async move {
+                if let Err(e) = store.delete_update(uid, version).await {
+                    store.set_error(e);
+                }
+                saving.set(false);
             });
         })
     };
 
     let on_delete = {
-        let token = props.token.clone();
-        let id_value = current.id;
+        let id_value = current.id();
         let navigator = navigator.clone();
         let store = store.clone();
         Callback::from(move |_| {
-            let _ = &token;
-            let navigator = navigator.clone();
-            let store = store.clone();
+            let (navigator, store) = (navigator.clone(), store.clone());
             wasm_bindgen_futures::spawn_local(async move {
-                match store.delete_incident(id_value).await {
+                match store.delete_incident(id_value, incident_version).await {
                     Ok(()) => {
-                        // The store has already dropped it from the shared list; leave the page.
                         if let Some(nav) = navigator {
                             nav.push(&Route::Incidents);
                         }
@@ -226,6 +229,31 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
     };
 
     let status_class = impact_class(current.current_impact());
+    // Newest update first in the editor.
+    let mut updates = current.updates.clone();
+    updates.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+
+    let on_new_impact = {
+        let new_impact = new_impact.clone();
+        Callback::from(move |e: Event| {
+            let el: HtmlSelectElement = e.target_unchecked_into();
+            new_impact.set(el.value());
+        })
+    };
+    let on_new_message = {
+        let new_message = new_message.clone();
+        Callback::from(move |e: InputEvent| {
+            let el: HtmlTextAreaElement = e.target_unchecked_into();
+            new_message.set(el.value());
+        })
+    };
+    let on_draft_message = {
+        let message_draft = message_draft.clone();
+        Callback::from(move |e: InputEvent| {
+            let el: HtmlTextAreaElement = e.target_unchecked_into();
+            message_draft.set(el.value());
+        })
+    };
 
     html! {
         <div class="page incident-edit">
@@ -238,14 +266,14 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                             value={(*title).clone()}
                             oninput={on_title}
                         />
-                        <span class="incident-id">{format!("#{}", current.id)}</span>
+                        <span class="incident-id">{format!("#{}", current.id())}</span>
                     </div>
-                    if dirty {
+                    if title_dirty {
                         <button
                             class={classes!("incident-edit__save-icon", (*saving).then_some("saving"))}
-                            title="Save changes"
+                            title="Save title"
                             disabled={*saving}
-                            onclick={on_save}
+                            onclick={on_save_title}
                         >
                             { save_icon() }
                         </button>
@@ -253,13 +281,38 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                 </div>
 
                 <ul class="incident-timeline incident-timeline--editing">
-                    { for (*updates).iter().enumerate().rev().map(|(i, update)| {
+                    <li class="incident-timeline__item incident-timeline__item--new">
+                        <div class="incident-timeline__rail">
+                            <span class={classes!("incident-timeline__circle", impact_class(new_impact.parse().unwrap_or_default()))}></span>
+                            <span class={classes!("incident-timeline__tail", impact_class(new_impact.parse().unwrap_or_default()))}></span>
+                        </div>
+                        <div class="incident-timeline__body">
+                            <div class="incident-timeline__time">
+                                <select onchange={on_new_impact}>
+                                    { for [Impact::Offline, Impact::Degraded, Impact::None, Impact::Hidden].into_iter().map(|opt| html! {
+                                        <option value={opt.as_str()} selected={opt.as_str() == *new_impact}>{opt.label()}</option>
+                                    }) }
+                                </select>
+
+                                <button type="button" class="incident-edit__icon-button" disabled={*saving} onclick={on_add_update}>{check_icon()}</button>
+                            </div>
+                            <div class={classes!("incident-timeline__card", status_class)}>
+                                <textarea
+                                    class="incident-timeline__message-input"
+                                    rows="3"
+                                    value={(*new_message).clone()}
+                                    oninput={on_new_message}
+                                    placeholder="Enter your next incident update in markdown form..."
+                                />
+                            </div>
+                        </div>
+                    </li>
+
+                    { for updates.iter().map(|update| {
                         let class = impact_class(update.impact);
-                        // An update is "posted" once it is part of the loaded incident: its impact then
-                        // becomes fixed and only its message stays editable. New (unsaved) updates keep
-                        // full control so the impact can still be chosen before the first save.
-                        let posted = current.updates.iter().any(|u| u.timestamp == update.timestamp);
-                        let is_editing = *editing == Some(i);
+                        let uid = update.id;
+                        let version = update.version;
+                        let is_editing = *editing == Some(uid);
                         html! {
                             <li class="incident-timeline__item">
                                 <div class="incident-timeline__rail">
@@ -267,51 +320,34 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                                     <span class={classes!("incident-timeline__tail", class)}></span>
                                 </div>
                                 <div class="incident-timeline__body">
-                                    if posted {
-                                        <div class="incident-timeline__time">{update.timestamp.format("%Y-%m-%d %H:%M UTC").to_string()}</div>
-                                        <div class={classes!("incident-timeline__card", class)}>
-                                            <div class="incident-timeline__card-head">
-                                                <span class={classes!("incident-status-pill", class)}>{update.impact.label()}</span>
-                                                if is_editing {
-                                                    <button type="button" class="incident-edit__icon-button" title="Done editing"
-                                                        onclick={ let editing = editing.clone(); Callback::from(move |_| editing.set(None)) }>
-                                                        { check_icon() }
-                                                    </button>
-                                                } else {
-                                                    <button type="button" class="incident-edit__icon-button" title="Edit message"
-                                                        onclick={ let editing = editing.clone(); Callback::from(move |_| editing.set(Some(i))) }>
-                                                        { edit_icon() }
-                                                    </button>
-                                                }
-                                            </div>
-                                            if is_editing {
-                                                <textarea
-                                                    class="incident-timeline__message-input"
-                                                    rows="3"
-                                                    value={update.message.clone()}
-                                                    oninput={on_update_message(i)}
-                                                />
-                                            } else {
-                                                <div class="incident-timeline__card-message markdown">{ render_markdown(&update.message) }</div>
-                                            }
-                                        </div>
-                                    } else {
-                                        <div class="incident-timeline__edit-row">
-                                            <select onchange={on_update_impact(i)}>
-                                                { for [Impact::Offline, Impact::Degraded, Impact::None, Impact::Hidden].into_iter().map(|opt| html! {
-                                                    <option value={opt.as_str()} selected={opt == update.impact}>{opt.label()}</option>
-                                                }) }
-                                            </select>
-                                            <span class="incident-timeline__time">{update.timestamp.format("%Y-%m-%d %H:%M UTC").to_string()}</span>
-                                            <button type="button" class="link-button danger" onclick={on_remove_update(i)}>{"Remove"}</button>
-                                        </div>
-                                        <textarea
-                                            class="incident-timeline__message-input"
-                                            rows="3"
-                                            value={update.message.clone()}
-                                            oninput={on_update_message(i)}
-                                        />
-                                    }
+                                    <div class="incident-timeline__time">
+                                        <span class={classes!("incident-status-pill", class)}>{update.impact.label()}</span>
+                                        <time datetime={update.timestamp.to_rfc3339()}>{time_format(update.timestamp)}</time>
+                                        if is_editing {
+                                            <button type="button" class="incident-edit__icon-button" title="Save message"
+                                                disabled={*saving} onclick={on_save_update(uid, version)}>
+                                                { check_icon() }
+                                            </button>
+                                        } else {
+                                            <button type="button" class="incident-edit__icon-button" title="Edit message"
+                                                onclick={ let editing = editing.clone(); let message_draft = message_draft.clone(); let msg = update.message.clone(); Callback::from(move |_| { message_draft.set(msg.clone()); editing.set(Some(uid)); }) }>
+                                                { edit_icon() }
+                                            </button>
+                                            <button type="button" class="incident-edit__icon-button danger" title="Remove update" disabled={*saving} onclick={on_remove_update(uid, version)}>{ trash_icon() }</button>
+                                        }
+                                    </div>
+                                    <div class={classes!("incident-timeline__card", class)}>
+                                        if is_editing {
+                                            <textarea
+                                                class="incident-timeline__message-input"
+                                                rows="3"
+                                                value={(*message_draft).clone()}
+                                                oninput={on_draft_message.clone()}
+                                            />
+                                        } else {
+                                            <div class="incident-timeline__card-message markdown">{ render_markdown(&update.message) }</div>
+                                        }
+                                    </div>
                                 </div>
                             </li>
                         }
@@ -319,8 +355,7 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                 </ul>
 
                 <div class="incident-admin-controls">
-                    <button type="button" onclick={on_add_update}>{"Add update"}</button>
-                    <button type="button" class="danger" onclick={on_delete}>{"Delete incident"}</button>
+                    <button type="button" class="danger" disabled={*saving} onclick={on_delete}>{"Delete incident"}</button>
                 </div>
 
                 <p class="incident-edit__hint">

--- a/ui/src/views/incidents_list.rs
+++ b/ui/src/views/incidents_list.rs
@@ -1,4 +1,4 @@
-use grey_api::Incident;
+use grey_api::IncidentView;
 use yew::prelude::*;
 use yew_router::prelude::*;
 
@@ -30,7 +30,7 @@ pub fn incidents_list() -> Html {
     }
 }
 
-fn incident_list_body(incidents: &[Incident]) -> Html {
+fn incident_list_body(incidents: &[IncidentView]) -> Html {
     if incidents.is_empty() {
         return html! {
             <crate::components::EmptyState title="No incidents reported">
@@ -40,7 +40,7 @@ fn incident_list_body(incidents: &[Incident]) -> Html {
     }
     html! {
         { for incidents.iter().map(|incident| html! {
-            <IncidentBlock key={incident.id.to_string()} incident={incident.clone()} />
+            <IncidentBlock key={incident.id().to_string()} incident={incident.clone()} />
         }) }
     }
 }

--- a/ui/src/views/new_incident.rs
+++ b/ui/src/views/new_incident.rs
@@ -99,7 +99,7 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
                 match store.create_incident(input).await {
                     Ok(created) => {
                         if let Some(nav) = navigator {
-                            nav.push(&Route::Incident { id: created.id.to_string() });
+                            nav.push(&Route::Incident { id: created.id().to_string() });
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
## Overview

Builds on the `feat/cron` branch to make **incidents replicate across the cluster** (and, via the same generalisation, converts crons to the same model). Stacked on `feat/cron` — the base is set to `feat/cron` so this diff is just the incident-replication commit; GitHub will retarget to `main` once cron merges.

## What changed & why

Introduces a **`GlobalLwwEntity`** gossip family so incidents and crons converge cluster-wide as *single global records* — one row per entity id, whole-entity **last-writer-wins** resolved by the total order `(version, last_writer)` — riding the same scuttlebutt path as probes. Probes stay on their existing per-observer `(node_id, name)` path (the two families are genuinely different; merging them was rejected after two design passes).

- **Incidents are now two gossiped entities** — `Incident` (header) + standalone `IncidentUpdate` — with **snowflake ids** (`Identifier` u64, `IncidentUpdateId` u128 = `incident_id<<64 | snowflake`, giving a contiguous key range per incident). Splitting updates out is what makes whole-entity LWW correct: concurrent edits to *different* updates never conflict. `version` = last-modified wall-clock millis (gossip clock + GC age + HTTP ETag); `deleted` = propagating tombstone, filtered from reads and reaped by GC.
- **Gossip mechanics:** the partition is the entity's `last_writer` (kept in the redb value, not the key) — advertising under self would re-introduce digest masking. Generic read-path helpers (`digest_lww`/`emit_lww_table_diffs`); concrete per-variant write path sharing `lww_supersedes`. The `(version, last_writer)` tiebreaker is mandatory so equal-millisecond writes from two nodes converge instead of split-braining.
- **API:** paginated public `GET /api/v1/incidents?limit=&cursor=` returning `IncidentView` with embedded updates (no N+1); per-entity admin endpoints with If-Match CAS (**PUT/replace only, no PATCH**) for incident title/delete and update create/edit/delete.
- **UI:** migrated `Incident` → `IncidentView`; the editor now performs per-entity operations instead of one batched whole-incident PUT.

## ⚠️ Reviewer note — cron behaviour change

Adopting this model **converts crons from the runs-union CRDT to whole-record LWW** (the trait can't quiesce a multi-contributor CRDT under the per-node digest). Run history is now **best-effort**: preserved when a cron checks in on one node, but a run can be lost if the *same* cron checks in on two nodes before gossip converges. This was an explicit trade-off (low write volume, typically one node per cron).

## Other notes

- **No migration:** legacy v1.10.0 incident table + per-node cron table are abandoned (new table names; state refills from check-ins / re-creation).
- **Known gap:** the public `/incidents/{id}` page only resolves incidents in the store's first page (no public get-by-id endpoint) — older public incidents'\'' detail pages won'\''t load. A small public get-by-id would close this.

## Testing

`grey-api` 44 tests, `grey` 140 tests (incl. LWW tiebreaker, GC tombstone reaping, and a full digest→diff→apply round-trip with transitive relay), `trunk build` (wasm) + `cargo build -p grey` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)