### PR TITLE
fix: Mark probes which exceed their timeout as failed

### DIFF
--- a/agent/src/probe_runner.rs
+++ b/agent/src/probe_runner.rs
@@ -132,56 +132,56 @@ impl ProbeRunner {
             .record("probe.checks", debug(&probe.checks))
             .record("probe.tags", debug(&probe.tags));
 
-        let result = async {
-            match tokio::time::timeout(
-                probe.policy.timeout,
-                async {
-                    while !self.cancel.load(std::sync::atomic::Ordering::Relaxed)
+        let result = match tokio::time::timeout(
+            probe.policy.timeout,
+            async {
+                while !self.cancel.load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    sample.start_time = chrono::Utc::now();
+                    debug!(
+                        "Running probe attempt {}/{}...",
+                        sample.retries + 1, total_attempts,
+                    );
+                    match self.run_attempt(&probe, &mut sample).await
                     {
-                        sample.start_time = chrono::Utc::now();
-                        debug!(
-                            "Running probe attempt {}/{}...",
-                            sample.retries + 1, total_attempts,
-                        );
-                        match self.run_attempt(&probe, &mut sample).await
-                        {
-                            Ok(res) => return Ok(res),
-                            Err(err) => {
-                                debug!("Probe failed: {}", err);
-                                sample.retries += 1;
-                                sample.message = err.to_string();
-                                if sample.retries >= total_attempts {
-                                    return Err(err);
-                                }
+                        Ok(res) => return Ok(res),
+                        Err(err) => {
+                            debug!("Probe failed: {}", err);
+                            sample.retries += 1;
+                            sample.message = err.to_string();
+                            if sample.retries >= total_attempts {
+                                return Err(err);
                             }
                         }
                     }
+                }
 
-                    Err("Probe was cancelled.".into())
-            }).await {
-                Ok(Ok(res)) => return Ok(res),
-                Ok(Err(err)) => {
-                    debug!("Probe failed: {}", err);
-                    if sample.retries + 1 == total_attempts {
-                        warn!("Probe failed after {} retries: {}", sample.retries, err);
-                    }
-                    return Err(err);
+                Err("Probe was cancelled.".into())
+        }).await {
+            Ok(Ok(res)) => Ok(res),
+            Ok(Err(err)) => {
+                debug!("Probe failed: {}", err);
+                if sample.retries >= total_attempts {
+                    warn!("Probe failed after {} attempts: {}", sample.retries, err);
                 }
-                Err(err) => {
-                    debug!("Probe timed out: {}", err);
-                    if sample.retries == total_attempts {
-                        warn!("Probe timed out after {} retries: {}", sample.retries, err);
-                        if sample.message.is_empty() {
-                            sample.message = format!("Probe timed out after {} retries .", sample.retries);
-                        }
-                        return Err(format!("Probe timed out after {} retries.", sample.retries).into());
-                    }
-                }
+                Err(err)
             }
-
-            Ok(())
-        }
-        .await;
+            // The timeout bounds the whole retry loop, so when it elapses the in-flight attempt
+            // was dropped before its checks could be evaluated (and the retry counter can never
+            // have reached the attempt limit — exhaustion returns through the arm above). The
+            // probe therefore always fails here, however many attempts had completed.
+            Err(_) => {
+                let message = format!(
+                    "Probe timed out after {} (attempt {}/{}).",
+                    humantime::format_duration(probe.policy.timeout),
+                    sample.retries + 1,
+                    total_attempts
+                );
+                warn!("{message}");
+                sample.message = message.clone();
+                Err(message.into())
+            }
+        };
 
 
         Span::current().record("probe.attempts", sample.retries);
@@ -265,5 +265,41 @@ impl ProbeRunner {
         }
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::targets::TargetType;
+
+    /// A probe whose target stalls past the policy timeout must be recorded as a failure. The
+    /// timeout arm used to fall through to the success path (the retry counter can never have
+    /// reached the attempt limit once the deadline drops the in-flight attempt), so a stalled
+    /// probe — e.g. a DNS lookup against an unresponsive resolver — was stored as passing even
+    /// though none of its checks had been evaluated.
+    #[tokio::test]
+    async fn timed_out_probe_is_marked_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State::test(dir.path().to_path_buf()).await;
+
+        let mut probe = state.get_config().probes[0].clone();
+        probe.policy.timeout = std::time::Duration::from_millis(50);
+        probe.target = TargetType::Hang;
+
+        let runner = ProbeRunner::new(probe.clone(), state.clone());
+        let result = runner.run_scheduled_execution().await;
+        let err = result.expect_err("a timed-out probe must report an error").to_string();
+        assert!(err.contains("timed out"), "unexpected error: {err}");
+
+        let states = state.get_probe_states().await.unwrap();
+        let stored = states.get(&probe.name).expect("the probe state to be stored");
+        let bucket = stored.history.last().expect("a history bucket to be recorded");
+        assert!(!bucket.pass, "a timed-out probe must be recorded as failing");
+        assert!(bucket.message.contains("timed out"), "unexpected message: {}", bucket.message);
+        assert!(
+            bucket.validations.is_empty(),
+            "no checks ran before the deadline, so no validations should be recorded"
+        );
     }
 }

--- a/agent/src/targets/mod.rs
+++ b/agent/src/targets/mod.rs
@@ -21,6 +21,10 @@ pub trait Target: Display {
 pub enum TargetType {
     #[cfg(test)]
     Mock,
+    /// A test-only target that never completes, standing in for a real target that has
+    /// stalled (e.g. a DNS lookup against an unresponsive resolver).
+    #[cfg(test)]
+    Hang,
     Dns(dns::DnsTarget),
     Grpc(grpc::GrpcTarget),
     Http(http::HttpTarget),
@@ -41,6 +45,8 @@ impl TargetType {
         match self {
             #[cfg(test)]
             TargetType::Mock => Ok(Sample::default()),
+            #[cfg(test)]
+            TargetType::Hang => std::future::pending().await,
             TargetType::Dns(target) => target.run(cancel).await,
             TargetType::Grpc(target) => target.run(cancel).await,
             TargetType::Http(target) => target.run(cancel).await,
@@ -56,6 +62,8 @@ impl Display for TargetType {
         match self {
             #[cfg(test)]
             TargetType::Mock => write!(f, "Mock"),
+            #[cfg(test)]
+            TargetType::Hang => write!(f, "Hang"),
             TargetType::Dns(target) => write!(f, "{}", target),
             TargetType::Grpc(target) => write!(f, "{}", target),
             TargetType::Http(target) => write!(f, "{}", target),
@@ -71,6 +79,8 @@ impl Target for TargetType {
         match self {
             #[cfg(test)]
             TargetType::Mock => Ok(Sample::default()),
+            #[cfg(test)]
+            TargetType::Hang => std::future::pending().await,
             TargetType::Dns(target) => target.run(cancel).await,
             TargetType::Grpc(target) => target.run(cancel).await,
             TargetType::Http(target) => target.run(cancel).await,


### PR DESCRIPTION
## Summary

Probes whose target stalled past the policy timeout were being recorded as **passing**, with no checks evaluated and no error on their trace. This was observed as DNS probes performing SPF validation against `sierrasoftworks.com` running up to their 5s timeout and then "completing" with no `probe.validate` trace events — and never being marked as failed.

## Root cause

In `ProbeRunner::run_scheduled_execution`, `probe.policy.timeout` wraps the *entire* retry loop, and that loop returns the moment its retry counter reaches the attempt limit. As a result, whenever the timer elapsed mid-attempt the counter was necessarily still below the limit, so the guard on the elapsed-timeout arm (`if sample.retries == total_attempts`) could never be true. Control fell through to the success path, which stamped the sample with `pass = true` and "Probe completed successfully." — even though the in-flight attempt had been dropped before any of the probe's checks ran.

## Changes

- An elapsed timeout now always fails the probe. The stored result and probe error read `Probe timed out after <timeout> (attempt <n>/<total>).`, a warning event is emitted on the `probe.run` span, and the span itself now records the error (so traces no longer show a "successful" run that never evaluated its conditions).
- Fixed the attempt-exhaustion warning in the sibling arm, whose off-by-one condition (`retries + 1 == total_attempts`) could also never fire.
- Added a test-only `Hang` target (a target that never completes, standing in for a stalled DNS lookup) and a regression test asserting that a timed-out probe is stored as failing, with a timeout message and no validations. The test fails against the previous fall-through behaviour.

## Testing

- `cargo test -p grey` — 184 passed; the only failures are the 5 pre-existing `api::` tests that require the CI-built `ui/dist` artifact (they fail identically on `main` in this environment).
- Verified the new regression test fails when the old timeout arm is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HyvRtvX5gsdm7Z627HjmBX

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyvRtvX5gsdm7Z627HjmBX)_