### PR TITLE
ci: restore cache before fetching versioned Cargo.toml

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -186,6 +186,21 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
 
+      # Set up the cache before fetching the versioned Cargo.toml.
+      # Swatinem/rust-cache derives its cache key from the contents of
+      # Cargo.toml/Cargo.lock, so restoring the version-bumped Cargo.toml first
+      # would change the key on release builds and prevent any cache from being
+      # restored, forcing a full rebuild every time.
+      - name: Setup Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Give each matrix entry its own cache scope. Without this, every
+          # entry in the matrix shares the same automatic cache key (derived
+          # from the job name + Cargo.lock), so the jobs clobber one another's
+          # caches and targets like aarch64 (built via cross) never get a
+          # usable cache restored, forcing a full rebuild on every run.
+          key: ${{ matrix.target }}
+
       - name: Fetch Versioned Cargo.toml
         uses: actions/download-artifact@v8
         with:
@@ -196,16 +211,6 @@ jobs:
         with:
           name: ui-build
           path: ./ui/dist
-
-      - name: Setup Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Give each matrix entry its own cache scope. Without this, every
-          # entry in the matrix shares the same automatic cache key (derived
-          # from the job name + Cargo.lock), so the jobs clobber one another's
-          # caches and targets like aarch64 (built via cross) never get a
-          # usable cache restored, forcing a full rebuild on every run.
-          key: ${{ matrix.target }}
 
       - name: Install cross
         if: ${{ matrix.cross }}


### PR DESCRIPTION
## Problem

On release builds the `build-app` job never restores a Rust build cache, so every release does a full rebuild for all targets.

The cause is step ordering. The job currently runs:

1. Check out code
2. **Fetch Versioned Cargo.toml** — downloads the artifact created by the `version` job, overwriting `Cargo.toml` with the version-bumped one (e.g. `version = "1.2.3"`)
3. Fetch UI build artifacts
4. **Setup Cache** (`Swatinem/rust-cache@v2`)

`Swatinem/rust-cache` derives its cache key from the contents of `Cargo.toml`/`Cargo.lock`. Because the version-bumped `Cargo.toml` is restored *before* the cache step, the computed cache key differs from the one stored by normal (non-release) builds, which use the `0.0.0-dev` version. As a result the cache lookup misses and no cache is restored.

## Fix

Move the `Setup Cache` step ahead of the `Fetch Versioned Cargo.toml` step so the cache key is computed against the canonical (unbumped) `Cargo.toml`, matching the key used by every other build. The versioned `Cargo.toml` is still fetched before `cargo build`, so the release artifacts keep the correct version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QKavbCC6KYahZF9DdMkLQw)_