### PR TITLE
Add `visible` filter for probe and cron visibility control

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ immediately rather than at run time, and each is reported as its own pass/fail r
 the dashboard and in telemetry. See the [Checks guide](https://grey.sierrasoftworks.com/checks/)
 for the full expression language.
 
+A probe (or cron) can also carry a `visible` filter — the same `filt-rs` language — to control who
+sees it on the status page and in the API. It is evaluated against the viewer's auth context (`auth`,
+`auth.admin`, and `claims.<name>`), defaults to `true` (everyone), and an entry a viewer may not see is
+never sent to their browser. For example `visible: auth.admin` restricts an entry to signed-in
+administrators. See the [configuration guide](https://grey.sierrasoftworks.com/guide/configuration.html#visibility).
+
 ## Cron monitoring
 Some work can't be probed from the outside — backups, batch jobs, and scheduled tasks only
 tell you they're healthy by *running*. Grey's cron monitors are a passive "deadman's

--- a/agent/src/api/auth.rs
+++ b/agent/src/api/auth.rs
@@ -5,10 +5,10 @@ use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use actix_web::{
-    HttpMessage, HttpResponse,
+    HttpMessage, HttpRequest, HttpResponse,
     body::BoxBody,
     dev::{ServiceRequest, ServiceResponse},
-    http::{StatusCode, header::AUTHORIZATION},
+    http::{StatusCode, header::AUTHORIZATION, header::HeaderMap},
     middleware::Next,
     web,
 };
@@ -332,6 +332,141 @@ fn json_to_filter_value(value: &Value) -> FilterValue<'_> {
     }
 }
 
+/// Extracts a bearer token from an `Authorization` header, accepting either capitalisation of the
+/// `Bearer` scheme. Shared by the admin middleware and the public-endpoint [`resolve_auth_context`].
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| {
+            value
+                .strip_prefix("Bearer ")
+                .or_else(|| value.strip_prefix("bearer "))
+        })
+        .map(|token| token.trim().to_string())
+}
+
+/// A request's resolved authentication context, used to decide which probes and crons a viewer may
+/// see via their `visible` filter.
+///
+/// Unlike [`require_admin`] (which rejects an unauthorised request outright), this is computed for the
+/// *public* read endpoints, so an anonymous request — or one carrying an invalid/expired token —
+/// simply resolves to "not authenticated, not admin" and sees only the entities visible to everyone.
+#[derive(Clone, Default)]
+pub struct AuthContext {
+    /// Whether a valid OIDC bearer token accompanied the request.
+    pub authenticated: bool,
+    /// Whether the validated identity also satisfied the configured admin ACL.
+    pub admin: bool,
+    /// The validated token claims (empty when unauthenticated), exposed to a `visible` filter under
+    /// the `claims.` prefix for parity with the admin ACL.
+    pub claims: Map<String, Value>,
+}
+
+impl AuthContext {
+    /// Whether a viewer with this context may see an entity guarded by `visible`. A filter that fails
+    /// to evaluate is treated as *not* visible (fail-closed), matching the deny-by-default posture of
+    /// the admin ACL: a malformed visibility rule hides the entity rather than leaking it.
+    pub fn can_see(&self, visible: &filt_rs::Filter) -> bool {
+        visible.matches(&VisibilityFilter(self)).unwrap_or(false)
+    }
+}
+
+/// Exposes a request's resolved [`AuthContext`] to a probe/cron `visible` filter. The addressable
+/// fields are `auth` (a boolean: any valid token was presented), `auth.admin` (a boolean: the admin
+/// ACL passed), and `claims.<name>` (a validated token claim). Unknown keys resolve to null, matching
+/// `filt-rs`'s own convention — so `visible: auth.admin` restricts an entity to administrators while
+/// the default `visible: true` shows it to everyone.
+struct VisibilityFilter<'a>(&'a AuthContext);
+
+impl Filterable for VisibilityFilter<'_> {
+    fn get(&self, key: &str) -> FilterValue<'_> {
+        match key {
+            "auth" => FilterValue::Bool(self.0.authenticated),
+            "auth.admin" => FilterValue::Bool(self.0.admin),
+            k if k.starts_with("claims.") => self
+                .0
+                .claims
+                .get(&k["claims.".len()..])
+                .map(json_to_filter_value)
+                .unwrap_or(FilterValue::Null),
+            _ => FilterValue::Null,
+        }
+    }
+}
+
+/// Resolves the [`AuthContext`] for a request to a public read endpoint. The context is anonymous
+/// when admin auth is not configured, or when no/invalid bearer token is presented. A valid token
+/// populates the claims and marks the request authenticated; the configured admin ACL is then
+/// evaluated (against the same `method`/`path`/`claims` fields [`require_admin`] uses) to decide
+/// whether the viewer also counts as an administrator.
+pub async fn resolve_auth_context(req: &HttpRequest, data: &AppState) -> AuthContext {
+    let config = data.state.get_config();
+    let Some(admin) = config.ui.admin.as_ref() else {
+        return AuthContext::default();
+    };
+
+    let Some(token) = bearer_token(req.headers()) else {
+        return AuthContext::default();
+    };
+
+    // An invalid or expired token on a public endpoint is treated as anonymous rather than an error:
+    // the viewer still sees everything visible to the public, exactly as if they had presented none.
+    let Ok(claims) = data.oidc.validate(&admin.oidc, &token).await else {
+        return AuthContext::default();
+    };
+
+    let is_admin = admin
+        .acl
+        .matches(&AdminRequestFilter {
+            method: req.method().as_str(),
+            path: req.path(),
+            claims: &claims,
+        })
+        .unwrap_or(false);
+
+    AuthContext {
+        authenticated: true,
+        admin: is_admin,
+        claims,
+    }
+}
+
+/// Drops the probes the given viewer may not see, honouring each probe's configured `visible` filter.
+/// A pooled probe with no local configuration entry (e.g. a gossiped record for a probe this node no
+/// longer configures) has no `visible` rule and stays visible, preserving the pre-visibility default.
+pub fn retain_visible_probes(
+    config: &crate::config::Config,
+    ctx: &AuthContext,
+    probes: &mut Vec<grey_api::Probe>,
+) {
+    probes.retain(|probe| {
+        config
+            .probes
+            .iter()
+            .find(|cfg| cfg.name == probe.name)
+            .map(|cfg| ctx.can_see(&cfg.visible))
+            .unwrap_or(true)
+    });
+}
+
+/// Drops the crons the given viewer may not see, honouring each cron's configured `visible` filter.
+/// As with [`retain_visible_probes`], a pooled cron with no local configuration entry stays visible.
+pub fn retain_visible_crons(
+    config: &crate::config::Config,
+    ctx: &AuthContext,
+    crons: &mut Vec<grey_api::Cron>,
+) {
+    crons.retain(|cron| {
+        config
+            .crons
+            .iter()
+            .find(|cfg| cfg.name == cron.name)
+            .map(|cfg| ctx.can_see(&cfg.visible))
+            .unwrap_or(true)
+    });
+}
+
 fn json_error(status: StatusCode, error: ApiError) -> HttpResponse {
     // Stamp the HTTP status onto the body so clients can classify the failure from the error object
     // alone (the SPA branches on this code without re-reading the transport status). `ApiError`'s
@@ -362,18 +497,7 @@ pub async fn require_admin(
         )));
     };
 
-    let token = req
-        .headers()
-        .get(AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .and_then(|value| {
-            value
-                .strip_prefix("Bearer ")
-                .or_else(|| value.strip_prefix("bearer "))
-        })
-        .map(|token| token.trim().to_string());
-
-    let Some(token) = token else {
+    let Some(token) = bearer_token(req.headers()) else {
         return Ok(req.into_response(json_error(
             StatusCode::UNAUTHORIZED,
             ApiError::new("Authentication is required to access this resource.")
@@ -572,6 +696,89 @@ mod tests {
             acl.matches(&AdminRequestFilter { method: "GET", path: "/", claims: &claims })
                 .unwrap()
         );
+    }
+
+    /// The `visible` filter sees `auth` (any valid session) and `auth.admin` (the admin ACL passed)
+    /// as booleans, and the default `true` filter is visible to everyone.
+    #[test]
+    fn visibility_filter_exposes_auth_and_admin_flags() {
+        let public = filt_rs::Filter::new("true").unwrap();
+        let any_auth = filt_rs::Filter::new("auth").unwrap();
+        let admin_only = filt_rs::Filter::new("auth.admin").unwrap();
+
+        let anonymous = AuthContext::default();
+        let signed_in = AuthContext { authenticated: true, admin: false, claims: Map::new() };
+        let admin = AuthContext { authenticated: true, admin: true, claims: Map::new() };
+
+        // The default filter shows the entity to everyone.
+        assert!(anonymous.can_see(&public));
+        assert!(signed_in.can_see(&public));
+        assert!(admin.can_see(&public));
+
+        // `auth` gates on any valid session.
+        assert!(!anonymous.can_see(&any_auth));
+        assert!(signed_in.can_see(&any_auth));
+        assert!(admin.can_see(&any_auth));
+
+        // `auth.admin` gates on passing the admin ACL.
+        assert!(!anonymous.can_see(&admin_only));
+        assert!(!signed_in.can_see(&admin_only));
+        assert!(admin.can_see(&admin_only));
+    }
+
+    /// For parity with the admin ACL, a `visible` filter can also match on token `claims.*`; an
+    /// anonymous viewer carries no claims, so a claims-based filter excludes them.
+    #[test]
+    fn visibility_filter_exposes_claims() {
+        let in_group = filt_rs::Filter::new(r#"claims.groups contains "ops""#).unwrap();
+
+        assert!(!AuthContext::default().can_see(&in_group), "an anonymous viewer has no claims");
+
+        let mut claims = Map::new();
+        claims.insert(
+            "groups".into(),
+            Value::Array(vec![Value::String("ops".into()), Value::String("dev".into())]),
+        );
+        let ctx = AuthContext { authenticated: true, admin: false, claims };
+        assert!(ctx.can_see(&in_group));
+    }
+
+    /// The retain helper drops entities the viewer may not see, keeps unrestricted ones, and leaves
+    /// pooled records with no local configuration entry (orphans) visible.
+    #[tokio::test]
+    async fn retain_visible_probes_honours_context_and_orphans() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_yaml = format!(
+            "state: {}\nprobes:\n  - name: public.probe\n    policy: {{ interval: 60s, timeout: 5s }}\n    target: !Http\n      url: https://example.com\n  - name: admin.probe\n    policy: {{ interval: 60s, timeout: 5s }}\n    target: !Http\n      url: https://example.com\n    visible: auth.admin\n",
+            dir.path().join("s.redb").display().to_string().replace('\\', "/")
+        );
+        let path = dir.path().join("c.yml");
+        tokio::fs::write(&path, config_yaml).await.unwrap();
+        let config = crate::Config::load_from_path(&path).await.unwrap();
+
+        let api_probe = |name: &str| grey_api::Probe {
+            name: name.into(),
+            tags: std::collections::HashMap::new(),
+            last_updated: chrono::DateTime::UNIX_EPOCH,
+            history: Vec::new(),
+            observations: std::collections::HashMap::new(),
+            streak: grey_api::Streak::default(),
+        };
+
+        // Anonymous: only the public probe survives, but the orphan (no config entry) is kept.
+        let mut probes = vec![api_probe("public.probe"), api_probe("admin.probe"), api_probe("orphan.probe")];
+        retain_visible_probes(&config, &AuthContext::default(), &mut probes);
+        let mut names: Vec<&str> = probes.iter().map(|p| p.name.as_str()).collect();
+        names.sort();
+        assert_eq!(names, vec!["orphan.probe", "public.probe"]);
+
+        // An administrator sees the restricted probe too.
+        let admin = AuthContext { authenticated: true, admin: true, claims: Map::new() };
+        let mut probes = vec![api_probe("public.probe"), api_probe("admin.probe")];
+        retain_visible_probes(&config, &admin, &mut probes);
+        let mut names: Vec<&str> = probes.iter().map(|p| p.name.as_str()).collect();
+        names.sort();
+        assert_eq!(names, vec!["admin.probe", "public.probe"]);
     }
 
     #[test]

--- a/agent/src/api/cron.rs
+++ b/agent/src/api/cron.rs
@@ -116,10 +116,16 @@ async fn record(
     }
 }
 
-/// `GET /api/v1/crons` — every cron's current state, sorted by name. Public, mirroring `/probes`.
-pub async fn get_crons(data: web::Data<AppState>) -> Result<HttpResponse> {
+/// `GET /api/v1/crons` — the crons the requesting viewer may see, sorted by name. Public, mirroring
+/// `/probes`: a cron restricted with e.g. `visible: auth.admin` is returned only once a matching
+/// bearer token is presented.
+pub async fn get_crons(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpResponse> {
+    let ctx = super::auth::resolve_auth_context(&req, &data).await;
+    let config = data.state.get_config();
+
     let crons = data.state.get_cron_states().await?;
     let mut crons: Vec<Cron> = crons.into_values().collect();
+    super::auth::retain_visible_crons(&config, &ctx, &mut crons);
     crons.sort_by_key(|c| c.name.clone());
 
     Ok(HttpResponse::Ok().json(crons))
@@ -208,6 +214,31 @@ mod tests {
             .uri("/api/v1/cron/backup/check-in?status=bogus")
             .to_request();
         assert_eq!(test::call_service(&app, req).await.status(), StatusCode::BAD_REQUEST);
+    }
+
+    /// A cron restricted with `visible: auth.admin` is omitted from the public listing for an
+    /// anonymous viewer, while an unrestricted cron is returned.
+    #[actix_web::test]
+    async fn restricted_crons_are_hidden_from_anonymous_viewers() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = format!(
+            "ui:\n  enabled: true\n  listen: 127.0.0.1:0\ncrons:\n  - name: public.cron\n    interval: 60s\n  - name: secret.cron\n    interval: 60s\n    visible: auth.admin\nstate: {}\nprobes: []\n",
+            dir.path().join("state.redb").display().to_string().replace('\\', "/")
+        );
+        let config_path = dir.path().join("config.yml");
+        tokio::fs::write(&config_path, config).await.unwrap();
+        let state = AppState::new(State::new(&config_path).await.unwrap());
+        let app = test::init_service(
+            App::new().app_data(web::Data::new(state)).configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::get().uri("/api/v1/crons").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let crons: Vec<Cron> = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        let names: Vec<&str> = crons.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, vec!["public.cron"], "the admin-only cron must be hidden from anonymous viewers");
     }
 
     #[actix_web::test]

--- a/agent/src/api/page.rs
+++ b/agent/src/api/page.rs
@@ -6,10 +6,16 @@ use super::{ASSETS_DIR, AppState};
 use crate::state::{CronStore, IncidentStore, ProbeStore};
 
 pub async fn index(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpResponse> {
-    let probe_histories = data.state.get_probe_states().await?;
-
+    // Resolve the viewer's auth context so the server-rendered snapshot honours each entity's
+    // `visible` filter. A normal browser navigation carries no `Authorization` header, so this is
+    // anonymous in practice — admin-only probes/crons are therefore never embedded in the delivered
+    // HTML and instead appear after sign-in, when the SPA's authenticated polls fetch them.
+    let ctx = super::auth::resolve_auth_context(&req, &data).await;
     let config = data.state.get_config();
+
+    let probe_histories = data.state.get_probe_states().await?;
     let mut probes: Vec<grey_api::Probe> = probe_histories.into_values().collect();
+    super::auth::retain_visible_probes(&config, &ctx, &mut probes);
     probes.sort_by_key(|p| p.name.clone());
 
     let mut crons: Vec<grey_api::Cron> = data
@@ -19,6 +25,7 @@ pub async fn index(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpRe
         .unwrap_or_default()
         .into_values()
         .collect();
+    super::auth::retain_visible_crons(&config, &ctx, &mut crons);
     crons.sort_by_key(|c| c.name.clone());
 
     // Only the first page of publicly visible incidents is server-rendered for unauthenticated

--- a/agent/src/api/probes.rs
+++ b/agent/src/api/probes.rs
@@ -1,12 +1,20 @@
-use actix_web::{HttpResponse, Result, web};
+use actix_web::{HttpRequest, HttpResponse, Result, web};
 
 use super::AppState;
+use super::auth::{resolve_auth_context, retain_visible_probes};
 use crate::state::ProbeStore;
 
-/// `GET /api/v1/probes` — every probe's current state, sorted by name. Public.
-pub async fn get_probes(data: web::Data<AppState>) -> Result<HttpResponse> {
+/// `GET /api/v1/probes` — the probes the requesting viewer may see, sorted by name. Public: an
+/// anonymous viewer sees every probe whose `visible` filter permits it (the default permits
+/// everyone), while a probe restricted with e.g. `visible: auth.admin` is returned only once a
+/// matching bearer token is presented.
+pub async fn get_probes(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpResponse> {
+    let ctx = resolve_auth_context(&req, &data).await;
+    let config = data.state.get_config();
+
     let api_probes = data.state.get_probe_states().await?;
     let mut probes: Vec<grey_api::Probe> = api_probes.into_values().collect();
+    retain_visible_probes(&config, &ctx, &mut probes);
     probes.sort_by_key(|p| p.name.clone());
 
     Ok(HttpResponse::Ok().json(probes))
@@ -16,16 +24,18 @@ pub async fn get_probes(data: web::Data<AppState>) -> Result<HttpResponse> {
 mod tests {
     use actix_web::body::MessageBody;
     use actix_web::http::StatusCode;
+    use actix_web::test::TestRequest;
     use tempfile::tempdir;
 
     use super::*;
+    use crate::state::State;
 
     #[actix_web::test]
     async fn test_get_probes() {
         let temp_dir = tempdir().unwrap();
 
         let app_state = AppState::test(temp_dir.path().to_path_buf()).await;
-        let resp = get_probes(web::Data::new(app_state)).await;
+        let resp = get_probes(TestRequest::default().to_http_request(), web::Data::new(app_state)).await;
 
         let resp = resp.expect("Failed to get probes");
         assert_eq!(resp.status(), StatusCode::OK);
@@ -34,5 +44,29 @@ mod tests {
         let body = String::from_utf8_lossy(&body_bytes);
         let probes: Vec<grey_api::Probe> = serde_json::from_str(&body).unwrap();
         assert_eq!(probes.len(), 1);
+    }
+
+    /// A probe restricted with `visible: auth.admin` is omitted from the public listing for an
+    /// anonymous viewer (no bearer token), while an unrestricted probe is returned.
+    #[actix_web::test]
+    async fn restricted_probes_are_hidden_from_anonymous_viewers() {
+        let dir = tempdir().unwrap();
+        let config = format!(
+            "ui:\n  enabled: true\n  listen: 127.0.0.1:0\nprobes:\n  - name: public.probe\n    policy: {{ interval: 60s, timeout: 5s }}\n    target: !Http\n      url: https://example.com\n  - name: secret.probe\n    policy: {{ interval: 60s, timeout: 5s }}\n    target: !Http\n      url: https://example.com\n    visible: auth.admin\nstate: {}\n",
+            dir.path().join("state.redb").display().to_string().replace('\\', "/")
+        );
+        let config_path = dir.path().join("config.yml");
+        tokio::fs::write(&config_path, config).await.unwrap();
+        let app_state = AppState::new(State::new(&config_path).await.unwrap());
+
+        let resp = get_probes(TestRequest::default().to_http_request(), web::Data::new(app_state))
+            .await
+            .expect("Failed to get probes");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body_bytes = resp.into_body().try_into_bytes().unwrap();
+        let probes: Vec<grey_api::Probe> = serde_json::from_slice(&body_bytes).unwrap();
+
+        let names: Vec<&str> = probes.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["public.probe"], "the admin-only probe must be hidden from anonymous viewers");
     }
 }

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -64,6 +64,14 @@ pub struct CronConfig {
 
     #[serde(default)]
     pub tags: HashMap<String, String>,
+
+    /// A `filt-rs` expression deciding which viewers may see this cron in the API and UI, evaluated
+    /// against the requesting viewer's auth context: `auth` (a valid token was presented),
+    /// `auth.admin` (the configured admin ACL passed), and `claims.<name>` (a validated token claim,
+    /// for parity with the admin ACL). Defaults to `true` (visible to everyone); for example
+    /// `visible: auth.admin` restricts the cron to signed-in administrators.
+    #[serde(default = "default_visible_filter")]
+    pub visible: filt_rs::Filter,
 }
 
 impl CronConfig {
@@ -151,6 +159,13 @@ impl WebhookConfig {
 /// changes.
 fn default_webhook_filter() -> filt_rs::Filter {
     filt_rs::Filter::new("true").expect("the match-all webhook filter must parse")
+}
+
+/// The default visibility filter shows an entity to everyone, so a probe or cron with no `visible`
+/// expression is public — matching the behaviour before per-entity visibility was introduced. Shared
+/// by [`CronConfig`] and [`crate::Probe`].
+pub(crate) fn default_visible_filter() -> filt_rs::Filter {
+    filt_rs::Filter::new("true").expect("the match-all visibility filter must parse")
 }
 
 fn default_webhook_timeout() -> std::time::Duration {

--- a/agent/src/probe.rs
+++ b/agent/src/probe.rs
@@ -17,6 +17,14 @@ pub struct Probe {
     /// of its checks does not match.
     #[serde(default)]
     pub checks: Vec<filt_rs::Filter>,
+
+    /// A `filt-rs` expression deciding which viewers may see this probe in the API and UI, evaluated
+    /// against the requesting viewer's auth context: `auth` (a valid token was presented),
+    /// `auth.admin` (the configured admin ACL passed), and `claims.<name>` (a validated token claim,
+    /// for parity with the admin ACL). Defaults to `true` (visible to everyone); for example
+    /// `visible: auth.admin` restricts the probe to signed-in administrators.
+    #[serde(default = "crate::config::default_visible_filter")]
+    pub visible: filt_rs::Filter,
 }
 
 impl Probe {
@@ -28,6 +36,7 @@ impl Probe {
             target: crate::targets::TargetType::test(),
             tags: HashMap::new(),
             checks: vec![filt_rs::Filter::new("output.test == true").unwrap()],
+            visible: crate::config::default_visible_filter(),
         }
     }
 

--- a/agent/src/state/crons.rs
+++ b/agent/src/state/crons.rs
@@ -172,6 +172,7 @@ mod tests {
             grace: None,
             token: None,
             tags: HashMap::new(),
+            visible: crate::config::default_visible_filter(),
         }];
         *state.config.write().unwrap() = Arc::new(config);
         state

--- a/agent/src/state/mod.rs
+++ b/agent/src/state/mod.rs
@@ -693,6 +693,7 @@ mod tests {
             grace: None,
             token: None,
             tags: HashMap::new(),
+            visible: crate::config::default_visible_filter(),
         }];
         *state.config.write().unwrap() = Arc::new(config);
         state

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -92,6 +92,53 @@ You can read more about the fields available for each target in the [Targets](..
 section of the documentation.
 :::
 
+### Visibility
+The optional `visible` property controls who can see a probe on the status dashboard and in the API.
+It is a [`filt-rs`](../checks/README.md) expression — the same language used by `checks` — but instead
+of being evaluated against a probe sample, it is evaluated against the **auth context** of whoever is
+making the request:
+
+| Field | Type | Meaning |
+| --- | --- | --- |
+| `auth` | boolean | `true` when the viewer presented a valid sign-in (a shortcut for "any authenticated user"). |
+| `auth.admin` | boolean | `true` when the viewer passed the [admin ACL](../ui/incidents.md#access-control). |
+| `claims.<name>` | claim value | A validated token claim, mirroring the admin ACL (e.g. `claims.groups`). |
+
+`visible` defaults to `true`, so a probe with no `visible` expression is shown to everyone, exactly as
+before. Set it to restrict a probe to a subset of viewers — entries a viewer may not see are never sent
+to their browser at all (they are filtered out of both the server-rendered page and the API response):
+
+```yaml
+probes:
+  - name: internal.dashboard
+    policy:
+      interval: 30s
+      timeout: 5s
+    target: !Http
+      url: https://internal.example.com/health
+    # Only signed-in administrators can see this probe.
+    visible: auth.admin
+
+  - name: partner.api
+    policy:
+      interval: 30s
+      timeout: 5s
+    target: !Http
+      url: https://partner.example.com/health
+    # Anyone signed in (not necessarily an admin) can see this probe.
+    visible: auth
+```
+
+Because `auth.admin` reuses the admin ACL, visibility requires an [`admin`](../ui/incidents.md) block to
+be configured; with no admin configured, nobody passes `auth.admin` and such an entry is hidden from
+everyone. The same `visible` property is available on [crons](crons.md).
+
+::: warning
+Visibility is a presentation control, not a security boundary for the probed services themselves — it
+governs what the status page and API expose, so use it to tidy a public status page rather than as the
+only protection for sensitive endpoints.
+:::
+
 ## Status Dashboard
 Grey includes an optional web-based user interface that provides real-time visibility
 into probe status and execution history. The UI can be enabled on any node and integrates

--- a/docs/guide/crons.md
+++ b/docs/guide/crons.md
@@ -39,6 +39,10 @@ crons:
 
   - name: sync.hourly
     interval: 1h           # the simple fixed-cadence form — or use `schedule` instead
+
+  - name: internal.report
+    schedule: '0 6 * * *'
+    visible: auth.admin    # only signed-in administrators can see this cron
 ```
 
 | Option | Default | Description |
@@ -50,6 +54,7 @@ crons:
 | `grace` | `interval / 10`, or `5m` for a crontab | Slack after the due time before a late run reads as missing. |
 | `token` | _none_ | When set, callers must present this secret on every check-in. |
 | `tags` | _none_ | Free-form labels; the `service` tag groups the cron with the probes of the same service. |
+| `visible` | `true` | A [`filt-rs`](../checks/README.md) expression over the viewer's auth context (`auth`, `auth.admin`, `claims.<name>`) deciding who can see this cron. See [Visibility](configuration.md#visibility). |
 
 ## Checking In
 

--- a/docs/ui/incidents.md
+++ b/docs/ui/incidents.md
@@ -103,6 +103,12 @@ provide an expression that matches your account.
 A request with a valid token whose claims fail the ACL receives `403`; a request
 with no (or an invalid) token receives `401`.
 
+The same signed-in identity also drives per-probe and per-cron
+[visibility](../guide/configuration.md#visibility): a probe or cron with a
+`visible: auth.admin` filter is shown only to viewers who pass this ACL, while
+`visible: auth` shows it to anyone signed in. Whichever way it is set, entries a
+viewer may not see are filtered out before the page or API response reaches them.
+
 ## Managing incidents
 
 Once signed in, the **Incidents** page shows every incident (including hidden

--- a/example/checks.yml
+++ b/example/checks.yml
@@ -56,3 +56,8 @@ probes:
     tags:
       domain: github.com
       service: Coding
+    # Control who can see this probe on the status page and in the API. The expression is evaluated
+    # against the viewer's auth context: `auth` (any valid sign-in), `auth.admin` (passed the `admin`
+    # ACL configured above), and `claims.<name>` (a validated token claim). It defaults to `true`
+    # (visible to everyone). Uncomment to restrict this probe to signed-in administrators:
+    # visible: auth.admin

--- a/example/crons.yml
+++ b/example/crons.yml
@@ -27,6 +27,11 @@ crons:
     grace: 1h              # slack after 02:00 before a no-show reads as missing
     tags:
       service: Backups
+    # Control who can see this cron on the status page and in the API. The expression is evaluated
+    # against the viewer's auth context — `auth` (any valid sign-in), `auth.admin` (passed the admin
+    # ACL), and `claims.<name>` — and defaults to `true` (visible to everyone). Uncomment to restrict
+    # this cron to signed-in administrators:
+    # visible: auth.admin
 
   # A simple "every N" job that only reports on completion. With no `running` phase the
   # completion detector stays dormant; only the schedule (missed-run) detector applies.

--- a/ui/src/contexts/store.rs
+++ b/ui/src/contexts/store.rs
@@ -385,6 +385,29 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
                 || ()
             });
         }
+
+        // Re-fetch the live entities the moment the session changes (sign-in or sign-out): an
+        // administrator should immediately see the probes/crons their access unlocks via a `visible`
+        // filter, and an anonymous viewer should stop seeing them on sign-out, without waiting for the
+        // next poll. The authenticated polls carry the bearer token, so the agent returns the set the
+        // viewer is permitted to see. The initial (mount) run is skipped, since the effects above
+        // already seed the starting set.
+        {
+            let state = state.clone();
+            let client = client.clone();
+            let first = use_mut_ref(|| true);
+            use_effect_with(state.token.is_some(), move |_| {
+                if std::mem::replace(&mut *first.borrow_mut(), false) {
+                    // Mount: the initial fetch is handled by the effects above.
+                } else {
+                    wasm_bindgen_futures::spawn_local(async move {
+                        state.dispatch(load_probes(&client).await);
+                        state.dispatch(load_crons(&client).await);
+                    });
+                }
+                || ()
+            });
+        }
     }
 
     let login = {


### PR DESCRIPTION
## Summary

Probes and crons can now declare a `visible: <filt-rs>` expression that controls who sees them on the status page and in the API. The expression is evaluated against the requesting viewer's **auth context** — resolved the same way as the admin ACL — which exposes:

- **`auth`** — boolean shortcut: a valid sign-in was presented (any authenticated user).
- **`auth.admin`** — boolean shortcut: the viewer passed the configured [admin ACL](https://grey.sierrasoftworks.com/ui/incidents.html#access-control).
- **`claims.<name>`** — validated token claims, for parity with the admin ACL (e.g. `claims.groups contains "ops"`).

```yaml
probes:
  - name: internal.dashboard
    policy: { interval: 30s, timeout: 5s }
    target: !Http { url: https://internal.example.com/health }
    visible: auth.admin    # only signed-in administrators can see this probe

crons:
  - name: internal.report
    schedule: '0 6 * * *'
    visible: auth.admin
```

`visible` defaults to `true` (visible to everyone), so existing configs are unchanged.

## How it works

- A new `AuthContext` is resolved for the public read endpoints (`/api/v1/probes`, `/api/v1/crons`) and the server-rendered page. It reuses the existing OIDC validation and admin ACL — but, unlike `require_admin`, an anonymous/invalid request simply resolves to "not authenticated" rather than being rejected.
- A `VisibilityFilter` exposes `auth` / `auth.admin` / `claims.*` to the `filt-rs` expression. Evaluation is **fail-closed**: a malformed `visible` rule hides the entity rather than leaking it.
- Entries a viewer may not see are filtered out of **both** the server-rendered HTML and the API responses, so they are never sent to the browser. A normal page navigation carries no bearer token, so the SSR snapshot is the anonymous view; admin-only entries appear once the authenticated SPA polls fetch them.
- The SPA re-fetches the live entities the moment the session changes (sign-in/out), so an administrator sees restricted entries immediately instead of waiting for the next poll.
- Pooled records with no local configuration entry (e.g. gossiped orphans) have no `visible` rule and stay visible, preserving prior behaviour.

## Tests

- `auth.rs`: `VisibilityFilter` / `can_see` semantics for `auth`, `auth.admin`, and `claims.*`; `retain_visible_*` honours context and leaves orphans visible.
- `probes.rs` / `cron.rs`: a `visible: auth.admin` entry is hidden from an anonymous viewer while an unrestricted one is returned.
- Existing example-drift and SSR tests still pass.

## Docs

Documented under the [configuration guide](docs/guide/configuration.md) (new "Visibility" section), the [cron guide](docs/guide/crons.md), and cross-referenced from the [incidents/access-control docs](docs/ui/incidents.md); examples added (commented) to `example/checks.yml` and `example/crons.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FBqJupmBwLNDQJbMcnCVej)_