### PR TITLE
ci: publish releases to the Homebrew tap

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -243,3 +243,18 @@ jobs:
         with:
           name: grey-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.extension }}
           path: target/${{ matrix.target }}/release/grey${{ matrix.extension }}
+
+  tap:
+    name: Update Homebrew Tap
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    needs:
+      - build-app
+    steps:
+      - name: Update Homebrew Tap
+        uses: SierraSoftworks/actions-tap@v1
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          aliases: major minor


### PR DESCRIPTION
Add a release-only fan-in job that runs after the build-app matrix completes (needs: build-app) and is guarded by
`if: github.event_name == 'release'` so it only fires on published releases, not on push or pull_request events. The job invokes SierraSoftworks/actions-tap to update the grey formula in the Homebrew tap, publishing major and minor versioned aliases alongside the exact release version.