### PR TITLE
fix(api): 401 public reads on an invalid token instead of downgrading

### DIFF
--- a/agent/src/api/auth.rs
+++ b/agent/src/api/auth.rs
@@ -395,25 +395,42 @@ impl Filterable for VisibilityFilter<'_> {
     }
 }
 
-/// Resolves the [`AuthContext`] for a request to a public read endpoint. The context is anonymous
-/// when admin auth is not configured, or when no/invalid bearer token is presented. A valid token
+/// Resolves the [`AuthContext`] for a request to a public read endpoint.
+///
+/// Returns an anonymous context when admin auth is not configured, or when the request carries no
+/// bearer token at all — such a viewer sees only the entities visible to everyone. A *valid* token
 /// populates the claims and marks the request authenticated; the configured admin ACL is then
 /// evaluated (against the same `method`/`path`/`claims` fields [`require_admin`] uses) to decide
 /// whether the viewer also counts as an administrator.
-pub async fn resolve_auth_context(req: &HttpRequest, data: &AppState) -> AuthContext {
+///
+/// A token that is *present but invalid or expired* is reported as an [`Err`] (a `401`) rather than
+/// being silently downgraded to the anonymous view. A viewer who presents a token is asking for their
+/// authenticated set; quietly returning the smaller public set instead would make a signed-in
+/// administrator's probes and crons vanish the moment their token lapsed — e.g. while the tab sat
+/// backgrounded and polling was paused — with no 401 to prompt the SPA to renew it. Surfacing the
+/// 401 lets the client refresh the session and retry (its existing reaction to a 401), restoring the
+/// authenticated set. The SSR page render, where a token can't be renewed mid-request, opts back into
+/// the anonymous fallback via `.unwrap_or_default()`.
+pub async fn resolve_auth_context(
+    req: &HttpRequest,
+    data: &AppState,
+) -> Result<AuthContext, ApiError> {
     let config = data.state.get_config();
     let Some(admin) = config.ui.admin.as_ref() else {
-        return AuthContext::default();
+        return Ok(AuthContext::default());
     };
 
     let Some(token) = bearer_token(req.headers()) else {
-        return AuthContext::default();
+        return Ok(AuthContext::default());
     };
 
-    // An invalid or expired token on a public endpoint is treated as anonymous rather than an error:
-    // the viewer still sees everything visible to the public, exactly as if they had presented none.
-    let Ok(claims) = data.oidc.validate(&admin.oidc, &token).await else {
-        return AuthContext::default();
+    let claims = match data.oidc.validate(&admin.oidc, &token).await {
+        Ok(claims) => claims,
+        Err(e) => {
+            info!("Rejected a public read carrying an invalid bearer token: {e}");
+            return Err(ApiError::unauthorized("Your session is invalid or has expired.")
+                .with_advice("Sign in again to continue."));
+        }
     };
 
     let is_admin = admin
@@ -425,11 +442,11 @@ pub async fn resolve_auth_context(req: &HttpRequest, data: &AppState) -> AuthCon
         })
         .unwrap_or(false);
 
-    AuthContext {
+    Ok(AuthContext {
         authenticated: true,
         admin: is_admin,
         claims,
-    }
+    })
 }
 
 /// Drops the probes the given viewer may not see, honouring each probe's configured `visible` filter.

--- a/agent/src/api/cron.rs
+++ b/agent/src/api/cron.rs
@@ -120,7 +120,12 @@ async fn record(
 /// `/probes`: a cron restricted with e.g. `visible: auth.admin` is returned only once a matching
 /// bearer token is presented.
 pub async fn get_crons(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpResponse> {
-    let ctx = super::auth::resolve_auth_context(&req, &data).await;
+    let ctx = match super::auth::resolve_auth_context(&req, &data).await {
+        Ok(ctx) => ctx,
+        // Mirror `/probes`: a stale/invalid token is a 401 so the SPA renews and retries, rather than
+        // a silent downgrade that would hide the viewer's restricted crons.
+        Err(err) => return Ok(err.into()),
+    };
     let config = data.state.get_config();
 
     let crons = data.state.get_cron_states().await?;
@@ -239,6 +244,34 @@ mod tests {
         let crons: Vec<Cron> = serde_json::from_slice(&test::read_body(resp).await).unwrap();
         let names: Vec<&str> = crons.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, vec!["public.cron"], "the admin-only cron must be hidden from anonymous viewers");
+    }
+
+    /// A bearer token the agent can't validate yields a 401 from the public cron listing rather than a
+    /// silent downgrade to the anonymous view, mirroring `/probes`. The SPA renews the session on the
+    /// 401 and retries, so a signed-in viewer's crons don't collapse to the public subset when their
+    /// token lapses. The OIDC endpoint is unreachable, so validation fails as it would for an expired
+    /// token.
+    #[actix_web::test]
+    async fn invalid_bearer_token_is_rejected_not_downgraded() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = format!(
+            "ui:\n  enabled: true\n  listen: 127.0.0.1:0\n  admin:\n    oidc:\n      endpoint: http://127.0.0.1:1\n      client_id: grey\n      client_secret: secret\ncrons:\n  - name: public.cron\n    interval: 60s\nstate: {}\nprobes: []\n",
+            dir.path().join("state.redb").display().to_string().replace('\\', "/")
+        );
+        let config_path = dir.path().join("config.yml");
+        tokio::fs::write(&config_path, config).await.unwrap();
+        let state = AppState::new(State::new(&config_path).await.unwrap());
+        let app = test::init_service(
+            App::new().app_data(web::Data::new(state)).configure(configure),
+        )
+        .await;
+
+        let req = test::TestRequest::get()
+            .uri("/api/v1/crons")
+            .insert_header(("Authorization", "Bearer not-a-real-token"))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[actix_web::test]

--- a/agent/src/api/page.rs
+++ b/agent/src/api/page.rs
@@ -9,8 +9,12 @@ pub async fn index(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpRe
     // Resolve the viewer's auth context so the server-rendered snapshot honours each entity's
     // `visible` filter. A normal browser navigation carries no `Authorization` header, so this is
     // anonymous in practice — admin-only probes/crons are therefore never embedded in the delivered
-    // HTML and instead appear after sign-in, when the SPA's authenticated polls fetch them.
-    let ctx = super::auth::resolve_auth_context(&req, &data).await;
+    // HTML and instead appear after sign-in, when the SPA's authenticated polls fetch them. A request
+    // that somehow carries an invalid token can't renew it mid-render, so it falls back to the
+    // anonymous view rather than failing the whole page (the public read endpoints return the 401).
+    let ctx = super::auth::resolve_auth_context(&req, &data)
+        .await
+        .unwrap_or_default();
     let config = data.state.get_config();
 
     let probe_histories = data.state.get_probe_states().await?;

--- a/agent/src/api/probes.rs
+++ b/agent/src/api/probes.rs
@@ -9,7 +9,12 @@ use crate::state::ProbeStore;
 /// everyone), while a probe restricted with e.g. `visible: auth.admin` is returned only once a
 /// matching bearer token is presented.
 pub async fn get_probes(req: HttpRequest, data: web::Data<AppState>) -> Result<HttpResponse> {
-    let ctx = resolve_auth_context(&req, &data).await;
+    let ctx = match resolve_auth_context(&req, &data).await {
+        Ok(ctx) => ctx,
+        // A stale/invalid token is a 401 (not a silent public-only listing), so the SPA renews the
+        // session and retries rather than quietly dropping the viewer's restricted probes.
+        Err(err) => return Ok(err.into()),
+    };
     let config = data.state.get_config();
 
     let api_probes = data.state.get_probe_states().await?;
@@ -68,5 +73,31 @@ mod tests {
 
         let names: Vec<&str> = probes.iter().map(|p| p.name.as_str()).collect();
         assert_eq!(names, vec!["public.probe"], "the admin-only probe must be hidden from anonymous viewers");
+    }
+
+    /// A request that presents a bearer token the agent can't validate (an expired or otherwise
+    /// invalid session) is rejected with a 401 rather than being silently downgraded to the anonymous
+    /// listing. The SPA reacts to the 401 by renewing the session and retrying, so a signed-in
+    /// viewer's probes don't quietly collapse to the public subset when their token lapses (e.g. while
+    /// the tab was backgrounded). The OIDC endpoint is unreachable, so validation fails — exactly as
+    /// it would for a genuinely expired token.
+    #[actix_web::test]
+    async fn invalid_bearer_token_is_rejected_not_downgraded() {
+        let dir = tempdir().unwrap();
+        let config = format!(
+            "ui:\n  enabled: true\n  listen: 127.0.0.1:0\n  admin:\n    oidc:\n      endpoint: http://127.0.0.1:1\n      client_id: grey\n      client_secret: secret\nprobes:\n  - name: public.probe\n    policy: {{ interval: 60s, timeout: 5s }}\n    target: !Http\n      url: https://example.com\nstate: {}\n",
+            dir.path().join("state.redb").display().to_string().replace('\\', "/")
+        );
+        let config_path = dir.path().join("config.yml");
+        tokio::fs::write(&config_path, config).await.unwrap();
+        let app_state = AppState::new(State::new(&config_path).await.unwrap());
+
+        let req = TestRequest::default()
+            .insert_header(("Authorization", "Bearer not-a-real-token"))
+            .to_http_request();
+        let resp = get_probes(req, web::Data::new(app_state))
+            .await
+            .expect("the handler renders the error as a response rather than returning Err");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
## Problem

When a signed-in administrator re-focused the UI, the focus-triggered API refresh collapsed their visible probes/cron jobs to the **anonymous (public) subset**. Switching to the Incidents view and back restored the full list without re-authenticating.

### Root cause

The public read endpoints `GET /api/v1/probes` and `GET /api/v1/crons` resolve the viewer with `resolve_auth_context`, which treated an **invalid/expired** bearer token identically to **no** token — returning `200 OK` with only the publicly visible subset:

```rust
// before
let Ok(claims) = data.oidc.validate(&admin.oidc, &token).await else {
    return AuthContext::default(); // silent downgrade to anonymous, still 200
};
```

But the SPA only renews its session **in reaction to a 401** (`ui/src/api.rs`). Background polling pauses while the tab is unfocused, so by the time the page is re-focused the ID token has often expired. The catch-up poll then sent the stale token, received a silent `200` with the anonymous subset, and overwrote the store — making the admin's restricted entities disappear, with nothing to prompt a token refresh.

Navigating to the Incidents view hit `/api/v1/admin/incidents` (guarded by `require_admin`, which **does** return `401`), which triggered the client's refresh-and-retry and restored a valid token — which is why switching views appeared to "fix" it.

## Fix

Treat the **presence** of a token as a request for the authenticated view. `resolve_auth_context` now returns `Result<AuthContext, ApiError>`:

- **No token** (or admin auth not configured) → anonymous context → `200` (unchanged).
- **Valid token** → authenticated context → `200` (unchanged).
- **Token present but invalid/expired** → `Err(401)` instead of a silent downgrade.

The public read handlers (`get_probes`, `get_crons`) propagate the `401`, so the SPA's existing refresh-and-retry kicks in and restores the authenticated set with no view switch required. No client changes are needed.

The SSR page render (`page.rs`) keeps the anonymous fallback via `.unwrap_or_default()`, since a document navigation carries no token and can't renew one mid-request.

## Reviewer notes

- **Genuinely anonymous viewers are unaffected** — a request with no `Authorization` header still resolves to the anonymous context and a `200` with the public subset.
- **Edge case:** if the ID token *and* the refresh token are both dead (e.g. a very long absence), the poll now gets a `401`, the refresh fails, and the SPA surfaces a "session expired" banner before reverting to the anonymous view. This is correct — the session genuinely ended and needs re-login — versus the old behavior of silently showing less data.

## Testing

- Added `probes::tests::invalid_bearer_token_is_rejected_not_downgraded` and `cron::tests::invalid_bearer_token_is_rejected_not_downgraded`: with admin auth configured and an unvalidatable bearer token, the endpoint returns `401` rather than a public listing. (The OIDC endpoint is set to an unreachable address so validation fails fast — exactly as for a genuinely expired token.)
- Existing anonymous-viewer tests (`restricted_probes_are_hidden_from_anonymous_viewers`, `restricted_crons_are_hidden_from_anonymous_viewers`) still pass unchanged.
- `cargo test -p grey --bins api::` → 35 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)