### PR TITLE
tweak: Streamline the cron card layout

### DIFF
--- a/ui/src/components/_cron.scss
+++ b/ui/src/components/_cron.scss
@@ -84,10 +84,12 @@
     .cron__tag-value { font-weight: 600; }
 }
 
-// The recent-runs strip: one cell per observed run, oldest first.
+// The recent-runs strip: one cell per observed run, oldest first. Cells align to the end so the most
+// recent run sits at the right edge and the strip grows leftward.
 .cron__runs {
     display: flex;
     flex-direction: row;
+    justify-content: end;
     gap: 3px;
     height: 0.8rem;
     margin-top: 0.5rem;
@@ -116,17 +118,9 @@
     color: $color-text-muted;
 }
 
-.cron__meta {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 0.5rem 1rem;
-    margin-top: 0.5rem;
-    font-size: 0.8rem;
-    color: $color-text-muted;
-}
-
-.cron__message {
-    font-family: monospace;
-    color: $color-text;
+// The time since the last check-in, shown on the far right of the title (mirrors
+// `.probe__availability`).
+.cron__last-checkin {
+    float: right;
+    clear: both;
 }

--- a/ui/src/components/cron.rs
+++ b/ui/src/components/cron.rs
@@ -42,11 +42,9 @@ pub fn cron(props: &CronProps) -> Html {
         CronSchedule::Cron(expr) => Some(expr.clone()),
     };
 
+    // The time since the last check-in, shown terse ("22m ago") on the right of the title.
     let last_checkin = cron.last_checkin.as_ref().map(|checkin| {
-        format!(
-            "last check-in {} ago",
-            compact_duration(now.signed_duration_since(checkin.at))
-        )
+        format!("{} ago", compact_duration(now.signed_duration_since(checkin.at)))
     });
 
     let run_count = cron.runs.len();
@@ -73,6 +71,9 @@ pub fn cron(props: &CronProps) -> Html {
                     }
                 </div>
                 <div class="cron__state">{state_text}</div>
+                if let Some(last_checkin) = last_checkin {
+                    <div class="cron__last-checkin">{last_checkin}</div>
+                }
             </div>
 
             <div class="cron__runs">
@@ -103,17 +104,6 @@ pub fn cron(props: &CronProps) -> Html {
                     })}
                 }
             </div>
-
-            if let Some(checkin) = cron.last_checkin.as_ref() {
-                <div class="cron__meta">
-                    if let Some(last_checkin) = last_checkin {
-                        <span class="cron__last-checkin">{last_checkin}</span>
-                    }
-                    if !checkin.message.is_empty() {
-                        <span class="cron__message">{&checkin.message}</span>
-                    }
-                </div>
-            }
         </div>
     }
 }
@@ -204,7 +194,7 @@ mod tests {
         });
         let html = render(cron).await;
         assert!(html.contains("cron-run"), "expected a run cell, got: {html}");
-        assert!(html.contains("done"), "expected the check-in message, got: {html}");
+        assert!(html.contains("cron__last-checkin"), "expected the last check-in time, got: {html}");
         assert!(html.contains("healthy for"), "{html}");
     }
 


### PR DESCRIPTION
- Align the recent-runs strip to the end of its container (justify-content:
  end) so the most recent run sits at the right edge.
- Move the time since the last check-in into the title row, styled and
  positioned like a probe's availability ("22m ago"), and drop the separate
  meta/message row.