### PR TITLE
fix(cluster): gossip each peer at most once per round, preferring configured addresses

### DIFF
--- a/agent/src/cluster/client.rs
+++ b/agent/src/cluster/client.rs
@@ -1,3 +1,4 @@
+use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 use std::str::FromStr;
@@ -152,37 +153,10 @@ where
         self.membership.bump_heartbeat();
         self.membership.sweep(now);
 
-        // Build the gossip target set. Prefer healthy peers up to `gossip_factor`, reserve one slot
-        // to retry an unhealthy peer that is due (so recovery is detected), and always include the
-        // configured seeds — a node forgotten after a long partition can only rejoin via a live seed.
-        let candidates = self.membership.gossip_candidates(now);
-        let mut healthy = Vec::new();
-        let mut unhealthy = Vec::new();
-        for candidate in candidates {
-            if !candidate.due {
-                continue;
-            }
-            if candidate.liveness == Liveness::Healthy {
-                healthy.push((candidate.id, candidate.address));
-            } else {
-                unhealthy.push((candidate.id, candidate.address));
-            }
-        }
-
-        let mut targets: Vec<(Option<S::Id>, T::Address)> = Vec::new();
-        for (id, addr) in sample_peers(healthy, self.gossip_factor) {
-            targets.push((Some(id), addr));
-        }
-        for (id, addr) in sample_peers(unhealthy, 1) {
-            targets.push((Some(id), addr));
-        }
         // The resolved seed addresses are maintained by the background resolver loop so we never
-        // block the gossip hot path on DNS resolution here. Seeds have no known NodeID yet.
-        for addr in self.resolved_seed_peers.read().await.iter().cloned() {
-            targets.push((None, addr));
-        }
-
-        let targets = unique_by_address(targets);
+        // block the gossip hot path on DNS resolution here.
+        let seed_addresses = self.resolved_seed_peers.read().await.clone();
+        let targets = self.build_targets(now, &seed_addresses);
         if targets.is_empty() {
             return Ok(());
         }
@@ -231,6 +205,67 @@ where
         }
 
         Ok(())
+    }
+
+    /// Builds this round's gossip target set: healthy peers up to `gossip_factor`, one slot to
+    /// retry an unhealthy peer that is due (so recovery is detected), and always the configured
+    /// seeds — a node forgotten after a long partition can only rejoin via a live seed.
+    ///
+    /// At most one address is selected per peer. [`Membership::gossip_candidates`] chooses the
+    /// single address for every discovered peer (preferring a configured seed address unless it is
+    /// failing its retry backoff while another address is eligible), and a seed address that is
+    /// known to belong to an already-targeted member is skipped rather than producing a second Syn
+    /// to the same peer in the same round.
+    fn build_targets(
+        &self,
+        now: Instant,
+        seed_addresses: &[T::Address],
+    ) -> Vec<(Option<S::Id>, T::Address)> {
+        // The single address chosen for each known peer this round: any send to that peer —
+        // including one triggered by a seed address it owns — uses this address.
+        let mut chosen: HashMap<S::Id, T::Address> = HashMap::new();
+        let mut healthy = Vec::new();
+        let mut unhealthy = Vec::new();
+        for candidate in self.membership.gossip_candidates(now) {
+            chosen.insert(candidate.id.clone(), candidate.address.clone());
+            if !candidate.due {
+                continue;
+            }
+            if candidate.liveness == Liveness::Healthy {
+                healthy.push((candidate.id, candidate.address));
+            } else {
+                unhealthy.push((candidate.id, candidate.address));
+            }
+        }
+
+        let mut targets: Vec<(Option<S::Id>, T::Address)> = Vec::new();
+        let mut targeted: HashSet<S::Id> = HashSet::new();
+        for (id, addr) in sample_peers(healthy, self.gossip_factor) {
+            targeted.insert(id.clone());
+            targets.push((Some(id), addr));
+        }
+        for (id, addr) in sample_peers(unhealthy, 1) {
+            targeted.insert(id.clone());
+            targets.push((Some(id), addr));
+        }
+
+        for addr in seed_addresses {
+            match self.membership.owner_of(addr) {
+                Some(owner) => {
+                    // The seed belongs to a discovered member: contact it once, at the member's
+                    // chosen address, and attribute the send so the address's link health (and
+                    // retry backoff) is tracked.
+                    if !targeted.insert(owner.clone()) {
+                        continue;
+                    }
+                    let addr = chosen.get(&owner).cloned().unwrap_or_else(|| addr.clone());
+                    targets.push((Some(owner), addr));
+                }
+                None => targets.push((None, addr.clone())),
+            }
+        }
+
+        unique_by_address(targets)
     }
 
     async fn receive_loop(&self) {
@@ -577,6 +612,139 @@ mod tests {
             ma.liveness_of(&nb, Instant::now()),
             Some(Liveness::Unreachable),
             "A should detect that B is online but not responding to its messages"
+        );
+    }
+
+    // ---- Per-peer target selection (one address per peer per round) ------------------------------
+
+    /// A peer that is both a configured seed and a discovered member (with a different advertised
+    /// address) must receive exactly one Syn per round, at its configured (seed) address.
+    #[tokio::test]
+    async fn build_targets_selects_a_single_address_per_peer() {
+        let a: SocketAddr = "127.0.0.1:23001".parse().unwrap();
+        let seed_b: SocketAddr = "127.0.0.1:23002".parse().unwrap();
+        let advertised_b: SocketAddr = "10.0.0.2:23002".parse().unwrap();
+        let (na, nb) = (NodeID::new(), NodeID::new());
+
+        let net = MockNet::new();
+        let ma = socket_membership(na, a);
+        ma.set_seed_addresses([seed_b]);
+        let client = mock_client(&net, na, a, vec![seed_b], ma.clone());
+
+        let now = Instant::now();
+        ma.record_inbound(&nb, seed_b, now);
+        ma.record_inbound(&nb, advertised_b, now);
+
+        let targets = client.build_targets(now, &[seed_b]);
+        assert_eq!(
+            targets,
+            vec![(Some(nb), seed_b)],
+            "the peer must be targeted exactly once, at its configured address"
+        );
+    }
+
+    /// When the configured address is failing its retry backoff and another discovered address is
+    /// eligible, the peer is contacted (once) at the eligible address instead.
+    #[tokio::test]
+    async fn build_targets_uses_discovered_address_when_seed_is_backing_off() {
+        let a: SocketAddr = "127.0.0.1:23011".parse().unwrap();
+        let seed_b: SocketAddr = "127.0.0.1:23012".parse().unwrap();
+        let advertised_b: SocketAddr = "10.0.0.2:23012".parse().unwrap();
+        let (na, nb) = (NodeID::new(), NodeID::new());
+
+        let net = MockNet::new();
+        let ma = socket_membership(na, a);
+        ma.set_seed_addresses([seed_b]);
+        let client = mock_client(&net, na, a, vec![seed_b], ma.clone());
+
+        let base = Instant::now();
+        ma.record_inbound(&nb, seed_b, base);
+        ma.record_inbound(&nb, advertised_b, base);
+
+        // An unanswered send to the seed address trips its backoff once the reply timeout passes.
+        ma.record_send(&nb, &seed_b, base + Duration::from_millis(10));
+        let later = base + Duration::from_millis(500);
+        ma.sweep(later);
+
+        let targets = client.build_targets(later, &[seed_b]);
+        assert_eq!(
+            targets,
+            vec![(Some(nb), advertised_b)],
+            "the eligible discovered address must be used, and the seed must not add a second Syn"
+        );
+    }
+
+    /// Multiple configured addresses that all belong to the same discovered peer must still result
+    /// in a single Syn per round.
+    #[tokio::test]
+    async fn build_targets_collapses_multiple_seed_addresses_of_one_peer() {
+        let a: SocketAddr = "127.0.0.1:23021".parse().unwrap();
+        let seed1_b: SocketAddr = "127.0.0.1:23022".parse().unwrap();
+        let seed2_b: SocketAddr = "10.0.0.2:23022".parse().unwrap();
+        let (na, nb) = (NodeID::new(), NodeID::new());
+
+        let net = MockNet::new();
+        let ma = socket_membership(na, a);
+        ma.set_seed_addresses([seed1_b, seed2_b]);
+        let client = mock_client(&net, na, a, vec![seed1_b, seed2_b], ma.clone());
+
+        let base = Instant::now();
+        ma.record_inbound(&nb, seed1_b, base + Duration::from_millis(10));
+        ma.record_inbound(&nb, seed2_b, base);
+
+        let targets = client.build_targets(base + Duration::from_millis(10), &[seed1_b, seed2_b]);
+        assert_eq!(
+            targets,
+            vec![(Some(nb), seed1_b)],
+            "both configured addresses belong to the same peer, so only one may be contacted"
+        );
+    }
+
+    /// A seed address that cannot be attributed to any discovered member is still always contacted
+    /// (it is the only way a forgotten node can rejoin the cluster).
+    #[tokio::test]
+    async fn build_targets_keeps_unattributed_seed_addresses() {
+        let a: SocketAddr = "127.0.0.1:23031".parse().unwrap();
+        let seed: SocketAddr = "127.0.0.1:23032".parse().unwrap();
+        let na = NodeID::new();
+
+        let net = MockNet::new();
+        let ma = socket_membership(na, a);
+        ma.set_seed_addresses([seed]);
+        let client = mock_client(&net, na, a, vec![seed], ma.clone());
+
+        let targets = client.build_targets(Instant::now(), &[seed]);
+        assert_eq!(
+            targets,
+            vec![(None, seed)],
+            "an unknown seed address must be contacted anonymously as before"
+        );
+    }
+
+    /// A seed-owning member that was not picked by the random per-round sampling is still contacted
+    /// every round (seeds are never skipped), attributed to the member so its link health is
+    /// tracked.
+    #[tokio::test]
+    async fn build_targets_attributes_unsampled_seed_members() {
+        let a: SocketAddr = "127.0.0.1:23041".parse().unwrap();
+        let seed_b: SocketAddr = "127.0.0.1:23042".parse().unwrap();
+        let (na, nb) = (NodeID::new(), NodeID::new());
+
+        let net = MockNet::new();
+        let ma = socket_membership(na, a);
+        ma.set_seed_addresses([seed_b]);
+        // A gossip factor of zero means the healthy sampling never picks the peer, leaving the
+        // seed loop as the only path that can contact it.
+        let client = mock_client(&net, na, a, vec![seed_b], ma.clone()).with_gossip_factor(0);
+
+        let now = Instant::now();
+        ma.record_inbound(&nb, seed_b, now);
+
+        let targets = client.build_targets(now, &[seed_b]);
+        assert_eq!(
+            targets,
+            vec![(Some(nb), seed_b)],
+            "the seed contact must be attributed to its member so sends feed its link health"
         );
     }
 }

--- a/agent/src/cluster/membership.rs
+++ b/agent/src/cluster/membership.rs
@@ -254,7 +254,9 @@ pub struct GossipCandidate<Id, Addr> {
     pub id: Id,
     pub address: Addr,
     pub liveness: Liveness,
-    /// False when this address is currently in backoff and should only be retried opportunistically.
+    /// False when this address is currently in backoff and should only be retried
+    /// opportunistically. Because eligible addresses are always selected first, this is only
+    /// false when *every* known address for the peer is in backoff.
     pub due: bool,
 }
 
@@ -563,18 +565,27 @@ where
         sample
     }
 
-    /// The peers (and the single best address for each) we should consider gossiping with this round,
-    /// annotated with liveness and whether the address is out of backoff.
+    /// The peers (and the single address selected for each) we should consider gossiping with this
+    /// round, annotated with liveness and whether the address is out of backoff.
+    ///
+    /// Exactly one address is selected per peer, so a peer discovered at several addresses is never
+    /// sent more than one message per round. A configured seed address always wins while it is
+    /// eligible (out of retry backoff); when it is failing that check and another address is
+    /// eligible, the eligible address is selected instead, and when no address is eligible at all
+    /// the seed address wins again. Remaining ties are broken by the most recent positive signal.
     pub fn gossip_candidates(&self, now: Instant) -> Vec<GossipCandidate<Id, Addr>> {
         let members = self.members.read().unwrap();
+        let seeds = self.seeds.read().unwrap();
         let window = self.working_window(members.len());
         let mut out = Vec::new();
         for (id, member) in members.iter() {
-            // Pick the best address: prefer working ones, ranked by the most recent good signal.
-            let best = member
-                .addresses
-                .iter()
-                .max_by_key(|(_, h)| h.last_good());
+            let best = member.addresses.iter().max_by_key(|(addr, health)| {
+                (
+                    now >= health.backoff_until,
+                    seeds.contains(addr),
+                    health.last_good(),
+                )
+            });
             if let Some((addr, health)) = best {
                 out.push(GossipCandidate {
                     id: id.clone(),
@@ -585,6 +596,15 @@ where
             }
         }
         out
+    }
+
+    /// The member known to own `addr`, if any — used to attribute a configured seed address to an
+    /// already-discovered peer so that peer is not gossiped more than once per round.
+    pub fn owner_of(&self, addr: &Addr) -> Option<Id> {
+        let members = self.members.read().unwrap();
+        members
+            .iter()
+            .find_map(|(id, member)| member.addresses.contains_key(addr).then(|| id.clone()))
     }
 
     /// Per-round maintenance: account for unconfirmed sends (advancing per-address backoff), emit
@@ -1009,6 +1029,91 @@ mod tests {
             !advertised.contains(&stale.to_string()),
             "an address sent to long ago must not be confirmed by an unrelated reply"
         );
+    }
+
+    #[test]
+    fn gossip_candidates_select_one_address_per_peer_preferring_seeds() {
+        let m = membership();
+        let base = Instant::now();
+        let seed = addr("10.0.0.2:8888");
+        let advertised = addr("10.1.0.2:8888");
+        m.set_seed_addresses([seed]);
+
+        // The advertised address has the freshest signal, but the configured seed address is
+        // eligible, so it must still be the one selected.
+        m.record_inbound(&nid(2), seed, base);
+        m.record_inbound(&nid(2), advertised, base + Duration::from_secs(1));
+
+        let candidates = m.gossip_candidates(base + Duration::from_secs(1));
+        assert_eq!(candidates.len(), 1, "exactly one address per peer per round");
+        assert_eq!(
+            candidates[0].address, seed,
+            "a configured seed address must be preferred while it is eligible"
+        );
+        assert!(candidates[0].due);
+    }
+
+    #[test]
+    fn gossip_candidates_fall_back_when_seed_address_is_backing_off() {
+        let m = membership();
+        let base = Instant::now();
+        let seed = addr("10.0.0.2:8888");
+        let advertised = addr("10.1.0.2:8888");
+        m.set_seed_addresses([seed]);
+
+        m.record_inbound(&nid(2), seed, base);
+        m.record_inbound(&nid(2), advertised, base);
+
+        // A send to the seed address that goes unanswered past the reply timeout trips its retry
+        // backoff (the circuit-breaker check for that address)...
+        m.record_send(&nid(2), &seed, base + Duration::from_millis(10));
+        let later = base + Duration::from_secs(2);
+        m.sweep(later);
+
+        // ...so the other, still-eligible address must be selected in its place.
+        let candidates = m.gossip_candidates(later);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].address, advertised,
+            "an eligible discovered address must replace a seed address that is backing off"
+        );
+        assert!(candidates[0].due);
+    }
+
+    #[test]
+    fn gossip_candidates_return_seed_address_when_no_address_is_eligible() {
+        let m = membership();
+        let base = Instant::now();
+        let seed = addr("10.0.0.2:8888");
+        let advertised = addr("10.1.0.2:8888");
+        m.set_seed_addresses([seed]);
+
+        m.record_inbound(&nid(2), seed, base);
+        m.record_inbound(&nid(2), advertised, base);
+        m.record_send(&nid(2), &seed, base + Duration::from_millis(10));
+        m.record_send(&nid(2), &advertised, base + Duration::from_millis(10));
+        let later = base + Duration::from_secs(2);
+        m.sweep(later);
+
+        let candidates = m.gossip_candidates(later);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].address, seed,
+            "with every address in backoff the configured address is still the one to retry"
+        );
+        assert!(
+            !candidates[0].due,
+            "a peer with no eligible address is only an opportunistic target"
+        );
+    }
+
+    #[test]
+    fn owner_of_attributes_known_addresses_to_their_member() {
+        let m = membership();
+        let a = addr("10.0.0.2:8888");
+        m.record_inbound(&nid(2), a, Instant::now());
+        assert_eq!(m.owner_of(&a), Some(nid(2)));
+        assert_eq!(m.owner_of(&addr("10.9.9.9:1")), None);
     }
 
     #[test]

--- a/docs/guide/clustering.md
+++ b/docs/guide/clustering.md
@@ -351,6 +351,12 @@ capabilities:
   `cluster.health.transition` event. Gossip prefers healthy links and backs off unhealthy ones, while
   always contacting seeds.
 
+A peer may be known at several addresses at once (a configured seed address, an advertised address,
+and the source addresses of its gossip). Each gossip round selects **exactly one** of them per peer,
+so a multi-homed peer never receives duplicate gossip in the same round. An address configured in
+`peers` is always preferred; only while it is failing its retry backoff *and* another known address
+is eligible does gossip route around it, returning to the configured address once it recovers.
+
 Each peer is summarised with an aggregate health, the best state across all of its addresses:
 **Online** (a confirmed two-way link), **Transitive** (alive in the cluster but no confirmed direct
 link), **Suspect** (heartbeats slowing), or **Offline** (not heard from for a long time).


### PR DESCRIPTION
## Problem

When gossiping/clustering is enabled, Grey can discover multiple endpoints for the same peer (different advertised addresses, static seed configuration, gossip source addresses, ...). A single gossip round could then send several `Syn` requests to the same peer:

- The per-member candidate selection picks one address per discovered member, but the always-contacted resolved seed addresses were appended unconditionally with no peer attribution, so a peer that is both a configured seed and a discovered member (under a different address) received two `Syn`s per round.
- Two configured seed addresses pointing at the same peer (e.g. IPv4 + IPv6, or two names) likewise both received a `Syn`.
- `unique_by_address` only deduplicated *identical* addresses, not distinct addresses of the same peer.

## Fix

Each gossip round now selects **exactly one address per peer**:

- `Membership::gossip_candidates` ranks each member's addresses by `(eligible, configured-seed, most recent good signal)`. An address hard-coded in `cluster.peers` is therefore always used while it is out of its retry backoff (the per-address circuit-breaker); only when it is failing that check **and** another discovered address is eligible does gossip route around it, and when no address is eligible at all the configured address is preferred again (so it is the one retried once due).
- The gossip client's new `build_targets` skips a resolved seed address that is known to belong to an already-targeted member instead of producing a second `Syn`, collapses multiple seed addresses owned by the same member into one contact, and routes seed contacts for known-but-unsampled members through the member's single chosen address — now attributed to the member (previously anonymous), so those sends feed the address's link health and retry backoff.

Behaviour that is deliberately preserved:

- Seed peers are still contacted every round (the partition-healing guarantee).
- Seed addresses that cannot be attributed to any discovered member are still contacted anonymously, as before.

## Testing

- New unit tests for `Membership::gossip_candidates` covering seed preference while eligible, fallback to an eligible discovered address when the seed is backing off, and returning to the seed when nothing is eligible, plus `owner_of` attribution.
- New unit tests for `GossipClient::build_targets` covering single-target-per-peer for seed+advertised peers, backoff fallback, collapsing multiple seed addresses of one peer, keeping unattributed seeds, and attributing unsampled seed members.
- `cargo test -p grey`: all cluster tests pass (182 passed; the only failures are the 5 pre-existing UI-asset tests that require a trunk-built `ui/dist`, which also fail on `main` in this environment).

Docs: added a paragraph to `docs/guide/clustering.md` describing the one-address-per-peer selection and configured-address preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dPLqZg6wS47Fw58jaCHxE

---
_Generated by [Claude Code](https://claude.ai/code/session_013dPLqZg6wS47Fw58jaCHxE)_