### PR TITLE
docs: document Homebrew tap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ Grey is small enough to run on every server in your fleet, and its built-in
 [clustering](#clustering) lets those instances pool their results so that many vantage
 points contribute to a single, shared view of your platform's health.
 
+## Installation
+Install with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/grey
+```
+
+Pre-compiled binaries for other platforms are available from the
+[GitHub releases](https://github.com/SierraSoftworks/grey/releases) page.
+
 ## Highlights
 - **Clustered probing.** Run Grey on as many machines as you like and have them
   cooperate: every node probes independently and gossips its results, so the cluster

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -13,8 +13,14 @@ setup is a great place to start.
 :::
 
 ## Step #1: Installation
-You can download the latest version of Grey from our [GitHub releases][release] page.
-We include pre-compiled binaries for many different platforms, including Windows, Linux,
+On macOS and Linux you can install Grey with [Homebrew](https://brew.sh):
+
+```sh
+brew install sierrasoftworks/tap/grey
+```
+
+Alternatively, you can download the latest version of Grey from our [GitHub releases][release]
+page. We include pre-compiled binaries for many different platforms, including Windows, Linux,
 and MacOS in both `amd64` and `arm64` variants.
 
 ## Step #2: Configuration


### PR DESCRIPTION
Adds a concise Homebrew installation section to the README and documentation site, pointing users at the Sierra Softworks tap:

    brew install sierrasoftworks/tap/grey

Part of the Homebrew tap rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
