### PR TITLE
fix: only send webhooks on health transitions, not every token change

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Pre-compiled binaries for other platforms are available from the
 - **Expressive checks.** Validate responses with [`filt-rs`](https://docs.rs/filt-rs)
   expressions: ranges, regular expressions, membership, and relationships between fields.
 - **Webhook notifications.** Deliver a signed JSON event to incident-management and
-  automation tools whenever a probe or cron changes state, filtered with the same
-  [`filt-rs`](https://docs.rs/filt-rs) expression language as checks.
+  automation tools whenever a probe or cron crosses between healthy and unhealthy, filtered
+  with the same [`filt-rs`](https://docs.rs/filt-rs) expression language as checks.
 - **Native OpenTelemetry.** Export traces (with propagation) to any OTLP endpoint.
 - **Built-in status page.** An optional, brandable status page with customer-facing
   incident management.

--- a/agent/src/notify.rs
+++ b/agent/src/notify.rs
@@ -1,6 +1,13 @@
 //! Webhook notifications: a background task that watches the cluster-pooled probe and cron state for
-//! transitions and delivers a signed JSON [`grey_api::WebhookEvent`] to every configured endpoint
-//! whose filter matches.
+//! *health* transitions — an entity crossing between healthy and unhealthy — and delivers a signed
+//! JSON [`grey_api::WebhookEvent`] to every configured endpoint whose filter matches.
+//!
+//! Only a crossing of the health axis notifies. Movement *within* a health class does not — most
+//! importantly a cron cycling `succeeded` → `running` → `succeeded` on every run, which reads as
+//! healthy throughout (`pending`/`running`/`succeeded` are all passing) and would otherwise deliver
+//! two events per run. A frequently-scheduled job therefore produces no traffic until it actually
+//! breaks. The specific state an entity moved to is still carried on the event (`state.current` /
+//! `state.previous`); it just isn't what gates delivery.
 //!
 //! Detection is poll-based rather than event-driven, because some transitions are driven purely by
 //! the passage of time rather than by a sample or a check-in: a probe recovers once no failure has
@@ -150,11 +157,15 @@ impl Notifier {
 }
 
 /// Records the current status of every probe and cron against `last`, returning a
-/// [`WebhookEvent`] for each entity whose status token changed since the previous pass.
+/// [`WebhookEvent`] for each entity that crossed between healthy and unhealthy since the previous
+/// pass.
 ///
-/// `last` is always updated to the current status (so it tracks the pooled view continuously); events
-/// are only produced when `notify` is set, when the entity already had a recorded baseline, and when
-/// its token actually changed — so the first time an entity is seen it is seeded silently.
+/// `last` is always updated to the current status (so it tracks the pooled view continuously,
+/// including token changes that stay within one health class); events are only produced when
+/// `notify` is set, when the entity already had a recorded baseline, and when its *health* flipped —
+/// so the first time an entity is seen it is seeded silently, and same-health churn (a healthy cron
+/// moving `succeeded` ⇆ `running` as runs come and go) never notifies. The event still reports the
+/// specific tokens it moved between.
 fn detect_transitions(
     last: &mut HashMap<String, Status>,
     now: DateTime<Utc>,
@@ -166,13 +177,15 @@ fn detect_transitions(
 
     for (name, probe) in probes {
         let key = format!("probe:{name}");
-        // The token is derived from the cluster-converged streak (recovery settling included).
+        // Both the token and the healthy axis it collapses to are read from the cluster-converged
+        // streak, which already folds in the recovery settling window; delivery is gated on the
+        // healthy axis so only a genuine passing⇆failing crossing notifies.
         let token = probe.status_token();
         let healthy = probe.passing();
 
         if notify
             && let Some(previous) = last.get(&key)
-            && previous.token != token
+            && previous.healthy != healthy
         {
             events.push(WebhookEvent::for_probe(
                 new_id(),
@@ -188,13 +201,17 @@ fn detect_transitions(
 
     for (name, cron) in crons {
         let key = format!("cron:{name}");
+        // The derived health already accounts for the schedule grace and `max_duration` settling
+        // windows. Delivery is gated on the healthy axis, so the `succeeded`/`running` churn a normal
+        // run produces (all healthy) is silent — only a crossing into or out of `failed`/`missing`/
+        // `stuck` notifies.
         let health = cron.health(now);
         let token = health.as_str();
         let healthy = health.passing();
 
         if notify
             && let Some(previous) = last.get(&key)
-            && previous.token != token
+            && previous.healthy != healthy
         {
             events.push(WebhookEvent::for_cron(
                 new_id(),
@@ -432,6 +449,21 @@ mod tests {
         cron
     }
 
+    /// A cron on a fixed 60s schedule with a single run of `status` that started at `started_at`, so
+    /// its health at a chosen `now` can be steered across the health axis (a stale `succeeded` run
+    /// reads as `missing`, a `failed` run as `failed`, and so on).
+    fn cron_at(status: CronStatus, started_at: DateTime<Utc>) -> Cron {
+        let mut cron = Cron::from_config(
+            "job",
+            HashMap::new(),
+            CronSchedule::Every(Duration::from_secs(60)),
+            None,
+            None,
+        );
+        cron.push_run(CronRun { started_at, status, duration: None });
+        cron
+    }
+
     fn webhook(endpoint: String, secret: Option<&str>, filter: &str) -> WebhookConfig {
         WebhookConfig {
             name: Some("test".into()),
@@ -505,6 +537,49 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].state.previous, "succeeded");
         assert_eq!(events[0].state.current, "failed");
+    }
+
+    /// Delivery is gated on the health axis, not the specific token: a cron churning through healthy
+    /// sub-states (a normal run: succeeded → running → succeeded) stays silent, and so does churn
+    /// between unhealthy sub-states (failed → missing). Only the crossings out of and back into
+    /// healthy fire — each exactly once, carrying the specific tokens involved. This is the flood
+    /// that previously delivered two events on every run of a perfectly healthy job.
+    #[test]
+    fn notifies_only_on_health_axis_crossings() {
+        let mut last = HashMap::new();
+        let now = Utc::now();
+        let probes = HashMap::new();
+        let map = |cron: Cron| HashMap::from([("job".to_string(), cron)]);
+
+        // Seed healthy (a completed run).
+        let succeeded = map(cron_at(CronStatus::Succeeded, now));
+        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true).is_empty());
+
+        // A new run starts — running is still healthy, so nothing fires...
+        let running = map(cron_at(CronStatus::Running, now));
+        assert!(detect_transitions(&mut last, now, &probes, &running, true).is_empty());
+        // ...and completing it (back to succeeded) is still healthy: still silent.
+        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true).is_empty());
+
+        // The run fails: healthy -> unhealthy fires exactly one event.
+        let failed = map(cron_at(CronStatus::Failed, now));
+        let events = detect_transitions(&mut last, now, &probes, &failed, true);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].state.previous, "succeeded");
+        assert_eq!(events[0].state.current, "failed");
+
+        // A stale on-time run then reads as `missing` — unhealthy -> unhealthy is silent.
+        let missing = map(cron_at(CronStatus::Succeeded, now - chrono::Duration::seconds(120)));
+        assert_eq!(missing["job"].health(now), grey_api::CronHealth::Missing);
+        assert!(detect_transitions(&mut last, now, &probes, &missing, true).is_empty());
+
+        // Finally a fresh run succeeds: unhealthy -> healthy fires one event, reporting the specific
+        // token (`missing`) it recovered from rather than the older `failed`.
+        let recovered = map(cron_at(CronStatus::Succeeded, now));
+        let events = detect_transitions(&mut last, now, &probes, &recovered, true);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].state.previous, "missing");
+        assert_eq!(events[0].state.current, "succeeded");
     }
 
     #[test]

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -176,8 +176,9 @@ cluster:
 You can read more about clustering in the [Clustering](../clustering/README.md) section of the documentation.
 
 ## Webhooks
-Grey can notify external systems whenever a probe or cron changes state, which is handy for wiring
-Grey into incident-management platforms, chat tools, or your own automation. Each webhook declares a
+Grey can notify external systems whenever a probe or cron crosses between healthy and unhealthy,
+which is handy for wiring Grey into incident-management platforms, chat tools, or your own
+automation. Each webhook declares a
 destination `endpoint`, an optional shared `secret` used to sign deliveries, an optional set of extra
 `headers`, and a `filter` (in the same [`filt-rs`](../checks/README.md) language as `checks`) that
 selects which events it receives.

--- a/docs/guide/webhooks.md
+++ b/docs/guide/webhooks.md
@@ -18,14 +18,21 @@ A full, runnable example lives in [`example/webhooks.yml`](https://github.com/Si
 
 ## What triggers a notification
 Grey continuously re-derives the displayed state of every probe and cron — exactly the state the
-status page renders — and sends an event whenever an entity's status changes:
+status page renders — and sends an event whenever an entity crosses between **healthy** and
+**unhealthy**. Movement *within* a health class is not notified, so a healthy job running on a tight
+schedule does not produce a stream of events.
 
-- **Probes** transition between `passing` and `failing`. The `failing` state includes a probe that
-  has stopped responding: recovery is implicit, so a probe reads as failing until no failure has been
-  observed for the recovery window, then transitions back to `passing`.
-- **Crons** transition between the [cron health states](./crons.md): `pending`, `running`,
-  `succeeded`, `failed`, `missing` (a run was not started in time), and `stuck` (a run is
-  overrunning its `max_duration`).
+- **Probes** are healthy while `passing` and unhealthy while `failing`. The `failing` state includes
+  a probe that has stopped responding: recovery is implicit, so a probe reads as failing until no
+  failure has been observed for the recovery window, then transitions back to `passing`.
+- **Crons** are healthy while `pending`, `running`, or `succeeded`, and unhealthy while `failed`,
+  `missing` (a run was not started in time), or `stuck` (a run is overrunning its `max_duration`).
+  An event fires only when a cron crosses between those two groups — a normal run cycling
+  `succeeded` → `running` → `succeeded` stays healthy throughout and is silent. The specific state
+  it moved to is carried in `state.current` (and the health axis in `state.healthy`).
+
+The recovery window (probes) and the schedule grace / `max_duration` (crons) act as a settling time
+on these transitions, so a transient blip that clears within those windows never produces an event.
 
 Because state is re-derived on a short cadence, both *event-driven* changes (a fresh probe sample or
 cron check-in) and *time-driven* changes (a probe recovering, or a cron run going missing) are

--- a/example/webhooks.yml
+++ b/example/webhooks.yml
@@ -2,9 +2,11 @@
 # This example demonstrates `webhooks`: state-change notifications that let Grey integrate
 # with incident-management platforms and other automation.
 #
-# Whenever a probe flips between passing and failing, or a cron changes health (succeeded,
-# failed, missing, overrunning, ...), Grey delivers a JSON event to each configured endpoint
-# whose `filter` matches it. The body and headers are documented in docs/guide/webhooks.md;
+# Whenever a probe or cron crosses between healthy and unhealthy — a probe flipping between
+# passing and failing, or a cron failing / going missing / overrunning (and recovering from any
+# of those) — Grey delivers a JSON event to each configured endpoint whose `filter` matches it.
+# A normal run of a healthy cron (succeeded -> running -> succeeded) stays healthy throughout and
+# is not notified. The body and headers are documented in docs/guide/webhooks.md;
 # in short, every delivery carries:
 #
 #   POST <endpoint>


### PR DESCRIPTION
## Problem

Grey was sending a very large volume of webhook requests.

The notifier (`agent/src/notify.rs::detect_transitions`) fired an event whenever an entity's derived **status token** changed (`previous.token != token`). For crons the token is the full six-state `CronHealth` (`pending`/`running`/`succeeded`/`failed`/`missing`/`stuck`), and `pending`/`running`/`succeeded` all read as **healthy** (`CronHealth::passing()`).

A normal cron run therefore cycles `succeeded → running → succeeded` — three healthy tokens — so **every run of every healthy cron delivered two webhook events** (`succeeded→running` and `running→succeeded`). A frequently-scheduled job that reports both a `running` and a terminal check-in flooded every configured endpoint, even while perfectly healthy.

## Fix

Gate delivery on the **health axis** flipping (`previous.healthy != healthy`) rather than the specific token, so an event fires only on a genuine healthy↔unhealthy crossing — exactly the transitions operators care about (a probe failing/recovering; a cron failing, going missing, or overrunning, and recovering from any of those).

- **Probes** are unaffected: their token (`passing`/`failing`) already maps 1:1 onto the health axis.
- **Crons** no longer notify on within-health churn (`succeeded ⇆ running` as runs come and go, or `failed → missing` while staying unhealthy). Only the crossings in and out of the healthy group fire.

The settling windows that were already folded into the derived health continue to govern *when* a crossing happens, so transitions still account for a settling time in both directions:

- **Probes** — the streak's recovery window debounces `failing → passing`; per-sample `retries` absorb transient blips before a failure is even recorded.
- **Crons** — the schedule `grace` gates `→ missing`, and `max_duration` gates `→ stuck`.

The event payload is unchanged: `state.current` / `state.previous` still carry the specific tokens the entity moved between (and `state.healthy` / `state.was_healthy` the collapsed axis), so a consumer still learns the exact failure mode.

## Tests

- Added `notifies_only_on_health_axis_crossings`: a cron cycling `succeeded → running → succeeded` produces **no** events, `failed → missing` (unhealthy→unhealthy) is silent, and only the crossings out of and back into healthy fire — each exactly once, carrying the right tokens.
- Existing notify and `grey-api` webhook/cron tests still pass.

## Docs

Updated `docs/guide/webhooks.md`, `docs/guide/configuration.md`, `example/webhooks.yml`, and the `README.md` feature bullet to describe firing on healthy↔unhealthy crossings (and to note that a healthy cron's normal run cycle is silent).

## Note / possible follow-up

A cron that *fails on every run* still emits two events per cycle (`failed → running` counts as a recovery the instant a new run starts, then `running → failed`), because `running` is classified as healthy by the shared health model the status page also uses. This is unchanged from before and is not the source of the reported flood. If desired, a follow-up could treat a cron recovery as requiring a *successful* run rather than merely a started one — but that changes the health semantics system-wide, so it's left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016j7WwD4RNFYWtrJFnuhLCT

---
_Generated by [Claude Code](https://claude.ai/code/session_016j7WwD4RNFYWtrJFnuhLCT)_