### PR TITLE
ci: replace actions-rs/cargo with cargo shell commands

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -106,26 +106,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Run Tests for Grey
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast -p grey
+        run: cargo test --no-fail-fast -p grey
         env:
             RUSTFLAGS: -Cinstrument-coverage
 
       - name: Run Tests for Grey UI
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast -p grey-ui
+        run: cargo test --no-fail-fast -p grey-ui
         env:
           RUSTFLAGS: -Cinstrument-coverage
 
       - name: Run Tests for Grey API
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-fail-fast -p grey-api
+        run: cargo test --no-fail-fast -p grey-api
         env:
           RUSTFLAGS: -Cinstrument-coverage
 
@@ -216,12 +207,12 @@ jobs:
           # usable cache restored, forcing a full rebuild on every run.
           key: ${{ matrix.target }}
 
+      - name: Install cross
+        if: ${{ matrix.cross }}
+        run: cargo install cross --locked
+
       - name: cargo build
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          use-cross: ${{ matrix.cross }}
-          command: build
-          args: --release --target ${{ matrix.target }} ${{ matrix.flags }}
+        run: ${{ matrix.cross && 'cross' || 'cargo' }} build --release --target ${{ matrix.target }} ${{ matrix.flags }}
 
       # cross runs the compiler inside a Docker container as root, so the
       # registry downloads and build artifacts it writes into the cached


### PR DESCRIPTION
## Summary

Switches the Rust workflow away from the unmaintained `actions-rs/cargo` action and invokes `cargo` directly via shell `run:` steps instead.

## Changes

- **Test steps** (`grey`, `grey-ui`, `grey-api`): replaced `actions-rs/cargo@v1` with `run: cargo test ...`. The `RUSTFLAGS` env is preserved.
- **Build step**: replaced `actions-rs/cargo@v1.0.3` (which used `use-cross`) with a direct `run:` invocation. Since `use-cross` is no longer available, `cross` is now installed explicitly (`cargo install cross --locked`) only for matrix entries with `cross: true`, and the build command selects between `cross` and `cargo` based on `matrix.cross`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFpENeSwj7FcdpWnjV4d4e)_