### PR TITLE
Recolour cron states: running light-blue, overdue/slow orange

### DIFF
--- a/ui/src/components/_cron.scss
+++ b/ui/src/components/_cron.scss
@@ -44,6 +44,7 @@
     &.ok { border-color: $color-status-ok; color: $color-status-ok; }
     &.warn { border-color: $color-status-warn; color: $color-status-warn; }
     &.error { border-color: $color-status-error; color: $color-status-error; }
+    &.running { border-color: $color-status-running; color: $color-status-running; }
     &.unknown { border-color: $color-status-unknown; color: $color-status-unknown; }
 }
 
@@ -107,6 +108,7 @@
     &.ok { background-color: $color-status-ok; }
     &.warn { background-color: $color-status-warn; }
     &.error { background-color: $color-status-error; }
+    &.running { background-color: $color-status-running; }
 }
 
 .cron__no-runs {

--- a/ui/src/components/_status_dot.scss
+++ b/ui/src/components/_status_dot.scss
@@ -1,8 +1,8 @@
 @use '../styles/variables' as *;
 
 // The canonical status dot used across the UI (probe headers, popovers, tooltips, inline status
-// hints). Colour comes from a modifier class (`ok`/`warn`/`error`/`unknown`/`draft`); the diameter
-// is set inline by the `StatusDot` component, and `.active` enables the pulse animation.
+// hints). Colour comes from a modifier class (`ok`/`warn`/`error`/`running`/`unknown`/`draft`); the
+// diameter is set inline by the `StatusDot` component, and `.active` enables the pulse animation.
 .status-dot {
     width: 8px;
     height: 8px;
@@ -25,6 +25,10 @@
 
     &.error {
         background-color: $color-status-error;
+    }
+
+    &.running {
+        background-color: $color-status-running;
     }
 
     &.unknown {

--- a/ui/src/components/popover.rs
+++ b/ui/src/components/popover.rs
@@ -34,7 +34,7 @@ pub struct PopoverProps {
     /// How the popover anchors over its trigger.
     #[prop_or_default]
     pub align: PopoverAlign,
-    /// Colour class for the status dot (`ok`/`warn`/`error`/`unknown`/`draft`).
+    /// Colour class for the status dot (`ok`/`warn`/`error`/`running`/`unknown`/`draft`).
     pub status_class: AttrValue,
     /// The short status label shown next to the dot.
     pub status: AttrValue,

--- a/ui/src/components/status_dot.rs
+++ b/ui/src/components/status_dot.rs
@@ -1,7 +1,8 @@
 use yew::prelude::*;
 
 /// A small, coloured status dot used across the UI. The `class` is the colour modifier (`ok`,
-/// `warn`, `error`, `unknown`, or `draft`), matching the status colour classes used elsewhere.
+/// `warn`, `error`, `running`, `unknown`, or `draft`), matching the status colour classes used
+/// elsewhere.
 /// `active` toggles the pulse animation, and `size` controls the diameter in pixels.
 #[derive(Properties, PartialEq)]
 pub struct StatusDotProps {

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -14,6 +14,7 @@
     --color-status-ok: #28a745;
     --color-status-warn: #e67e22;
     --color-status-error: #e74c3c;
+    --color-status-running: #5dade2;
     --color-status-unknown: #3498db;
     --color-status-offline: #95a5a6;
 
@@ -35,6 +36,7 @@ $color-status-text: var(--color-status-text);
 $color-status-ok: var(--color-status-ok);
 $color-status-warn: var(--color-status-warn);
 $color-status-error: var(--color-status-error);
+$color-status-running: var(--color-status-running);
 $color-status-unknown: var(--color-status-unknown);
 $color-status-offline: var(--color-status-offline);
 

--- a/ui/src/styles/cron.rs
+++ b/ui/src/styles/cron.rs
@@ -1,21 +1,24 @@
 use grey_api::{CronHealth, CronStatus};
 
-/// The colour class for a cron's derived health: passing states are `ok`, an overrunning run is the
-/// intermediate `warn`, a missed or failed run is `error`, and a never-seen cron is `unknown`.
+/// The colour class for a cron's derived health: a healthy run is `ok` (green), an in-flight run is
+/// `running` (light-blue), an overdue or overrunning run is `warn` (orange), a failed run is `error`
+/// (red), and a never-seen cron is `unknown`.
 pub fn cron_class(health: CronHealth) -> &'static str {
     match health {
-        CronHealth::Succeeded | CronHealth::Running => "ok",
-        CronHealth::Stuck => "warn",
-        CronHealth::Failed | CronHealth::Missing => "error",
+        CronHealth::Succeeded => "ok",
+        CronHealth::Running => "running",
+        CronHealth::Missing | CronHealth::Stuck => "warn",
+        CronHealth::Failed => "error",
         CronHealth::Pending => "unknown",
     }
 }
 
-/// The colour class for a single run cell in the recent-runs strip.
+/// The colour class for a single run cell in the recent-runs strip: a successful run is `ok` (green),
+/// an in-flight run is `running` (light-blue), and a failed run is `error` (red).
 pub fn cron_run_class(status: CronStatus) -> &'static str {
     match status {
         CronStatus::Succeeded => "ok",
-        CronStatus::Running => "warn",
+        CronStatus::Running => "running",
         CronStatus::Failed => "error",
     }
 }
@@ -27,14 +30,14 @@ mod tests {
     #[test]
     fn classes_map_every_variant() {
         assert_eq!(cron_class(CronHealth::Succeeded), "ok");
-        assert_eq!(cron_class(CronHealth::Running), "ok");
+        assert_eq!(cron_class(CronHealth::Running), "running");
         assert_eq!(cron_class(CronHealth::Stuck), "warn");
         assert_eq!(cron_class(CronHealth::Failed), "error");
-        assert_eq!(cron_class(CronHealth::Missing), "error");
+        assert_eq!(cron_class(CronHealth::Missing), "warn");
         assert_eq!(cron_class(CronHealth::Pending), "unknown");
 
         assert_eq!(cron_run_class(CronStatus::Succeeded), "ok");
-        assert_eq!(cron_run_class(CronStatus::Running), "warn");
+        assert_eq!(cron_run_class(CronStatus::Running), "running");
         assert_eq!(cron_run_class(CronStatus::Failed), "error");
     }
 }


### PR DESCRIPTION
## Summary

Adjusts the colours used to represent cron job state on the UI so each state reads more intuitively:

- **Running** → a new light-blue (`#5dade2`), instead of being folded into the green "healthy" treatment (and the orange used on the run-cell strip).
- **Overdue / slow** → orange. A missed run (`Missing`) now uses the same orange as an overrunning run (`Stuck`), so a late job no longer reads as a hard red failure.
- **Failed** → red (unchanged).
- **Succeeded** → green (unchanged).

## Changes

- Added a `--color-status-running` palette entry (with the matching SCSS variable) in `_variables.scss`.
- Added a `running` modifier to the status dot, cron badge, and cron run-cell styles so the new class renders the light-blue.
- Updated `cron_class` / `cron_run_class`:
  - `CronHealth::Running` → `running`, `CronHealth::Missing` → `warn` (was `error`), `CronHealth::Stuck` stays `warn`.
  - `CronStatus::Running` → `running` (was `warn`).
- Updated the unit test and the related doc comments.

These changes are display-only — detection logic and the `passing()` semantics are untouched (a missed run still reads as not passing; only its colour changes).

## Testing

- `cargo test -p grey-ui` — all 20 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NicScLKwZB3LDHB7tk36nJ)_