### PR TITLE
Replace Umami analytics with the new Analytics battery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,10 +5375,11 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#89854ad16dde3c4af6b9fc6e87ffa0d64b158fc1"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#cf35de7fad4e013391383219abed2f4d58abe963"
 dependencies = [
  "chrono",
  "hex",
+ "iana-time-zone",
  "opentelemetry",
  "opentelemetry-appender-tracing",
  "opentelemetry-otlp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ tonic = { version = "0.14", features = [
 tonic-health = "0.14"
 tracing = "0.1.44"
 tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batteries-rs.git", features = [
-  "umami",
+  "analytics",
   "opentelemetry",
 ] }
 trust-dns-resolver = { version = "0.23", features = ["tokio-runtime"] }

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -47,10 +47,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let telemetry = tracing_batteries::Session::new("grey", version!("v"))
         .with_battery(tracing_batteries::OpenTelemetry::new(""))
-        .with_battery(tracing_batteries::Umami::new(
+        .with_battery(tracing_batteries::Analytics::new(
             "https://analytics.sierrasoftworks.com",
-            "75074736-b79c-4060-aa8e-a3297b0e61ba",
-        ).with_initial_page("/.app/"));
+        ));
 
     let state = state::State::new(&args.config).await?;
 


### PR DESCRIPTION
## Summary

Migrates `grey` off the retired Umami analytics battery and onto the new self-hosted `Analytics` battery shipped by `tracing-batteries-rs`, pointing at `https://analytics.sierrasoftworks.com`.

- **Cargo.toml**: swapped the `tracing-batteries` git dependency's `umami` cargo feature for `analytics`.
- **agent/src/main.rs**: replaced `tracing_batteries::Umami::new(server_url, website_id)` with `tracing_batteries::Analytics::new(server_url)`. The new battery takes only a server URL (no website ID), and the old `/.app/` page-path convention (previously set via `.with_initial_page("/.app/")`) is retired — the battery now defaults to page `/` on a virtual hostname of `{service}.app`, so that call was dropped entirely.
- **Cargo.lock**: bumped the `tracing-batteries` git pin to latest `main` to pick up the `Analytics` battery.

## Why

Umami is being retired in favor of the new self-hosted analytics server, and the `tracing-batteries` library now exposes this via an `Analytics` battery instead of the old `Umami` battery/feature.

## Test plan

- [x] `cargo update tracing-batteries` — bumped Cargo.lock pin successfully
- [x] `cargo check -p grey --bin grey` — passes (only pre-existing, unrelated deprecation warnings)
- [x] `cargo check -p grey-api` — passes
- [x] `cargo test -p grey` — 182 passed; 5 unrelated pre-existing failures caused by this sandbox lacking a built `ui/dist` (frontend requires `trunk`, not available here), not by this change
- [x] `cargo clippy -p grey --bin grey` — passes, only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NutKW958x2VF9rVagycenv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NutKW958x2VF9rVagycenv)_