### PR TITLE
feat: add sessionStorage API to script probes

### DIFF
--- a/agent/src/js/mod.rs
+++ b/agent/src/js/mod.rs
@@ -2,10 +2,12 @@ mod console;
 mod fetch;
 mod job_queue;
 mod runtime;
+mod storage;
 mod to_sample;
 
 pub(crate) use console::TraceLogger;
 pub(crate) use fetch::ReqwestFetcher;
 pub(crate) use job_queue::JobQueue;
 pub(crate) use runtime::setup_runtime;
+pub(crate) use storage::SessionStorage;
 pub(crate) use to_sample::JsInto;

--- a/agent/src/js/runtime.rs
+++ b/agent/src/js/runtime.rs
@@ -9,6 +9,7 @@ use tracing_batteries::prelude::*;
 
 pub fn setup_runtime(
     context: &mut Context,
+    storage: super::SessionStorage,
     args: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     boa_runtime::register(
@@ -19,6 +20,8 @@ pub fn setup_runtime(
         None,
         context,
     )?;
+
+    storage.register(context)?;
 
     context.register_global_property(
         js_string!("output"),

--- a/agent/src/js/storage.rs
+++ b/agent/src/js/storage.rs
@@ -1,0 +1,249 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use boa_engine::{
+    Context, IntoJsFunctionCopied, JsData, JsResult, JsValue, interop::ContextData, js_string,
+    object::ObjectInitializer, property::Attribute,
+};
+use boa_gc::{Finalize, Trace};
+
+/// A `sessionStorage`-like key-value store exposed to script probes, allowing
+/// them to cache state (such as access tokens) across probe invocations.
+///
+/// Cloned instances share the same underlying store, while separately
+/// constructed instances are fully isolated. Each probe's `ScriptTarget` owns
+/// one of these, so state survives across scheduled runs (which clone the
+/// target) and lasts until the probe's configuration is rebuilt by a config
+/// reload or the process restarts.
+#[derive(Clone, Debug, Default, Trace, Finalize, JsData)]
+pub(crate) struct SessionStorage {
+    #[unsafe_ignore_trace]
+    store: Arc<RwLock<BTreeMap<String, String>>>,
+}
+
+impl SessionStorage {
+
+    /// Exposes this storage instance as the `sessionStorage` global within the
+    /// provided JavaScript context, mirroring the Web Storage API's method
+    /// surface (`getItem`, `setItem`, `removeItem`, `clear`, `key`, `length`).
+    pub fn register(self, context: &mut Context) -> JsResult<()> {
+        context.insert_data(self);
+
+        let get_item_ = get_item.into_js_function_copied(context);
+        let set_item_ = set_item.into_js_function_copied(context);
+        let remove_item_ = remove_item.into_js_function_copied(context);
+        let clear_ = clear.into_js_function_copied(context);
+        let key_ = key.into_js_function_copied(context);
+        let length_ = length
+            .into_js_function_copied(context)
+            .to_js_function(context.realm());
+
+        let storage = ObjectInitializer::new(context)
+            .function(get_item_, js_string!("getItem"), 1)
+            .function(set_item_, js_string!("setItem"), 2)
+            .function(remove_item_, js_string!("removeItem"), 1)
+            .function(clear_, js_string!("clear"), 0)
+            .function(key_, js_string!("key"), 1)
+            .accessor(
+                js_string!("length"),
+                Some(length_),
+                None,
+                Attribute::ENUMERABLE,
+            )
+            .build();
+
+        context.register_global_property(
+            js_string!("sessionStorage"),
+            storage,
+            Attribute::READONLY | Attribute::ENUMERABLE,
+        )?;
+
+        Ok(())
+    }
+
+    fn read(&self) -> RwLockReadGuard<'_, BTreeMap<String, String>> {
+        self.store.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn write(&self) -> RwLockWriteGuard<'_, BTreeMap<String, String>> {
+        self.store.write().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+fn get_item(
+    ContextData(storage): ContextData<SessionStorage>,
+    key: JsValue,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let key = key.to_string(context)?.to_std_string_lossy();
+    Ok(storage
+        .read()
+        .get(&key)
+        .map_or_else(JsValue::null, |value| js_string!(value.as_str()).into()))
+}
+
+fn set_item(
+    ContextData(storage): ContextData<SessionStorage>,
+    key: JsValue,
+    value: JsValue,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let key = key.to_string(context)?.to_std_string_lossy();
+    let value = value.to_string(context)?.to_std_string_lossy();
+    storage.write().insert(key, value);
+    Ok(JsValue::undefined())
+}
+
+fn remove_item(
+    ContextData(storage): ContextData<SessionStorage>,
+    key: JsValue,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let key = key.to_string(context)?.to_std_string_lossy();
+    storage.write().remove(&key);
+    Ok(JsValue::undefined())
+}
+
+fn clear(ContextData(storage): ContextData<SessionStorage>) -> JsResult<JsValue> {
+    storage.write().clear();
+    Ok(JsValue::undefined())
+}
+
+fn key(
+    ContextData(storage): ContextData<SessionStorage>,
+    index: JsValue,
+    context: &mut Context,
+) -> JsResult<JsValue> {
+    let index = index.to_u32(context)? as usize;
+    Ok(storage
+        .read()
+        .keys()
+        .nth(index)
+        .map_or_else(JsValue::null, |key| js_string!(key.as_str()).into()))
+}
+
+fn length(ContextData(storage): ContextData<SessionStorage>) -> JsResult<JsValue> {
+    Ok(JsValue::from(storage.read().len() as u32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use boa_engine::Source;
+
+    fn context_with_storage(storage: SessionStorage) -> Context {
+        let mut context = Context::default();
+        storage.register(&mut context).unwrap();
+        context
+    }
+
+    fn eval(context: &mut Context, code: &str) -> JsValue {
+        context.eval(Source::from_bytes(code)).unwrap()
+    }
+
+    #[test]
+    fn test_set_and_get_item() {
+        let storage = SessionStorage::default();
+        let mut context = context_with_storage(storage.clone());
+
+        let result = eval(
+            &mut context,
+            r#"
+            sessionStorage.setItem("token", "abc123");
+            sessionStorage.getItem("token")
+            "#,
+        );
+        assert_eq!(result, js_string!("abc123").into());
+        assert_eq!(
+            storage.read().get("token").map(String::as_str),
+            Some("abc123")
+        );
+    }
+
+    #[test]
+    fn test_get_missing_item_returns_null() {
+        let mut context = context_with_storage(SessionStorage::default());
+
+        let result = eval(&mut context, r#"sessionStorage.getItem("missing")"#);
+        assert_eq!(result, JsValue::null());
+    }
+
+    #[test]
+    fn test_values_are_coerced_to_strings() {
+        let mut context = context_with_storage(SessionStorage::default());
+
+        let result = eval(
+            &mut context,
+            r#"
+            sessionStorage.setItem("number", 42);
+            typeof sessionStorage.getItem("number") + ":" + sessionStorage.getItem("number")
+            "#,
+        );
+        assert_eq!(result, js_string!("string:42").into());
+    }
+
+    #[test]
+    fn test_remove_item() {
+        let mut context = context_with_storage(SessionStorage::default());
+
+        let result = eval(
+            &mut context,
+            r#"
+            sessionStorage.setItem("a", "1");
+            sessionStorage.removeItem("a");
+            sessionStorage.getItem("a")
+            "#,
+        );
+        assert_eq!(result, JsValue::null());
+    }
+
+    #[test]
+    fn test_clear() {
+        let storage = SessionStorage::default();
+        let mut context = context_with_storage(storage.clone());
+
+        let result = eval(
+            &mut context,
+            r#"
+            sessionStorage.setItem("a", "1");
+            sessionStorage.setItem("b", "2");
+            sessionStorage.clear();
+            sessionStorage.length
+            "#,
+        );
+        assert_eq!(result, JsValue::from(0));
+        assert!(storage.read().is_empty());
+    }
+
+    #[test]
+    fn test_key_and_length() {
+        let mut context = context_with_storage(SessionStorage::default());
+
+        let result = eval(
+            &mut context,
+            r#"
+            sessionStorage.setItem("b", "2");
+            sessionStorage.setItem("a", "1");
+            [sessionStorage.length, sessionStorage.key(0), sessionStorage.key(1), sessionStorage.key(2)].join(",")
+            "#,
+        );
+        assert_eq!(result, js_string!("2,a,b,").into());
+    }
+
+    #[test]
+    fn test_persists_across_contexts() {
+        let storage = SessionStorage::default();
+
+        {
+            let mut context = context_with_storage(storage.clone());
+            eval(
+                &mut context,
+                r#"sessionStorage.setItem("token", "cached")"#,
+            );
+        }
+
+        let mut context = context_with_storage(storage);
+        let result = eval(&mut context, r#"sessionStorage.getItem("token")"#);
+        assert_eq!(result, js_string!("cached").into());
+    }
+}

--- a/agent/src/targets/mod.rs
+++ b/agent/src/targets/mod.rs
@@ -32,7 +32,9 @@ pub enum TargetType {
 impl TargetType {
     #[cfg(test)]
     pub fn test() -> Self {
-        TargetType::Script(script::ScriptTarget { code: "output.test = true".into(), args: vec![] })
+        let mut target = script::ScriptTarget::default();
+        target.code = "output.test = true".into();
+        TargetType::Script(target)
     }
 
     pub async fn run(&self, cancel: &AtomicBool) -> Result<Sample, Box<dyn std::error::Error>> {

--- a/agent/src/targets/script.rs
+++ b/agent/src/targets/script.rs
@@ -5,13 +5,27 @@ use tracing::instrument;
 use tracing_batteries::prelude::*;
 
 use crate::{Sample, js::JobQueue, targets::Target};
-use crate::js::JsInto;
+use crate::js::{JsInto, SessionStorage};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ScriptTarget {
     pub code: String,
     #[serde(default)]
     pub args: Vec<String>,
+    /// Runtime cache backing the script's `sessionStorage` global. Clones share the
+    /// same store, so state persists across the per-run clones taken by the probe
+    /// runner and lasts until a config reload rebuilds this target.
+    #[serde(skip)]
+    session: SessionStorage,
+}
+
+/// Equality covers only the configured fields — the session store is runtime cache,
+/// not configuration. The config reloader relies on this comparison to decide when a
+/// probe has changed and needs its target (and therefore its cache) rebuilt.
+impl PartialEq for ScriptTarget {
+    fn eq(&self, other: &Self) -> bool {
+        self.code == other.code && self.args == other.args
+    }
 }
 
 impl Target for ScriptTarget {
@@ -25,7 +39,7 @@ impl Target for ScriptTarget {
             .job_executor(executor.clone())
             .build()?;
 
-        crate::js::setup_runtime(context, args)?;
+        crate::js::setup_runtime(context, self.session.clone(), args)?;
 
         let module = Module::parse(Source::from_bytes(&code), None, context)?;
 
@@ -123,6 +137,7 @@ mod tests {
         let target = ScriptTarget {
             code: r#"output.a = arguments[0]; output.b = arguments[1]"#.into(),
             args: vec!["arg1".into(), "arg2".into()],
+            ..Default::default()
         };
 
         let cancel = AtomicBool::new(false);
@@ -202,6 +217,75 @@ mod tests {
             Ok(result) => panic!("Expected timeout, but got {:?}", result),
             Err(_) => {}
         }
+    }
+
+    #[tokio::test]
+    async fn test_script_session_storage() {
+        let target = ScriptTarget {
+            code: r#"
+            const runs = parseInt(sessionStorage.getItem("runs") ?? "0", 10) + 1;
+            sessionStorage.setItem("runs", runs);
+            output.runs = sessionStorage.getItem("runs");
+            "#
+            .into(),
+            ..Default::default()
+        };
+        let cancel = AtomicBool::new(false);
+
+        // state persists across invocations, including through the per-run clones
+        // taken by the probe runner
+        let sample = target.run(&cancel).await.expect("no error to be raised");
+        assert_eq!(sample.get("runs"), &SampleValue::from("1"));
+
+        let sample = target
+            .clone()
+            .run(&cancel)
+            .await
+            .expect("no error to be raised");
+        assert_eq!(sample.get("runs"), &SampleValue::from("2"));
+
+        // ...but a separately constructed target (e.g. another probe using the same
+        // script, or this probe after a config reload) starts from an empty store
+        let fresh = ScriptTarget {
+            code: target.code.clone(),
+            ..Default::default()
+        };
+        let sample = fresh.run(&cancel).await.expect("no error to be raised");
+        assert_eq!(sample.get("runs"), &SampleValue::from("1"));
+    }
+
+    #[tokio::test]
+    async fn test_script_target_equality_ignores_session_state() {
+        let populated = ScriptTarget {
+            code: "sessionStorage.setItem('k', 'v')".into(),
+            ..Default::default()
+        };
+        let empty = ScriptTarget {
+            code: populated.code.clone(),
+            ..Default::default()
+        };
+
+        let cancel = AtomicBool::new(false);
+        populated.run(&cancel).await.expect("no error to be raised");
+
+        // the config reloader compares probes to decide what to rebuild; cached
+        // session state must not make otherwise-identical configs look different
+        assert_eq!(populated, empty);
+        assert_ne!(
+            populated,
+            ScriptTarget {
+                code: "other".into(),
+                ..Default::default()
+            }
+        );
+        assert_ne!(
+            populated,
+            ScriptTarget {
+                code: populated.code.clone(),
+                args: vec!["arg".into()],
+                ..Default::default()
+            }
+        );
     }
 
     #[tokio::test]

--- a/docs/targets/script.md
+++ b/docs/targets/script.md
@@ -168,18 +168,31 @@ The following methods and properties are supported (property-style access like
 - `sessionStorage.length: number`
 
 ```js
-let token = sessionStorage.getItem("example.token");
-if (token === null) {
-    const auth = await fetch("https://example.com/api/v1/login", { method: "POST", /* ... */ });
-    token = (await auth.json()).token;
-    sessionStorage.setItem("example.token", token);
+async function getToken() {
+    let token = sessionStorage.getItem("example.token");
+    if (token === null) {
+        const auth = await fetch("https://example.com/api/v1/login", { method: "POST", /* ... */ });
+        token = (await auth.json()).token;
+        sessionStorage.setItem("example.token", token);
+    }
+    return token;
 }
 
-const resp = await fetch("https://example.com/api/v1/profile", {
-    headers: {
-        "Authorization": `Bearer ${token}`
-    }
-});
+async function getProfile() {
+    return await fetch("https://example.com/api/v1/profile", {
+        headers: {
+            "Authorization": `Bearer ${await getToken()}`
+        }
+    });
+}
+
+let resp = await getProfile();
+if (resp.status === 401) {
+    // The cached token has expired — evict it, fetch a fresh one, and retry once
+    sessionStorage.removeItem("example.token");
+    resp = await getProfile();
+}
+
 output["profile.status"] = resp.status;
 ```
 

--- a/docs/targets/script.md
+++ b/docs/targets/script.md
@@ -151,6 +151,47 @@ output['http.status_code'] = resp.status;
 output['http.body'] = await resp.text();
 ```
 
+### `sessionStorage`
+The `sessionStorage` global provides a [Web Storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage)-like
+API which persists data across invocations of the same probe. This is
+particularly useful for caching things like access tokens so that they do not
+need to be fetched on every probe invocation.
+
+The following methods and properties are supported (property-style access like
+`sessionStorage.myKey = "value"` is **not** supported):
+
+- `sessionStorage.getItem(key: string): string | null`
+- `sessionStorage.setItem(key: string, value: string)`
+- `sessionStorage.removeItem(key: string)`
+- `sessionStorage.clear()`
+- `sessionStorage.key(index: number): string | null`
+- `sessionStorage.length: number`
+
+```js
+let token = sessionStorage.getItem("example.token");
+if (token === null) {
+    const auth = await fetch("https://example.com/api/v1/login", { method: "POST", /* ... */ });
+    token = (await auth.json()).token;
+    sessionStorage.setItem("example.token", token);
+}
+
+const resp = await fetch("https://example.com/api/v1/profile", {
+    headers: {
+        "Authorization": `Bearer ${token}`
+    }
+});
+output["profile.status"] = resp.status;
+```
+
+::: warning
+Storage is isolated per probe: values written by one probe are never visible to
+scripts running under a different probe, even when they share the same script
+code. Both keys and values are always coerced to strings. Values are held in
+memory only and are discarded whenever the probe's configuration is modified
+(via a config reload) or the Grey process restarts — always handle the case
+where a key is missing.
+:::
+
 ### `getTraceId(): string`
 This method retrieves the current OpenTelemetry Trace ID for your probe
 execution, allowing you to pass this information along in requests to


### PR DESCRIPTION
## What

Adds a [Web Storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage)-like `sessionStorage` global to the JavaScript probe environment, letting scripts cache state across probe invocations for the lifetime of the process:

- `getItem` / `setItem` / `removeItem` / `clear` / `key` / `length`, with browser-matching string coercion of keys and values (`setItem("n", 42)` stores `"42"`, missing keys return `null`).
- Documented in `docs/targets/script.md` with a token-caching example.

## Why

Scripts that authenticate against a service currently have to fetch a fresh access token on every probe invocation. Caching the token between runs avoids hammering the identity provider and speeds up each probe.

## How

Each `ScriptTarget` owns its store as a hidden `#[serde(skip)]` field (`SessionStorage`, an `Arc`-shared map registered into each fresh Boa context via `ContextData`):

- **Persistence**: the probe runner clones its target for every scheduled run; clones share the underlying store, so state accumulates across runs.
- **Per-probe isolation**: separately constructed targets are fully isolated — YAML anchors expand to distinct instances, so probes sharing script code cannot read or clobber one another''s state (no key-prefixing discipline required, no cross-probe token leakage).
- **Reset on config change**: `ScriptTarget` now implements `PartialEq` explicitly over its configured fields only (`code`, `args`). The config reloader relies on that comparison to decide which probes to rebuild — editing a probe rebuilds its target and deliberately starts it with an empty store, so stale state never crosses config versions.

This design deliberately avoids threading probe identity through the `Target::run` signature; no other target types are touched.

## Reviewer notes

- The explicit `PartialEq` is load-bearing for the reload path: if the session field ever participated in equality, every reload cycle would rebuild every script probe. `test_script_target_equality_ignores_session_state` pins this down.
- `sessionStorage` is method-API only; property-style access (`sessionStorage.foo = "x"`) would need a proxy/exotic object in Boa and is called out as unsupported in the docs.
- `key()` ordering is deterministic (sorted via `BTreeMap`); the Web Storage spec leaves ordering implementation-defined.
- Values are memory-only and lost on restart or probe edit; the docs tell users to always handle `null`.

Tests: 178 pass, including new coverage for the storage bindings (coercion, `null` semantics, `clear`, `key`/`length`), clone-shares vs fresh-isolated behavior, and equality semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)