### PR TITLE
Update tracing-batteries to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5375,7 +5375,7 @@ dependencies = [
 [[package]]
 name = "tracing-batteries"
 version = "0.1.0"
-source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#cf35de7fad4e013391383219abed2f4d58abe963"
+source = "git+https://github.com/sierrasoftworks/tracing-batteries-rs.git#e1f168e57bb74c146405cf74d6120902fe677926"
 dependencies = [
  "chrono",
  "hex",


### PR DESCRIPTION
Bumps the `tracing-batteries` git dependency pin in `Cargo.lock` to the latest commit on its main branch.

- Old pin: `cf35de7fad4e013391383219abed2f4d58abe963`
- New pin: `e1f168e57bb74c146405cf74d6120902fe677926`

## Verification
- `cargo update tracing-batteries` — updated the lockfile pin as expected.
- `cargo check -p grey-api` — passes cleanly.
- `cargo check -p grey --bin grey` (with a temporary empty `ui/dist/.keep` stub, removed afterwards) — passes, with 2 pre-existing deprecation warnings in `agent/src/cluster/encryption/aes256gcm.rs` unrelated to this change.
- `grey-ui` crate check and asset-serving tests were skipped — pre-existing/environmental sandbox limitations (missing imports in grey-ui, no `trunk` available to build real UI assets), not caused by this dependency bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NutKW958x2VF9rVagycenv

---
_Generated by [Claude Code](https://claude.ai/code/session_01NutKW958x2VF9rVagycenv)_