### PR TITLE
chore: switch to new SierraSoftworks analytics tracking script

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -23,9 +23,10 @@ export default defineUserConfig({
     ['meta', { name: "description", content: "Documentation for Grey, a lightweight health probing agent with native OpenTelemetry integration." }],
     ['link', { rel: 'icon', href: '/favicon.ico' }],
     ["script", {
-        defer: "",
-        src: "https://analytics.sierrasoftworks.com/script.js",
-        "data-website-id": "75074736-b79c-4060-aa8e-a3297b0e61ba",
+        async: "",
+        src: "https://analytics.sierrasoftworks.com/tracker.js",
+        "data-api": "https://analytics.sierrasoftworks.com",
+        "data-auto-capture-exceptions": "true",
     }],
   ],
 


### PR DESCRIPTION
Migrates the docs site's analytics script registration in `docs/.vuepress/config.ts` to the new SierraSoftworks tracking script:

- `defer` → `async`
- Dropped `data-website-id`
- Added `data-api="https://analytics.sierrasoftworks.com"`
- Added `data-auto-capture-exceptions="true"`
- `src` now points at `tracker.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWwFpShoYkDFjkKUYQnn45)_