### PR TITLE
feat: Add configurable alerting debounce via a shared streak interface

### DIFF
--- a/agent/src/api/auth.rs
+++ b/agent/src/api/auth.rs
@@ -780,6 +780,7 @@ mod tests {
             history: Vec::new(),
             observations: std::collections::HashMap::new(),
             streak: grey_api::Streak::default(),
+            debounce: None,
         };
 
         // Anonymous: only the public probe survives, but the orphan (no config entry) is kept.

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -72,6 +72,59 @@ pub struct CronConfig {
     /// `visible: auth.admin` restricts the cron to signed-in administrators.
     #[serde(default = "default_visible_filter")]
     pub visible: filt_rs::Filter,
+
+    /// Controls webhook alerting for this cron: whether it is enabled and how long a health change
+    /// must persist before it is reported (see [`AlertingConfig`]).
+    #[serde(default)]
+    pub alerting: AlertingConfig,
+}
+
+/// Controls how state-change alerts (webhook notifications) behave for a probe or cron.
+///
+/// `debounce` also governs the entity's streak-derived health hysteresis: a fault is only reported
+/// once it has persisted continuously for this long, and a recovery once no failure has been observed
+/// for this long. It therefore doubles as the streak recovery window (replacing the historical fixed
+/// 5-minute constant). `enabled` gates webhook emission only — a disabled entity still tracks its
+/// health for the status page.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct AlertingConfig {
+    /// Whether webhook notifications fire for this entity's health transitions. Defaults to `true`.
+    #[serde(default = "default_alerting_enabled")]
+    pub enabled: bool,
+
+    /// How long the entity must continuously hold a new health state before the transition is
+    /// reported, suppressing brief flaps. Defaults to 5 minutes. Applied symmetrically to both the
+    /// onset of a fault and the recovery from it.
+    #[serde(
+        default = "default_alerting_debounce",
+        with = "crate::serializers::chrono_duration_humantime"
+    )]
+    pub debounce: chrono::Duration,
+}
+
+impl Default for AlertingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_alerting_enabled(),
+            debounce: default_alerting_debounce(),
+        }
+    }
+}
+
+impl AlertingConfig {
+    /// The debounce expressed as a [`std::time::Duration`] for stamping onto the API DTOs
+    /// (`debounce`). A negative configured duration clamps to zero.
+    pub fn debounce_std(&self) -> std::time::Duration {
+        self.debounce.to_std().unwrap_or(std::time::Duration::ZERO)
+    }
+}
+
+fn default_alerting_enabled() -> bool {
+    true
+}
+
+fn default_alerting_debounce() -> chrono::Duration {
+    chrono::Duration::minutes(5)
 }
 
 impl CronConfig {
@@ -87,13 +140,15 @@ impl CronConfig {
 
     /// A bare [`grey_api::Cron`] carrying this configuration, used to seed the pooled view.
     pub fn to_cron(&self) -> grey_api::Cron {
-        grey_api::Cron::from_config(
+        let mut cron = grey_api::Cron::from_config(
             self.name.clone(),
             self.tags.clone(),
             self.build_schedule(),
             self.max_duration,
             self.grace,
-        )
+        );
+        cron.debounce = Some(self.alerting.debounce_std());
+        cron
     }
 
     /// Re-applies this configuration onto a (possibly gossiped) record so display and detection use
@@ -103,6 +158,7 @@ impl CronConfig {
         cron.schedule = self.build_schedule();
         cron.max_duration = self.max_duration;
         cron.grace = self.grace;
+        cron.debounce = Some(self.alerting.debounce_std());
     }
 }
 
@@ -637,6 +693,31 @@ mod tests {
             .unwrap();
         let config = Config::load_from_path(&ok).await.expect("a valid webhook should load");
         assert_eq!(config.webhooks[0].filter.raw(), "true");
+    }
+
+    /// `alerting` deserializes with humantime debounce and sensible defaults: a bare entity is
+    /// enabled with a 5-minute debounce, and both fields can be overridden.
+    #[tokio::test]
+    async fn parses_alerting_config() {
+        let dir = tempfile::tempdir().unwrap();
+
+        // Defaults apply when no `alerting` block is present.
+        let default_probe = "probes:\n  - name: p\n    policy: { interval: 5s, timeout: 2s }\n    target: !Http\n      url: https://example.com\n";
+        let path = dir.path().join("default.yml");
+        tokio::fs::write(&path, default_probe).await.unwrap();
+        let config = Config::load_from_path(&path).await.unwrap();
+        assert!(config.probes[0].alerting.enabled);
+        assert_eq!(config.probes[0].alerting.debounce, chrono::Duration::minutes(5));
+
+        // Explicit values are honoured, on probes and crons alike.
+        let tuned = "probes:\n  - name: p\n    policy: { interval: 5s, timeout: 2s }\n    target: !Http\n      url: https://example.com\n    alerting:\n      enabled: false\n      debounce: 90s\ncrons:\n  - name: c\n    interval: 1h\n    alerting:\n      debounce: 10m\n";
+        let path = dir.path().join("tuned.yml");
+        tokio::fs::write(&path, tuned).await.unwrap();
+        let config = Config::load_from_path(&path).await.unwrap();
+        assert!(!config.probes[0].alerting.enabled);
+        assert_eq!(config.probes[0].alerting.debounce, chrono::Duration::seconds(90));
+        assert!(config.crons[0].alerting.enabled, "enabled defaults to true when omitted");
+        assert_eq!(config.crons[0].alerting.debounce, chrono::Duration::minutes(10));
     }
 
     /// A cron may not share a name with a probe: gossip keys replicated state by the bare entity

--- a/agent/src/cron.rs
+++ b/agent/src/cron.rs
@@ -41,6 +41,7 @@ impl CronCheckin {
                         started_at: at,
                         status: CronStatus::Running,
                         duration: None,
+                        reason: None,
                     });
                 }
                 // Otherwise this is a heartbeat for the run already in flight: it advances
@@ -56,8 +57,15 @@ impl CronCheckin {
                         started_at: at,
                         status: self.status,
                         duration: None,
+                        reason: None,
                     });
                 }
+
+                // Only terminal outcomes progress the streak — the common health interface shared
+                // with probes. A `running` heartbeat carries no pass/fail signal and is ignored.
+                let window = cron.window();
+                cron.streak
+                    .observe(self.status == CronStatus::Succeeded, at, window);
             }
         }
 
@@ -121,6 +129,28 @@ mod tests {
         checkin(CronStatus::Succeeded, "", 160).apply(&mut c);
         assert_eq!(c.runs.len(), 2);
         assert!(c.runs.iter().all(|r| r.duration.is_none()));
+    }
+
+    /// Only terminal check-ins progress the streak: a `running` heartbeat leaves it untouched, a
+    /// `succeeded` records a passing observation, and a `failed` records a failing one.
+    #[test]
+    fn terminal_checkins_progress_the_streak() {
+        let window = grey_api::Streak::default_recovery_window();
+        let mut c = cron();
+
+        // A running heartbeat carries no pass/fail signal.
+        checkin(CronStatus::Running, "", 100).apply(&mut c);
+        assert!(c.streak.is_empty(), "running must not progress the streak");
+
+        // A terminal success records a passing observation...
+        checkin(CronStatus::Succeeded, "ok", 130).apply(&mut c);
+        assert!(!c.streak.is_empty());
+        assert!(c.streak.passing_at(ts(130), window));
+
+        // ...and a later failure records a failing observation the streak reads as failing.
+        checkin(CronStatus::Failed, "boom", 260).apply(&mut c);
+        assert!(c.streak.failing_at(ts(260), window));
+        assert_eq!(c.streak.failing_since, Some(ts(260)));
     }
 
     #[test]

--- a/agent/src/cron_monitor.rs
+++ b/agent/src/cron_monitor.rs
@@ -1,0 +1,227 @@
+//! A background daemon that materialises *time-derived* cron faults — a run that never started
+//! (`missing`, the deadman-switch case) or one that overran its `max_duration` (`stuck`) — into
+//! persisted state.
+//!
+//! Unlike a probe sample or a cron check-in, these faults are driven purely by the passage of time,
+//! so nothing writes them to the store on its own. This monitor re-derives each configured cron's
+//! schedule/completion detectors on a fixed cadence and, when it finds a *new* fault, records a
+//! synthetic run (a [`grey_api::CronRunReason`]-tagged placeholder) plus a failing streak
+//! observation and a `last_checkin`. That has two effects: the fault surfaces as a run placeholder in
+//! the UI (rendered distinctly, "grey", rather than leaving a silent gap), and it progresses the same
+//! [`grey_api::Streak`] that terminal check-ins do — so the streak is the single health interface the
+//! notifier debounces and alerts on, for missed/stuck runs exactly as for reported failures.
+//!
+//! Detections are idempotent. A missed slot advances the record's last-run time to the slot it
+//! materialises, so the schedule detector only fires again once the *next* slot is genuinely overdue
+//! (one placeholder per missed occurrence, not one per evaluation). A stuck run is marked in place, so
+//! the overrun is recorded once rather than re-appended.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use grey_api::{CronHealth, CronRunReason};
+use tracing_batteries::prelude::*;
+
+use crate::state::{CronStore, State};
+
+/// How often the monitor re-derives cron state to look for missed/stuck runs. Crons are not expected
+/// to run frequently, so a relatively long cadence keeps the store quiet while still materialising a
+/// fault within a few minutes of its deadline.
+const EVALUATION_INTERVAL: Duration = Duration::from_secs(5 * 60);
+
+/// Watches configured crons for time-derived faults and persists them as run placeholders.
+pub struct CronMonitor {
+    state: State,
+}
+
+impl CronMonitor {
+    pub fn new(state: State) -> Self {
+        Self { state }
+    }
+
+    /// Runs the evaluation loop forever.
+    pub async fn run(self) {
+        loop {
+            if let Err(e) = self.evaluate().await {
+                warn!(name: "cron.monitor.evaluate", { exception = %e }, "Failed to evaluate cron monitor state.");
+            }
+            tokio::time::sleep(EVALUATION_INTERVAL).await;
+        }
+    }
+
+    /// Performs one evaluation pass over every pooled cron, materialising any newly detected missed or
+    /// stuck run.
+    async fn evaluate(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let now = Utc::now();
+        let crons = self.state.get_cron_states().await?;
+
+        for (name, cron) in crons {
+            // An in-flight run that has overrun its `max_duration` is stuck. Mark it once (a marked
+            // run no longer reads as in-flight, so this won't re-fire), taking precedence over the
+            // schedule detector: a job that is overrunning hasn't *missed* its next slot, it's hung.
+            let already_stuck = cron
+                .runs
+                .last()
+                .map(|run| run.reason == Some(CronRunReason::Stuck))
+                .unwrap_or(false);
+
+            if cron.completion_overdue(now) && !already_stuck {
+                let at = cron.since(CronHealth::Stuck).unwrap_or(now);
+                if self
+                    .state
+                    .record_cron_detection(&name, CronRunReason::Stuck, at)
+                    .await?
+                {
+                    debug!(name: "cron.monitor.stuck", { cron.name = %name }, "Recorded an overrunning cron run.");
+                }
+                continue;
+            }
+
+            // A run that was due but never started (past the schedule grace) is missing. The slot's
+            // due time anchors the placeholder, so successive ticks advance to — and only fire on —
+            // the next genuinely-overdue slot.
+            if cron.schedule_overdue(now) {
+                let Some(due) = cron.next_due() else {
+                    continue;
+                };
+                if self
+                    .state
+                    .record_cron_detection(&name, CronRunReason::Missed, due)
+                    .await?
+                {
+                    debug!(name: "cron.monitor.missing", { cron.name = %name }, "Recorded a missed cron run.");
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Config;
+    use crate::config::CronConfig;
+
+    async fn state_with_cron(dir: &std::path::Path, cfg: CronConfig) -> State {
+        let state = State::test(dir.to_path_buf()).await;
+        let mut config = Config::test(&dir.to_path_buf());
+        config.crons = vec![cfg];
+        state.set_config_for_test(config);
+        state
+    }
+
+    fn cron_config(name: &str, interval_secs: u64) -> CronConfig {
+        CronConfig {
+            name: name.into(),
+            interval: Some(Duration::from_secs(interval_secs)),
+            schedule: None,
+            max_duration: None,
+            grace: Some(Duration::from_secs(1)),
+            token: None,
+            tags: Default::default(),
+            visible: crate::config::default_visible_filter(),
+            alerting: Default::default(),
+        }
+    }
+
+    /// A cron whose scheduled run never arrives is materialised as a `missing` run placeholder, with a
+    /// failing streak observation — so it both shows in the UI and drives alerting.
+    #[tokio::test]
+    async fn materialises_a_missed_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_with_cron(dir.path(), cron_config("backup", 60)).await;
+
+        // A completed run well in the past, so the next slot is long overdue.
+        state
+            .record_cron_checkin(
+                "backup",
+                crate::cron::CronCheckin::new(
+                    grey_api::CronStatus::Succeeded,
+                    "ok".into(),
+                    Utc::now() - chrono::Duration::hours(1),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let monitor = CronMonitor::new(state.clone());
+        monitor.evaluate().await.unwrap();
+
+        let cron = state.get_cron_states().await.unwrap().remove("backup").unwrap();
+        let placeholder = cron.runs.last().expect("a placeholder run should be recorded");
+        assert_eq!(placeholder.reason, Some(CronRunReason::Missed));
+        assert!(
+            !cron.streak.is_empty() && cron.streak.failing_since.is_some(),
+            "the missed run must progress the streak as a failure"
+        );
+    }
+
+    /// A second evaluation immediately after does not record a duplicate placeholder for the same
+    /// slot — the materialised run advances the schedule so the detector waits for the next slot.
+    #[tokio::test]
+    async fn missed_run_detection_is_idempotent_per_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        // A long interval so, once the first slot is materialised, the next slot is not yet overdue.
+        let state = state_with_cron(dir.path(), cron_config("backup", 3600)).await;
+        state
+            .record_cron_checkin(
+                "backup",
+                crate::cron::CronCheckin::new(
+                    grey_api::CronStatus::Succeeded,
+                    "ok".into(),
+                    Utc::now() - chrono::Duration::hours(2),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let monitor = CronMonitor::new(state.clone());
+        monitor.evaluate().await.unwrap();
+        monitor.evaluate().await.unwrap();
+
+        let cron = state.get_cron_states().await.unwrap().remove("backup").unwrap();
+        let missed = cron
+            .runs
+            .iter()
+            .filter(|r| r.reason == Some(CronRunReason::Missed))
+            .count();
+        assert_eq!(missed, 1, "only one placeholder per missed slot");
+    }
+
+    /// An in-flight run that overruns its `max_duration` is marked stuck once, in place.
+    #[tokio::test]
+    async fn marks_an_overrunning_run_stuck() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut cfg = cron_config("job", 3600);
+        cfg.max_duration = Some(Duration::from_secs(1));
+        let state = state_with_cron(dir.path(), cfg).await;
+
+        // A run that started running two minutes ago and never completed.
+        state
+            .record_cron_checkin(
+                "job",
+                crate::cron::CronCheckin::new(
+                    grey_api::CronStatus::Running,
+                    "start".into(),
+                    Utc::now() - chrono::Duration::minutes(2),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let monitor = CronMonitor::new(state.clone());
+        monitor.evaluate().await.unwrap();
+        monitor.evaluate().await.unwrap();
+
+        let cron = state.get_cron_states().await.unwrap().remove("job").unwrap();
+        let stuck = cron
+            .runs
+            .iter()
+            .filter(|r| r.reason == Some(CronRunReason::Stuck))
+            .count();
+        assert_eq!(stuck, 1, "the overrun is marked once, in place");
+        assert!(cron.streak.failing_since.is_some(), "a stuck run progresses the streak");
+    }
+}

--- a/agent/src/engine.rs
+++ b/agent/src/engine.rs
@@ -62,6 +62,17 @@ impl Engine {
             });
         }
 
+        // Materialise time-derived cron faults (missed/stuck runs) into persisted state, so they
+        // surface as run placeholders in the UI and drive streak-based alerting like reported
+        // failures. Runs alongside the notifier so a missed run's failing streak observation is in
+        // place before the notifier evaluates it.
+        {
+            let state = self.state.clone();
+            tokio::task::spawn_local(async move {
+                crate::cron_monitor::CronMonitor::new(state).run().await;
+            });
+        }
+
         // Start probe runners
         for probe in self.probes.read().unwrap().values().cloned() {
             self.start_probe_runner(probe);

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -10,6 +10,7 @@ mod checks;
 mod cluster;
 mod config;
 mod cron;
+mod cron_monitor;
 mod engine;
 mod js;
 #[macro_use]

--- a/agent/src/notify.rs
+++ b/agent/src/notify.rs
@@ -101,12 +101,36 @@ impl Notifier {
         let probes = self.state.get_probe_states().await?;
         let crons = self.state.get_cron_states().await?;
 
+        // Whether a given entity has alerting enabled. The health axis is already debounced by the
+        // streak (via each entity's configured window); `enabled` only decides whether a genuine
+        // transition is delivered. A missing entry defaults to enabled.
+        let alerting_enabled = |key: &str| -> bool {
+            if let Some(name) = key.strip_prefix("probe:") {
+                config
+                    .probes
+                    .iter()
+                    .find(|p| p.name == name)
+                    .map(|p| p.alerting.enabled)
+                    .unwrap_or(true)
+            } else if let Some(name) = key.strip_prefix("cron:") {
+                config
+                    .crons
+                    .iter()
+                    .find(|c| c.name == name)
+                    .map(|c| c.alerting.enabled)
+                    .unwrap_or(true)
+            } else {
+                true
+            }
+        };
+
         let events = detect_transitions(
             &mut self.last,
             now,
             &probes,
             &crons,
             !config.webhooks.is_empty(),
+            &alerting_enabled,
         );
 
         if !events.is_empty() {
@@ -160,30 +184,34 @@ impl Notifier {
 /// [`WebhookEvent`] for each entity that crossed between healthy and unhealthy since the previous
 /// pass.
 ///
+/// The health axis is read from each entity's debounced, streak-derived health (`probe.passing()` /
+/// `cron.health(now, window)`), so a fault must persist for the entity's configured `alerting.debounce`
+/// before it reads unhealthy and a recovery must hold for that long before it reads healthy — the
+/// flap suppression is entirely in the streak, this function only detects the confirmed crossing.
+///
 /// `last` is always updated to the current status (so it tracks the pooled view continuously,
 /// including token changes that stay within one health class); events are only produced when
-/// `notify` is set, when the entity already had a recorded baseline, and when its *health* flipped —
-/// so the first time an entity is seen it is seeded silently, and same-health churn (a healthy cron
-/// moving `succeeded` ⇆ `running` as runs come and go) never notifies. The event still reports the
-/// specific tokens it moved between.
+/// `notify` is set, the entity's alerting is `enabled`, the entity already had a recorded baseline,
+/// and its *health* flipped — so the first time an entity is seen it is seeded silently, and
+/// same-health churn never notifies. The event still reports the specific tokens it moved between.
 fn detect_transitions(
     last: &mut HashMap<String, Status>,
     now: DateTime<Utc>,
     probes: &HashMap<String, Probe>,
     crons: &HashMap<String, Cron>,
     notify: bool,
+    enabled: &impl Fn(&str) -> bool,
 ) -> Vec<WebhookEvent> {
     let mut events = Vec::new();
 
     for (name, probe) in probes {
         let key = format!("probe:{name}");
-        // Both the token and the healthy axis it collapses to are read from the cluster-converged
-        // streak, which already folds in the recovery settling window; delivery is gated on the
-        // healthy axis so only a genuine passing⇆failing crossing notifies.
+        // The token and its healthy axis both come from the debounced, streak-derived health.
         let token = probe.status_token();
         let healthy = probe.passing();
 
         if notify
+            && enabled(&key)
             && let Some(previous) = last.get(&key)
             && previous.healthy != healthy
         {
@@ -201,15 +229,15 @@ fn detect_transitions(
 
     for (name, cron) in crons {
         let key = format!("cron:{name}");
-        // The derived health already accounts for the schedule grace and `max_duration` settling
-        // windows. Delivery is gated on the healthy axis, so the `succeeded`/`running` churn a normal
-        // run produces (all healthy) is silent — only a crossing into or out of `failed`/`missing`/
-        // `stuck` notifies.
-        let health = cron.health(now);
+        // The debounced health folds in the schedule grace / `max_duration` settling windows *and*
+        // the configured alerting debounce, so a normal run's `succeeded`/`running` churn is silent —
+        // only a confirmed crossing into or out of `failed`/`missing`/`stuck` notifies.
+        let health = cron.health(now, cron.window());
         let token = health.as_str();
         let healthy = health.passing();
 
         if notify
+            && enabled(&key)
             && let Some(previous) = last.get(&key)
             && previous.healthy != healthy
         {
@@ -419,18 +447,39 @@ mod tests {
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    /// Alerting-enabled for every entity — the common case for these tests.
+    fn all_enabled(_: &str) -> bool {
+        true
+    }
+
+    /// A probe in a *confirmed* passing or failing state under the default debounce window: a failing
+    /// probe carries a sustained fault episode (onset older than the window, still failing now), so
+    /// the debounced `passing()` reads failing rather than being suppressed as a fresh blip.
     fn probe(name: &str, failing: bool) -> Probe {
         let now = Utc::now();
-        let mut probe = Probe {
+        let window = Streak::default_recovery_window();
+        let streak = if failing {
+            Streak {
+                failing_since: Some(now - window - chrono::Duration::minutes(1)),
+                failing_until: Some(now),
+                covered_since: None,
+            }
+        } else {
+            Streak {
+                failing_since: None,
+                failing_until: None,
+                covered_since: Some(now - window - chrono::Duration::minutes(1)),
+            }
+        };
+        Probe {
             name: name.into(),
             tags: vec![("service".into(), "Web".into())].into_iter().collect(),
             last_updated: now,
             history: Vec::new(),
             observations: HashMap::new(),
-            streak: Streak::default(),
-        };
-        probe.streak.observe(!failing, now);
-        probe
+            streak,
+            debounce: None,
+        }
     }
 
     fn cron(name: &str, status: CronStatus) -> Cron {
@@ -445,13 +494,15 @@ mod tests {
             started_at: Utc::now(),
             status,
             duration: Some(Duration::from_secs(1)),
+            reason: None,
         });
         cron
     }
 
     /// A cron on a fixed 60s schedule with a single run of `status` that started at `started_at`, so
     /// its health at a chosen `now` can be steered across the health axis (a stale `succeeded` run
-    /// reads as `missing`, a `failed` run as `failed`, and so on).
+    /// reads as `missing`, a `failed` run as `failed`, and so on). The streak is left empty so the
+    /// health reads instantaneously (raw), isolating the crossing logic from the debounce.
     fn cron_at(status: CronStatus, started_at: DateTime<Utc>) -> Cron {
         let mut cron = Cron::from_config(
             "job",
@@ -460,7 +511,7 @@ mod tests {
             None,
             None,
         );
-        cron.push_run(CronRun { started_at, status, duration: None });
+        cron.push_run(CronRun { started_at, status, duration: None, reason: None });
         cron
     }
 
@@ -487,11 +538,11 @@ mod tests {
         let empty_crons = HashMap::new();
 
         // First pass seeds "passing" and fires nothing.
-        let events = detect_transitions(&mut last, now, &passing, &empty_crons, true);
+        let events = detect_transitions(&mut last, now, &passing, &empty_crons, true, &all_enabled);
         assert!(events.is_empty(), "the first observation must seed silently");
 
         // The probe goes failing: one event, summarising the transition.
-        let events = detect_transitions(&mut last, now, &failing, &empty_crons, true);
+        let events = detect_transitions(&mut last, now, &failing, &empty_crons, true, &all_enabled);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].state.previous, "passing");
         assert_eq!(events[0].state.current, "failing");
@@ -499,7 +550,7 @@ mod tests {
         assert!(events[0].state.was_healthy);
 
         // No further change: nothing fires.
-        let events = detect_transitions(&mut last, now, &failing, &empty_crons, true);
+        let events = detect_transitions(&mut last, now, &failing, &empty_crons, true, &all_enabled);
         assert!(events.is_empty());
     }
 
@@ -513,12 +564,12 @@ mod tests {
         let crons = HashMap::new();
 
         // notify=false: no events, but the baseline is recorded as "failing".
-        let events = detect_transitions(&mut last, now, &failing, &crons, false);
+        let events = detect_transitions(&mut last, now, &failing, &crons, false, &all_enabled);
         assert!(events.is_empty());
 
         // Now notifying, with the same (failing) state: still nothing, because it matches the seeded
         // baseline rather than being treated as a fresh transition.
-        let events = detect_transitions(&mut last, now, &failing, &crons, true);
+        let events = detect_transitions(&mut last, now, &failing, &crons, true, &all_enabled);
         assert!(events.is_empty());
     }
 
@@ -532,8 +583,8 @@ mod tests {
         let succeeded = HashMap::from([("backup".to_string(), cron("backup", CronStatus::Succeeded))]);
         let failed = HashMap::from([("backup".to_string(), cron("backup", CronStatus::Failed))]);
 
-        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true).is_empty());
-        let events = detect_transitions(&mut last, now, &probes, &failed, true);
+        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true, &all_enabled).is_empty());
+        let events = detect_transitions(&mut last, now, &probes, &failed, true, &all_enabled);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].state.previous, "succeeded");
         assert_eq!(events[0].state.current, "failed");
@@ -553,33 +604,102 @@ mod tests {
 
         // Seed healthy (a completed run).
         let succeeded = map(cron_at(CronStatus::Succeeded, now));
-        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true).is_empty());
+        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true, &all_enabled).is_empty());
 
         // A new run starts — running is still healthy, so nothing fires...
         let running = map(cron_at(CronStatus::Running, now));
-        assert!(detect_transitions(&mut last, now, &probes, &running, true).is_empty());
+        assert!(detect_transitions(&mut last, now, &probes, &running, true, &all_enabled).is_empty());
         // ...and completing it (back to succeeded) is still healthy: still silent.
-        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true).is_empty());
+        assert!(detect_transitions(&mut last, now, &probes, &succeeded, true, &all_enabled).is_empty());
 
         // The run fails: healthy -> unhealthy fires exactly one event.
         let failed = map(cron_at(CronStatus::Failed, now));
-        let events = detect_transitions(&mut last, now, &probes, &failed, true);
+        let events = detect_transitions(&mut last, now, &probes, &failed, true, &all_enabled);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].state.previous, "succeeded");
         assert_eq!(events[0].state.current, "failed");
 
         // A stale on-time run then reads as `missing` — unhealthy -> unhealthy is silent.
         let missing = map(cron_at(CronStatus::Succeeded, now - chrono::Duration::seconds(120)));
-        assert_eq!(missing["job"].health(now), grey_api::CronHealth::Missing);
-        assert!(detect_transitions(&mut last, now, &probes, &missing, true).is_empty());
+        assert_eq!(missing["job"].health(now, missing["job"].window()), grey_api::CronHealth::Missing);
+        assert!(detect_transitions(&mut last, now, &probes, &missing, true, &all_enabled).is_empty());
 
         // Finally a fresh run succeeds: unhealthy -> healthy fires one event, reporting the specific
         // token (`missing`) it recovered from rather than the older `failed`.
         let recovered = map(cron_at(CronStatus::Succeeded, now));
-        let events = detect_transitions(&mut last, now, &probes, &recovered, true);
+        let events = detect_transitions(&mut last, now, &probes, &recovered, true, &all_enabled);
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].state.previous, "missing");
         assert_eq!(events[0].state.current, "succeeded");
+    }
+
+    /// The onset debounce is entirely in the streak: a probe whose fault has not yet persisted for the
+    /// window reads healthy and fires nothing; once the fault is confirmed (a continuous episode older
+    /// than the window) the passing → failing crossing fires exactly once.
+    #[test]
+    fn debounces_a_probe_onset_via_the_streak() {
+        let mut last = HashMap::new();
+        let now = Utc::now();
+        let window = Streak::default_recovery_window();
+        let empty_crons = HashMap::new();
+
+        let with_streak = |streak: Streak| {
+            let mut p = probe("web", false);
+            p.streak = streak;
+            HashMap::from([("web".to_string(), p)])
+        };
+
+        // Seed passing.
+        let passing = with_streak(Streak {
+            covered_since: Some(now - chrono::Duration::hours(1)),
+            ..Default::default()
+        });
+        assert!(detect_transitions(&mut last, now, &passing, &empty_crons, true, &all_enabled).is_empty());
+
+        // A fresh fault (onset just now) is still within the debounce window: it reads healthy, so no
+        // event fires — the sensitivity reduction we set out to add.
+        let fresh_fault = with_streak(Streak {
+            failing_since: Some(now),
+            failing_until: Some(now),
+            covered_since: Some(now - chrono::Duration::hours(1)),
+        });
+        assert!(
+            detect_transitions(&mut last, now, &fresh_fault, &empty_crons, true, &all_enabled).is_empty(),
+            "an unconfirmed fault must not alert"
+        );
+
+        // Once the fault has persisted past the window (continuous episode), it is confirmed failing
+        // and the crossing fires exactly one event.
+        let confirmed = with_streak(Streak {
+            failing_since: Some(now - window - chrono::Duration::minutes(1)),
+            failing_until: Some(now),
+            covered_since: Some(now - chrono::Duration::hours(1)),
+        });
+        let events = detect_transitions(&mut last, now, &confirmed, &empty_crons, true, &all_enabled);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].state.previous, "passing");
+        assert_eq!(events[0].state.current, "failing");
+    }
+
+    /// A per-entity `enabled: false` suppresses delivery entirely, but the baseline is still tracked
+    /// so re-enabling does not replay the state the entity is already in.
+    #[test]
+    fn disabled_entity_never_notifies_but_tracks_baseline() {
+        let mut last = HashMap::new();
+        let now = Utc::now();
+        let empty_crons = HashMap::new();
+        let disabled = |_: &str| false;
+
+        let passing = HashMap::from([("web".to_string(), probe("web", false))]);
+        let failing = HashMap::from([("web".to_string(), probe("web", true))]);
+
+        // Seed passing, then flip to failing: with alerting disabled, nothing fires...
+        assert!(detect_transitions(&mut last, now, &passing, &empty_crons, true, &disabled).is_empty());
+        assert!(detect_transitions(&mut last, now, &failing, &empty_crons, true, &disabled).is_empty());
+
+        // ...but the baseline advanced to "failing", so re-enabling on the same (failing) state does
+        // not replay it as a fresh transition.
+        assert!(detect_transitions(&mut last, now, &failing, &empty_crons, true, &all_enabled).is_empty());
     }
 
     #[test]
@@ -764,11 +884,18 @@ mod tests {
         notifier.evaluate().await.unwrap();
         assert!(server.received_requests().await.unwrap().is_empty());
 
-        // Record a failing sample so the pooled probe flips to failing.
-        let mut sample = crate::result::ProbeResult::new();
-        sample.pass = false;
-        sample.message = "boom".into();
-        state.update_probe_state("web", sample.finish()).await.unwrap();
+        // Record a *sustained* failing episode so the debounced (default 5m window) health confirms
+        // the probe as failing rather than suppressing a single fresh sample as a blip: three failing
+        // samples spanning more than the window, each within the window of the last so they stay one
+        // continuous episode.
+        let now = Utc::now();
+        for offset_mins in [8, 4, 0] {
+            let mut sample = crate::result::ProbeResult::new();
+            sample.start_time = now - chrono::Duration::minutes(offset_mins);
+            sample.pass = false;
+            sample.message = "boom".into();
+            state.update_probe_state("web", sample).await.unwrap();
+        }
 
         // The next pass detects passing -> failing and delivers a matching event.
         notifier.evaluate().await.unwrap();

--- a/agent/src/probe.rs
+++ b/agent/src/probe.rs
@@ -25,6 +25,12 @@ pub struct Probe {
     /// `visible: auth.admin` restricts the probe to signed-in administrators.
     #[serde(default = "crate::config::default_visible_filter")]
     pub visible: filt_rs::Filter,
+
+    /// Controls webhook alerting for this probe: whether it is enabled and how long a health change
+    /// must persist before it is reported. The `debounce` also governs the probe's streak-derived
+    /// health hysteresis (see [`crate::config::AlertingConfig`]).
+    #[serde(default)]
+    pub alerting: crate::config::AlertingConfig,
 }
 
 impl Probe {
@@ -37,6 +43,7 @@ impl Probe {
             tags: HashMap::new(),
             checks: vec![filt_rs::Filter::new("output.test == true").unwrap()],
             visible: crate::config::default_visible_filter(),
+            alerting: crate::config::AlertingConfig::default(),
         }
     }
 
@@ -94,6 +101,7 @@ impl Into<grey_api::Probe> for &Probe {
             history: Vec::new(),
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
+            debounce: Some(self.alerting.debounce_std()),
         }
     }
 }

--- a/agent/src/result.rs
+++ b/agent/src/result.rs
@@ -100,7 +100,7 @@ impl ProbeResult {
             .or_insert_with(Default::default);
         observation.add_sample(self.pass, self.retries as u64, std::time::Duration::from_millis(self.duration.num_milliseconds() as u64));
 
-        probe.streak.observe(self.pass, sample_time);
+        probe.streak.observe(self.pass, sample_time, probe.window());
     }
 }
 
@@ -141,6 +141,7 @@ mod tests {
             history: Vec::new(),
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
+            debounce: None,
         }
     }
 
@@ -157,22 +158,22 @@ mod tests {
 
         assert!(probe.history.len() >= 3, "three hours of samples should span multiple buckets");
         let sampled_until = start + Duration::minutes(179);
-        assert!(probe.streak.passing_at(sampled_until));
-        assert_eq!(probe.streak.since_at(sampled_until), Some(start));
+        assert!(probe.streak.passing_at(sampled_until, grey_api::Streak::default_recovery_window()));
+        assert_eq!(probe.streak.since_at(sampled_until, grey_api::Streak::default_recovery_window()), Some(start));
 
-        // A failure starts an episode immediately, and further failing samples refresh
-        // it without moving the onset...
+        // A failure starts an episode immediately (the raw failing signal), and further failing
+        // samples refresh it without moving the onset marker.
         let failed_at = start + Duration::minutes(180);
         result_at(failed_at, false).apply("node", &mut probe);
         result_at(failed_at + Duration::minutes(1), false).apply("node", &mut probe);
-        assert!(probe.streak.failing_at(failed_at + Duration::minutes(1)));
-        assert_eq!(probe.streak.since_at(failed_at + Duration::minutes(1)), Some(failed_at));
+        assert!(probe.streak.failing_at(failed_at + Duration::minutes(1), grey_api::Streak::default_recovery_window()));
+        assert_eq!(probe.streak.failing_since, Some(failed_at), "the onset marker is pinned to the first failure");
 
         // ...and once no failures have been observed for the recovery window, the probe
         // reads as passing since the last failing observation.
-        let recovered = failed_at + Duration::minutes(1) + grey_api::Streak::recovery_window() + Duration::seconds(1);
+        let recovered = failed_at + Duration::minutes(1) + grey_api::Streak::default_recovery_window() + Duration::seconds(1);
         result_at(recovered, true).apply("node", &mut probe);
-        assert!(probe.streak.passing_at(recovered));
-        assert_eq!(probe.streak.since_at(recovered), Some(failed_at + Duration::minutes(1)));
+        assert!(probe.streak.passing_at(recovered, grey_api::Streak::default_recovery_window()));
+        assert_eq!(probe.streak.since_at(recovered, grey_api::Streak::default_recovery_window()), Some(failed_at + Duration::minutes(1)));
     }
 }

--- a/agent/src/state/crons.rs
+++ b/agent/src/state/crons.rs
@@ -11,7 +11,8 @@
 use std::collections::HashMap;
 use std::error::Error;
 
-use grey_api::Cron;
+use chrono::{DateTime, Utc};
+use grey_api::{CheckIn, Cron, CronRun, CronRunReason, CronStatus};
 use redb::{ReadableDatabase, ReadableTable, TableDefinition};
 
 use crate::cluster::Versioned;
@@ -69,6 +70,18 @@ pub trait CronStore {
         &self,
         name: &str,
         checkin: CronCheckin,
+    ) -> Result<bool, Box<dyn Error>>;
+
+    /// Materialises a monitor-detected fault (a missed or overrunning run) onto the named cron's
+    /// record: it appends (or marks) a synthetic run carrying the reason, records a failing streak
+    /// observation at `occurred_at`, and updates `last_checkin` — so the fault surfaces as a run
+    /// placeholder in the UI and drives streak-based alerting. Returns `Ok(false)` when the cron is
+    /// not in the local configuration.
+    async fn record_cron_detection(
+        &self,
+        name: &str,
+        reason: CronRunReason,
+        occurred_at: DateTime<Utc>,
     ) -> Result<bool, Box<dyn Error>>;
 }
 
@@ -146,6 +159,81 @@ impl CronStore for State {
 
         Ok(true)
     }
+
+    async fn record_cron_detection(
+        &self,
+        name: &str,
+        reason: CronRunReason,
+        occurred_at: DateTime<Utc>,
+    ) -> Result<bool, Box<dyn Error>> {
+        let config = self.get_config();
+        let Some(cfg) = config.crons.iter().find(|c| c.name == name) else {
+            return Ok(false);
+        };
+
+        let occurred_at = DateTime::from_timestamp_millis(occurred_at.timestamp_millis())
+            .unwrap_or(occurred_at);
+
+        let txn = self.database.begin_write()?;
+        {
+            let mut table = txn.open_table(CRON_TABLE)?;
+
+            let mut cron = table
+                .get(name)?
+                .and_then(|existing| {
+                    let (_version, _last_writer, data) = existing.value();
+                    rmp_serde::from_slice::<Cron>(data).ok()
+                })
+                .unwrap_or_else(|| cfg.to_cron());
+
+            // Keep config-echo (including the recovery window) current before deriving state.
+            cfg.stamp(&mut cron);
+
+            match reason {
+                // An overrun marks the run already in flight, so the same occurrence isn't recorded
+                // twice; if nothing is in flight (already closed), fall through to a placeholder.
+                CronRunReason::Stuck if cron.has_in_flight() => {
+                    if let Some(run) = cron.runs.last_mut() {
+                        run.reason = Some(reason);
+                    }
+                }
+                _ => {
+                    cron.push_run(CronRun {
+                        started_at: occurred_at,
+                        status: CronStatus::Failed,
+                        duration: None,
+                        reason: Some(reason),
+                    });
+                }
+            }
+
+            // The detection is a failing observation at the moment the fault began.
+            let window = cron.window();
+            cron.streak.observe(false, occurred_at, window);
+
+            let message = match reason {
+                CronRunReason::Missed => "no run started within the schedule grace",
+                CronRunReason::Stuck => "run overran its max_duration",
+            };
+            cron.last_checkin = Some(CheckIn {
+                at: occurred_at,
+                status: CronStatus::Failed,
+                message: message.into(),
+            });
+
+            // Advance the record's version to now so the detection supersedes prior state and gossips
+            // (a backfilled `occurred_at` in the past must not leave the version stale).
+            cron.last_updated = cron.last_updated.max(Utc::now());
+
+            table.insert(
+                name,
+                (cron.version(), self.node_id.into(), rmp_serde::to_vec_named(&cron)?.as_slice()),
+            )?;
+        }
+        txn.commit()?;
+
+        Ok(true)
+    }
 }
 
 #[cfg(test)]
@@ -173,6 +261,7 @@ mod tests {
             token: None,
             tags: HashMap::new(),
             visible: crate::config::default_visible_filter(),
+            alerting: Default::default(),
         }];
         *state.config.write().unwrap() = Arc::new(config);
         state
@@ -213,7 +302,7 @@ mod tests {
             grey_api::CronSchedule::Every(Duration::from_secs(60)),
             "config echo is stamped"
         );
-        assert!(backup.passing(chrono::Utc::now()));
+        assert!(backup.passing(chrono::Utc::now(), backup.window()));
         assert_eq!(backup.last_checkin.as_ref().unwrap().message, "done");
     }
 

--- a/agent/src/state/mod.rs
+++ b/agent/src/state/mod.rs
@@ -208,6 +208,13 @@ impl State {
         self.config.read().unwrap().clone()
     }
 
+    /// Replaces the in-memory configuration. Test-only helper for exercising code paths that read
+    /// `get_config()` without going through a config-file reload.
+    #[cfg(test)]
+    pub(crate) fn set_config_for_test(&self, config: Config) {
+        *self.config.write().unwrap() = Arc::new(config);
+    }
+
     /// Returns a redacted view of the known cluster peers for the API/UI. Only the node identifier
     /// and last-seen timestamp are exposed — peer **addresses are never returned**, since the API has
     /// no access control and may be reachable on the public internet.
@@ -620,6 +627,7 @@ mod tests {
             history: Vec::new(),
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
+            debounce: None,
         }
     }
 
@@ -641,7 +649,7 @@ mod tests {
         // A peer's record attests three days of coverage.
         let peer = NodeID::new();
         let mut peer_record = probe_at(&probe.name, now);
-        peer_record.streak.observe(true, streak_start);
+        peer_record.streak.observe(true, streak_start, grey_api::Streak::default_recovery_window());
 
         // Deliver the peer's record through the normal gossip apply path. This stores the
         // peer's record and folds its streak into this node's own record in one step.
@@ -652,7 +660,7 @@ mod tests {
         let pooled = state.get_probe_states().await.unwrap();
         let pooled_probe = pooled.get(&probe.name).expect("the probe to be pooled");
         assert!(pooled_probe.passing());
-        assert_eq!(pooled_probe.streak.since_at(now), Some(streak_start));
+        assert_eq!(pooled_probe.streak.since_at(now, grey_api::Streak::default_recovery_window()), Some(streak_start));
 
         // The apply also joined the peer's register into this node's own stored
         // record, so the claim survives even if the peer's record is eventually
@@ -689,6 +697,7 @@ mod tests {
             token: None,
             tags: HashMap::new(),
             visible: crate::config::default_visible_filter(),
+            alerting: Default::default(),
         }];
         *state.config.write().unwrap() = Arc::new(config);
         state

--- a/agent/src/state/probes.rs
+++ b/agent/src/state/probes.rs
@@ -43,8 +43,10 @@ pub trait ProbeStore {
 
 impl ProbeStore for State {
     async fn get_probe_states(&self) -> Result<HashMap<String, Probe>, Box<dyn Error>> {
+        let config = self.get_config();
+
         let mut histories = HashMap::new();
-        for probe in self.get_config().probes.iter() {
+        for probe in config.probes.iter() {
             histories.insert(probe.name.clone(), probe.into());
         }
 
@@ -66,6 +68,15 @@ impl ProbeStore for State {
                         })
                         .or_insert_with(|| snapshot.clone());
                 }
+            }
+        }
+
+        // The alerting debounce (the streak recovery window) is authoritative locally for display
+        // and detection — re-stamp it so a peer's stale config can never override the operator's
+        // view. Mirrors the cron config-echo in `get_cron_states`.
+        for probe in config.probes.iter() {
+            if let Some(pooled) = histories.get_mut(&probe.name) {
+                pooled.debounce = Some(probe.alerting.debounce_std());
             }
         }
 
@@ -227,6 +238,7 @@ impl Versioned for Probe {
                     .collect(),
                 observations: self.observations.clone(),
                 streak: self.streak.clone(),
+                debounce: self.debounce,
             })
         } else {
             None
@@ -253,6 +265,7 @@ mod tests {
             history: Vec::new(),
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
+            debounce: None,
         }
     }
 

--- a/agent/src/state/replicated.rs
+++ b/agent/src/state/replicated.rs
@@ -121,6 +121,7 @@ mod tests {
             history: vec![],
             observations: HashMap::new(),
             streak: Default::default(),
+            debounce: None,
         }
     }
 

--- a/api/src/cron.rs
+++ b/api/src/cron.rs
@@ -4,9 +4,11 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::Streak;
+
 /// How many recent runs are retained per cron. This bounded list is both the displayed history and
 /// the input the detectors read (for the last run's start time).
-pub const MAX_RUNS: usize = 20;
+pub const MAX_RUNS: usize = 50;
 
 /// The grace applied to a crontab schedule when none is configured. For an `Every` schedule the
 /// default is instead a tenth of the interval (see [`Cron::effective_grace`]).
@@ -154,6 +156,37 @@ impl CronHealth {
     }
 }
 
+/// Why a run was synthesised by the agent's cron monitor rather than reported by the job itself. A
+/// run carrying a reason is a *placeholder* the monitor persisted for a detected fault (a run that
+/// never checked in, or one that overran), so the UI can render it distinctly ("grey") and the
+/// streak can count it as a failure. Absent (`None`) for genuine, job-reported runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CronRunReason {
+    /// No run started within the schedule grace — a scheduled run was missed (deadman switch).
+    Missed,
+    /// An in-flight run overran its `max_duration` without reporting completion.
+    Stuck,
+}
+
+impl CronRunReason {
+    /// The derived health this synthetic run represents.
+    pub fn health(self) -> CronHealth {
+        match self {
+            CronRunReason::Missed => CronHealth::Missing,
+            CronRunReason::Stuck => CronHealth::Stuck,
+        }
+    }
+
+    /// A lowercase token suitable for a CSS class or serialized value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CronRunReason::Missed => "missed",
+            CronRunReason::Stuck => "stuck",
+        }
+    }
+}
+
 /// One observed run of a cron job, identified by its start time.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CronRun {
@@ -163,12 +196,16 @@ pub struct CronRun {
     /// The run's duration, set once a terminal check-in arrives.
     #[serde(default, with = "humantime_serde::option")]
     pub duration: Option<Duration>,
+    /// Set when this run is a monitor-synthesised placeholder for a detected fault (missed/stuck)
+    /// rather than a job-reported run. `None` for genuine runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<CronRunReason>,
 }
 
 impl CronRun {
     /// Whether this run is still in flight (reported `running`, no terminal status yet).
     pub fn is_in_flight(&self) -> bool {
-        self.status == CronStatus::Running
+        self.status == CronStatus::Running && self.reason.is_none()
     }
 }
 
@@ -225,6 +262,20 @@ pub struct Cron {
     /// The latest check-in, for displaying the reported status and message.
     #[serde(default)]
     pub last_checkin: Option<CheckIn>,
+
+    /// The cluster-converged record of this cron's pass/fail streaks, progressed by terminal run
+    /// outcomes (succeeded/failed) and by the monitor's missed/stuck detections. This is the common
+    /// health interface shared with probes: alerting and the debounced health axis are derived from
+    /// it. Records written before crons carried a streak decode as empty and fall back to the
+    /// instantaneous [`Cron::raw_health`].
+    #[serde(default)]
+    pub streak: Streak,
+
+    /// The debounce window applied to this cron's streak-derived health (a config echo of the cron's
+    /// `alerting.debounce`, stamped by the agent). Applied symmetrically to both the onset of a fault
+    /// and the recovery from it. `None` falls back to [`Streak::default_recovery_window`].
+    #[serde(default, with = "humantime_serde::option")]
+    pub debounce: Option<Duration>,
 }
 
 impl Cron {
@@ -246,6 +297,8 @@ impl Cron {
             grace,
             runs: Vec::new(),
             last_checkin: None,
+            streak: Streak::default(),
+            debounce: None,
         }
     }
 
@@ -329,11 +382,19 @@ impl Cron {
         self.completion_deadline().map(|d| now > d).unwrap_or(false)
     }
 
-    /// The cron's displayed health at `now`.
-    pub fn health(&self, now: DateTime<Utc>) -> CronHealth {
+    /// The cron's *raw* (un-debounced) displayed health at `now`, computed analytically from the
+    /// runs and schedule. A monitor-synthesised run reports its own reason (missed/stuck); otherwise
+    /// the schedule/completion detectors and the latest run's status decide.
+    pub fn raw_health(&self, now: DateTime<Utc>) -> CronHealth {
         let Some(latest) = self.runs.last() else {
             return CronHealth::Pending;
         };
+
+        // A materialised detection placeholder reports its reason directly, so the token survives
+        // (a synthetic missed/stuck run still reads `missing`/`stuck`, not `failed`).
+        if let Some(reason) = latest.reason {
+            return reason.health();
+        }
 
         if latest.status == CronStatus::Failed {
             return CronHealth::Failed;
@@ -351,9 +412,41 @@ impl Cron {
         }
     }
 
-    /// Whether the cron currently reads as passing.
-    pub fn passing(&self, now: DateTime<Utc>) -> bool {
-        self.health(now).passing()
+    /// The debounce/recovery window governing this cron's streak-derived health, falling back to the
+    /// default when the agent has not stamped a configured value.
+    pub fn window(&self) -> chrono::Duration {
+        self.debounce
+            .and_then(|w| chrono::Duration::from_std(w).ok())
+            .unwrap_or_else(Streak::default_recovery_window)
+    }
+
+    /// The cron's displayed health at `now`, debounced by `window`. The health *axis* (pass/fail) is
+    /// taken from the streak so a fault must persist for `window` before it shows and a recovery must
+    /// hold for `window` before it clears; the specific token is the raw one when it agrees with that
+    /// axis, or a neutral token on the confirmed side during a debounce window. A cron whose streak
+    /// carries no observations (legacy records) reads its instantaneous [`Cron::raw_health`].
+    pub fn health(&self, now: DateTime<Utc>, window: chrono::Duration) -> CronHealth {
+        let raw = self.raw_health(now);
+        if self.streak.is_empty() {
+            return raw;
+        }
+        match (self.streak.healthy_at(now, window), raw.passing()) {
+            // The debounced axis and the raw token already agree — report the specific token.
+            (true, true) | (false, false) => raw,
+            // Debounced-healthy while a fresh fault has not yet been confirmed: hold healthy.
+            (true, false) => CronHealth::Succeeded,
+            // Debounced-unhealthy while the raw token has already recovered: hold the fault.
+            (false, true) => CronHealth::Failed,
+        }
+    }
+
+    /// Whether the cron currently reads as passing at `now`, debounced by `window`.
+    pub fn passing(&self, now: DateTime<Utc>, window: chrono::Duration) -> bool {
+        if self.streak.is_empty() {
+            self.raw_health(now).passing()
+        } else {
+            self.streak.healthy_at(now, window)
+        }
     }
 
     /// When the current health state was entered, computed analytically (no sampling loop or streak
@@ -383,6 +476,11 @@ mod tests {
         DateTime::from_timestamp(secs, 0).unwrap()
     }
 
+    /// The window used by tests exercising the raw (empty-streak) health path.
+    fn win() -> chrono::Duration {
+        Streak::default_recovery_window()
+    }
+
     fn every(secs: u64) -> CronSchedule {
         CronSchedule::Every(Duration::from_secs(secs))
     }
@@ -392,6 +490,7 @@ mod tests {
             started_at: ts(start),
             status,
             duration: dur.map(Duration::from_secs),
+            reason: None,
         }
     }
 
@@ -411,18 +510,18 @@ mod tests {
     #[test]
     fn cold_start_is_pending() {
         let c = Cron::from_config("c", HashMap::new(), every(60), None, None);
-        assert_eq!(c.health(ts(10_000)), CronHealth::Pending);
-        assert!(c.passing(ts(10_000)));
+        assert_eq!(c.health(ts(10_000), win()), CronHealth::Pending);
+        assert!(c.passing(ts(10_000), win()));
         assert!(!c.schedule_overdue(ts(10_000)));
         assert!(!c.completion_overdue(ts(10_000)));
-        assert_eq!(c.since(c.health(ts(10_000))), None);
+        assert_eq!(c.since(c.health(ts(10_000), win())), None);
     }
 
     #[test]
     fn a_failed_latest_run_reads_failed() {
         let c = cron_with(every(60), vec![run(100, CronStatus::Failed, Some(0))], None, None);
-        assert_eq!(c.health(ts(101)), CronHealth::Failed);
-        assert!(!c.passing(ts(101)));
+        assert_eq!(c.health(ts(101), win()), CronHealth::Failed);
+        assert!(!c.passing(ts(101), win()));
 
         // A newer run that is merely running reads as running, not the previous failure.
         let c = cron_with(
@@ -431,17 +530,56 @@ mod tests {
             None,
             None,
         );
-        assert_eq!(c.health(ts(161)), CronHealth::Running);
+        assert_eq!(c.health(ts(161), win()), CronHealth::Running);
+    }
+
+    /// A monitor-synthesised run carries a reason marker: the raw health reports the reason's token
+    /// (missing/stuck) rather than `failed`, so the specific fault survives materialisation.
+    #[test]
+    fn synthetic_run_reports_its_reason_token() {
+        let mut c = cron_with(every(60), vec![run(100, CronStatus::Succeeded, Some(1))], None, None);
+        c.runs.push(CronRun {
+            started_at: ts(166),
+            status: CronStatus::Failed,
+            duration: None,
+            reason: Some(CronRunReason::Missed),
+        });
+        assert_eq!(c.raw_health(ts(200)), CronHealth::Missing);
+
+        c.runs.last_mut().unwrap().reason = Some(CronRunReason::Stuck);
+        assert_eq!(c.raw_health(ts(200)), CronHealth::Stuck);
+    }
+
+    /// With a non-empty streak the cron health is debounced by the window: a fault must persist for
+    /// the window before it shows, and a recovery must hold for the window before it clears.
+    #[test]
+    fn cron_health_is_debounced_by_the_streak() {
+        let window = chrono::Duration::minutes(5);
+        let base = ts(1_000);
+        let mut c = cron_with(every(60), vec![run(1_000, CronStatus::Failed, Some(0))], None, None);
+        // Model a sustained failing streak beginning at `base`.
+        c.streak = Streak {
+            failing_since: Some(base),
+            failing_until: Some(base + window),
+            covered_since: None,
+        };
+
+        // Raw health is failed immediately, but the debounced health holds healthy until the window.
+        assert_eq!(c.raw_health(base), CronHealth::Failed);
+        assert!(c.passing(base, window), "onset is debounced");
+        assert_eq!(c.health(base, window), CronHealth::Succeeded, "holds a healthy token during onset");
+        assert!(!c.passing(base + window, window), "trips at the window");
+        assert_eq!(c.health(base + window, window), CronHealth::Failed);
     }
 
     #[test]
     fn schedule_detector_flags_after_interval_plus_grace() {
         // interval 60s, default grace = 6s ⇒ deadline at last_start + 66s.
         let c = cron_with(every(60), vec![run(1_000, CronStatus::Succeeded, Some(5))], None, None);
-        assert_eq!(c.health(ts(1_065)), CronHealth::Succeeded);
-        assert!(c.passing(ts(1_065)));
-        assert_eq!(c.health(ts(1_067)), CronHealth::Missing);
-        assert!(!c.passing(ts(1_067)));
+        assert_eq!(c.health(ts(1_065), win()), CronHealth::Succeeded);
+        assert!(c.passing(ts(1_065), win()));
+        assert_eq!(c.health(ts(1_067), win()), CronHealth::Missing);
+        assert!(!c.passing(ts(1_067), win()));
     }
 
     #[test]
@@ -453,7 +591,7 @@ mod tests {
             .collect();
         let c = cron_with(every(60), runs, None, None);
         let last = 1_000 + 4 * 90;
-        assert_eq!(c.health(ts(last + 67)), CronHealth::Missing);
+        assert_eq!(c.health(ts(last + 67), win()), CronHealth::Missing);
     }
 
     #[test]
@@ -461,7 +599,7 @@ mod tests {
         // No max_duration: an in-flight run is never stuck (a long interval keeps the schedule
         // detector quiet so we isolate completion detection).
         let c = cron_with(every(3600), vec![run(1_000, CronStatus::Running, None)], None, None);
-        assert_eq!(c.health(ts(2_000)), CronHealth::Running);
+        assert_eq!(c.health(ts(2_000), win()), CronHealth::Running);
 
         // With max_duration, it goes stuck once exceeded, and clears once it completes.
         let c = cron_with(
@@ -470,8 +608,8 @@ mod tests {
             Some(Duration::from_secs(60)),
             None,
         );
-        assert_eq!(c.health(ts(1_055)), CronHealth::Running);
-        assert_eq!(c.health(ts(1_061)), CronHealth::Stuck);
+        assert_eq!(c.health(ts(1_055), win()), CronHealth::Running);
+        assert_eq!(c.health(ts(1_061), win()), CronHealth::Stuck);
 
         let c = cron_with(
             every(3600),
@@ -479,24 +617,24 @@ mod tests {
             Some(Duration::from_secs(60)),
             None,
         );
-        assert_eq!(c.health(ts(1_070)), CronHealth::Succeeded);
+        assert_eq!(c.health(ts(1_070), win()), CronHealth::Succeeded);
     }
 
     #[test]
     fn missing_since_is_the_deadline() {
         let c = cron_with(every(60), vec![run(1_000, CronStatus::Succeeded, Some(5))], None, None);
         let now = ts(2_000);
-        assert_eq!(c.health(now), CronHealth::Missing);
+        assert_eq!(c.health(now, win()), CronHealth::Missing);
         // last_start + interval + grace = 1000 + 60 + 6.
-        assert_eq!(c.since(c.health(now)), Some(ts(1_066)));
+        assert_eq!(c.since(c.health(now, win())), Some(ts(1_066)));
     }
 
     #[test]
     fn since_reports_failure_and_stuck_onsets() {
         // A failed terminal run reads as failing since the run finished (start + duration).
         let c = cron_with(every(60), vec![run(1_000, CronStatus::Failed, Some(5))], None, None);
-        assert_eq!(c.health(ts(1_006)), CronHealth::Failed);
-        assert_eq!(c.since(c.health(ts(1_006))), Some(ts(1_005)));
+        assert_eq!(c.health(ts(1_006), win()), CronHealth::Failed);
+        assert_eq!(c.since(c.health(ts(1_006), win())), Some(ts(1_005)));
 
         // A stuck in-flight run reads as overrunning since start + max_duration.
         let c = cron_with(
@@ -506,8 +644,8 @@ mod tests {
             None,
         );
         let now = ts(2_000);
-        assert_eq!(c.health(now), CronHealth::Stuck);
-        assert_eq!(c.since(c.health(now)), Some(ts(1_060)));
+        assert_eq!(c.health(now, win()), CronHealth::Stuck);
+        assert_eq!(c.since(c.health(now, win())), Some(ts(1_060)));
     }
 
     #[test]
@@ -563,16 +701,16 @@ mod tests {
         let start = DateTime::parse_from_rfc3339("2026-01-01T12:00:00Z").unwrap().with_timezone(&Utc);
         let c = cron_with(
             CronSchedule::Cron("* * * * *".into()),
-            vec![CronRun { started_at: start, status: CronStatus::Succeeded, duration: None }],
+            vec![CronRun { started_at: start, status: CronStatus::Succeeded, duration: None, reason: None }],
             None,
             None,
         );
 
         // Next due 12:01:00; deadline 12:06:00 (5m grace).
         let before = DateTime::parse_from_rfc3339("2026-01-01T12:05:00Z").unwrap().with_timezone(&Utc);
-        assert_eq!(c.health(before), CronHealth::Succeeded);
+        assert_eq!(c.health(before, win()), CronHealth::Succeeded);
         let after = DateTime::parse_from_rfc3339("2026-01-01T12:06:30Z").unwrap().with_timezone(&Utc);
-        assert_eq!(c.health(after), CronHealth::Missing);
+        assert_eq!(c.health(after, win()), CronHealth::Missing);
     }
 
     #[test]

--- a/api/src/probe.rs
+++ b/api/src/probe.rs
@@ -25,9 +25,25 @@ pub struct Probe {
     /// The cluster-converged record of this probe's pass/fail streaks
     #[serde(default)]
     pub streak: Streak,
+
+    /// The debounce window applied to this probe's streak-derived health (a config echo of the
+    /// probe's `alerting.debounce`, stamped by the agent). Applied symmetrically to both the onset of
+    /// a fault and the recovery from it. `None` falls back to [`Streak::default_recovery_window`],
+    /// preserving the historical 5-minute behaviour for records written before per-probe alerting
+    /// existed.
+    #[serde(default, with = "humantime_serde::option")]
+    pub debounce: Option<std::time::Duration>,
 }
 
 impl Probe {
+    /// The debounce window governing this probe's streak-derived health, falling back to the default
+    /// when the agent has not stamped a configured value.
+    pub fn window(&self) -> chrono::Duration {
+        self.debounce
+            .and_then(|w| chrono::Duration::from_std(w).ok())
+            .unwrap_or_else(Streak::default_recovery_window)
+    }
+
     /// Aggregate all observations into a single total observation
     pub fn total(&self) -> Observation {
         self.observations.values().fold(Observation::default(), |mut acc, obs| {
@@ -41,14 +57,19 @@ impl Probe {
         self.total().success_rate()
     }
 
-    /// Whether this probe is currently passing, falling back to the latest history
-    /// bucket's result when the streak record carries no observations.
+    /// Whether this probe is currently passing (debounced by its configured window), falling back to
+    /// the latest history bucket's result when the streak record carries no observations.
     pub fn passing(&self) -> bool {
         if self.streak.is_empty() {
             self.history.last().map(|h| h.pass).unwrap_or(true)
         } else {
-            self.streak.passing()
+            self.streak.healthy_at(chrono::Utc::now(), self.window())
         }
+    }
+
+    /// When the probe's current (debounced) state was entered.
+    pub fn since(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.streak.since_at(chrono::Utc::now(), self.window())
     }
 
     /// The derived status token used to describe the probe in notifications: `"passing"` or
@@ -143,6 +164,7 @@ mod tests {
                 total_latency: std::time::Duration::from_secs(5),
             })].into_iter().collect(),
             streak: Streak::default(),
+            debounce: None,
         };
 
         let probe2 = Probe {
@@ -157,6 +179,7 @@ mod tests {
                 total_latency: std::time::Duration::from_secs(3),
             })].into_iter().collect(),
             streak: Streak::default(),
+            debounce: None,
         };
 
         probe1.merge(&probe2);
@@ -190,6 +213,7 @@ mod tests {
                 }),
             ].into_iter().collect(),
             streak: Streak::default(),
+            debounce: None,
         };
 
         let total = probe.total();
@@ -221,6 +245,7 @@ mod tests {
                 }),
             ].into_iter().collect(),
             streak: Streak::default(),
+            debounce: None,
         };
 
         let availability = probe.availability();
@@ -237,6 +262,7 @@ mod tests {
             history: vec![],
             observations: HashMap::new(),
             streak: Streak::default(),
+            debounce: None,
         };
 
         // With an empty streak record (e.g. data from older agents), the probe falls
@@ -252,22 +278,37 @@ mod tests {
         });
         assert!(!probe.passing());
 
-        // A streak record with a long-standing coverage claim reports passing...
-        probe.streak.observe(true, now - chrono::Duration::days(3));
-        assert!(probe.streak.passing_at(now));
-        assert_eq!(probe.streak.since_at(now), Some(now - chrono::Duration::days(3)));
+        // A streak record with a long-standing coverage claim reports passing.
+        probe.streak.observe(true, now - chrono::Duration::days(3), Streak::default_recovery_window());
+        assert!(probe.streak.passing_at(now, Streak::default_recovery_window()));
+        assert_eq!(probe.streak.since_at(now, Streak::default_recovery_window()), Some(now - chrono::Duration::days(3)));
         assert!(probe.passing());
+    }
 
-        // ...until a failure is observed by any node, which wins immediately.
-        probe.streak.observe(false, now - chrono::Duration::minutes(1));
-        assert!(!probe.passing());
-        assert_eq!(probe.streak.since_at(now), Some(now - chrono::Duration::minutes(1)));
+    /// The streak-derived health is debounced by the window: a fault reads failing only once it has
+    /// persisted for the whole window, and reads passing again a window after the last failure. This
+    /// is evaluated at explicit instants (unlike [`Probe::passing`], which reads the wall clock).
+    #[test]
+    fn test_probe_health_is_debounced() {
+        let window = Streak::default_recovery_window();
+        let base = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+        // A continuous fault: onset at `base`, still failing at `base + window`.
+        let streak = Streak {
+            failing_since: Some(base),
+            failing_until: Some(base + window),
+            covered_since: None,
+        };
 
-        // Once no failures have been seen for the recovery window, the probe reads as
-        // passing again, since the last failing observation.
-        let later = now + Streak::recovery_window();
-        assert!(probe.streak.passing_at(later));
-        assert_eq!(probe.streak.since_at(later), Some(now - chrono::Duration::minutes(1)));
+        // The onset is debounced away until the fault is a full window old.
+        assert!(streak.healthy_at(base, window), "onset must be debounced");
+        assert!(streak.healthy_at(base + window - chrono::Duration::seconds(1), window));
+        assert!(!streak.healthy_at(base + window, window), "a sustained fault trips at the window");
+        assert_eq!(streak.since_at(base + window, window), Some(base));
+
+        // Recovery is likewise debounced: still failing until a window after the last failure.
+        let last_fail = base + window;
+        assert!(!streak.healthy_at(last_fail + window - chrono::Duration::seconds(1), window));
+        assert!(streak.healthy_at(last_fail + window + chrono::Duration::seconds(1), window));
     }
 
     #[test]
@@ -288,6 +329,7 @@ mod tests {
                 failing_until: Some(chrono::DateTime::from_timestamp(1_699_999_900, 0).unwrap()),
                 covered_since: Some(chrono::DateTime::from_timestamp(1_690_000_000, 0).unwrap()),
             },
+            debounce: None,
         };
 
         let packed = rmp_serde::to_vec(&probe).unwrap();

--- a/api/src/streak.rs
+++ b/api/src/streak.rs
@@ -16,9 +16,10 @@ pub struct Streak {
     pub failing_since: Option<DateTime<Utc>>,
 
     /// The most recent failing observation made by any node. The probe reads as failing
-    /// until this is more than [`Streak::recovery_window`] in the past, so a failure
-    /// which stops being observed (transient issues, or its only observer going away)
-    /// recovers on its own — there are no recovery declarations to converge on.
+    /// until this is more than the recovery window (a probe/cron's `alerting.debounce`,
+    /// defaulting to [`Streak::default_recovery_window`]) in the past, so a failure which
+    /// stops being observed (transient issues, or its only observer going away) recovers
+    /// on its own — there are no recovery declarations to converge on.
     #[serde(default, with = "chrono::serde::ts_milliseconds_option")]
     pub failing_until: Option<DateTime<Utc>>,
 
@@ -31,10 +32,11 @@ pub struct Streak {
 }
 
 impl Streak {
-    /// How long after the last failing observation the probe is still considered to be
-    /// failing. Recovery is implicit: failures which stop being observed for this long
-    /// expire, rather than requiring observers to agree on a recovery.
-    pub fn recovery_window() -> chrono::Duration {
+    /// The recovery window applied when a caller does not supply an explicit one: how long after the
+    /// last failing observation an entity is still considered failing before recovery is implied.
+    /// The window is configurable per-entity (a probe/cron's `alerting.debounce`); this is the
+    /// fallback preserving the historical behaviour.
+    pub fn default_recovery_window() -> chrono::Duration {
         chrono::Duration::minutes(5)
     }
 
@@ -44,49 +46,57 @@ impl Streak {
         self.failing_since.is_none() && self.failing_until.is_none() && self.covered_since.is_none()
     }
 
-    /// Whether the probe reads as failing at `now`: a failure has been observed within
-    /// the last [`Streak::recovery_window`].
-    pub fn failing_at(&self, now: DateTime<Utc>) -> bool {
+    /// Whether a failure has been observed within the last `window` at `now` — the raw (un-debounced)
+    /// failing signal, used both for display of an in-progress fault and as the building block for the
+    /// debounced [`Streak::failing_for`].
+    pub fn failing_at(&self, now: DateTime<Utc>, window: chrono::Duration) -> bool {
         self.failing_until
-            .map(|until| until > now - Self::recovery_window())
+            .map(|until| until > now - window)
             .unwrap_or(false)
     }
 
-    /// Whether the probe reads as passing at `now`.
-    pub fn passing_at(&self, now: DateTime<Utc>) -> bool {
-        !self.failing_at(now)
+    /// Whether no failure has been observed within the last `window` at `now`.
+    pub fn passing_at(&self, now: DateTime<Utc>, window: chrono::Duration) -> bool {
+        !self.failing_at(now, window)
     }
 
-    /// When the state reported at `now` was entered: the failure onset while failing;
-    /// after a failure expires, the streak starts at the last failing observation; and a
-    /// probe which has never failed has been passing for as long as it has been watched.
-    pub fn since_at(&self, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
-        if self.failing_at(now) {
+    /// The debounced failing signal: whether the entity has been *continuously* failing for at least
+    /// `window` at `now`. This is true only once a failure has been observed within the last `window`
+    /// (still failing) **and** the current episode began at least `window` ago — so a fault shorter
+    /// than `window` never trips it, and a genuine one trips exactly `window` after it began. Because
+    /// `failing_since` only advances at the start of a fresh episode, "began ≥ window ago" implies no
+    /// recovery occurred in between.
+    pub fn failing_for(&self, now: DateTime<Utc>, window: chrono::Duration) -> bool {
+        self.failing_at(now, window)
+            && self
+                .failing_since
+                .map(|since| now - since >= window)
+                .unwrap_or(false)
+    }
+
+    /// The debounced health at `now`: the entity reads healthy unless it has been continuously
+    /// failing for at least `window` (see [`Streak::failing_for`]). Symmetric — a failure shorter
+    /// than `window`, or a recovery younger than `window`, reads as the prior (healthy) state.
+    pub fn healthy_at(&self, now: DateTime<Utc>, window: chrono::Duration) -> bool {
+        !self.failing_for(now, window)
+    }
+
+    /// When the debounced state reported at `now` was entered: the failure onset while (debounced)
+    /// failing; otherwise the last failing observation, or — for an entity which has never failed —
+    /// the earliest passing observation.
+    pub fn since_at(&self, now: DateTime<Utc>, window: chrono::Duration) -> Option<DateTime<Utc>> {
+        if self.failing_for(now, window) {
             self.failing_since
         } else {
             self.failing_until.or(self.covered_since)
         }
     }
 
-    /// Whether the probe currently reads as failing.
-    pub fn failing(&self) -> bool {
-        self.failing_at(Utc::now())
-    }
-
-    /// Whether the probe currently reads as passing.
-    pub fn passing(&self) -> bool {
-        self.passing_at(Utc::now())
-    }
-
-    /// When the current state was entered.
-    pub fn since(&self) -> Option<DateTime<Utc>> {
-        self.since_at(Utc::now())
-    }
-
     /// Folds a sample into the register. Every write is monotone (it can only move the
     /// register up the join lattice), so concurrent observations from different nodes —
-    /// or even out-of-order samples — converge without coordination.
-    pub fn observe(&mut self, passing: bool, time: DateTime<Utc>) {
+    /// or even out-of-order samples — converge without coordination. `window` decides whether a
+    /// failing sample continues the current episode or starts a fresh one.
+    pub fn observe(&mut self, passing: bool, time: DateTime<Utc>, window: chrono::Duration) {
         if passing {
             // A no-op unless this is the earliest passing observation the cluster has
             // ever made; in particular a restarted node cannot shorten the streak.
@@ -95,7 +105,7 @@ impl Streak {
                 (mine, sample) => mine.or(sample),
             };
         } else {
-            if !self.failing_at(time) {
+            if !self.failing_at(time, window) {
                 // The first failure after a passing period starts a new episode; while
                 // the register already reads failing, the onset stays where it was.
                 self.failing_since = self.failing_since.max(Some(time));
@@ -129,6 +139,11 @@ mod tests {
 
     fn ts(secs: i64) -> DateTime<Utc> {
         DateTime::from_timestamp(secs, 0).unwrap()
+    }
+
+    /// The window used by tests that don't care about the exact debounce value.
+    fn win() -> chrono::Duration {
+        Streak::default_recovery_window()
     }
 
     fn streak(failing_since: Option<i64>, failing_until: Option<i64>, covered_since: Option<i64>) -> Streak {
@@ -181,65 +196,112 @@ mod tests {
         let mut register = streak(None, None, Some(1_000));
 
         // ...and a freshly restarted node's samples cannot shorten that streak.
-        register.observe(true, ts(500_000));
+        register.observe(true, ts(500_000), win());
         assert_eq!(register.covered_since, Some(ts(1_000)));
-        assert!(register.passing_at(ts(500_000)));
-        assert_eq!(register.since_at(ts(500_000)), Some(ts(1_000)));
+        assert!(register.passing_at(ts(500_000), win()));
+        assert_eq!(register.since_at(ts(500_000), win()), Some(ts(1_000)));
 
         // An earlier observation (e.g. replayed out of order) can only extend it.
-        register.observe(true, ts(500));
+        register.observe(true, ts(500), win());
         assert_eq!(register.covered_since, Some(ts(500)));
     }
 
     #[test]
     fn test_failure_episodes() {
-        let window = Streak::recovery_window().num_seconds();
+        let window = win().num_seconds();
         let mut register = streak(None, None, Some(1_000));
 
         // A failure starts an episode and reads as failing immediately.
-        register.observe(false, ts(10_000));
-        assert!(register.failing_at(ts(10_000)));
-        assert_eq!(register.since_at(ts(10_000)), Some(ts(10_000)));
+        register.observe(false, ts(10_000), win());
+        assert!(register.failing_at(ts(10_000), win()));
+        assert_eq!(register.since_at(ts(10_000), win()), Some(ts(10_000)));
 
         // Further failing observations refresh the high-water mark without moving the
         // onset, even from observers which joined the episode late.
-        register.observe(false, ts(10_060));
-        register.observe(false, ts(10_120));
+        register.observe(false, ts(10_060), win());
+        register.observe(false, ts(10_120), win());
         assert_eq!(register.failing_since, Some(ts(10_000)));
         assert_eq!(register.failing_until, Some(ts(10_120)));
 
         // Once no failure has been observed for the recovery window, the probe reads as
         // passing since the last failing observation...
         let recovered_at = ts(10_120 + window + 1);
-        assert!(register.passing_at(recovered_at));
-        assert_eq!(register.since_at(recovered_at), Some(ts(10_120)));
+        assert!(register.passing_at(recovered_at, win()));
+        assert_eq!(register.since_at(recovered_at, win()), Some(ts(10_120)));
 
         // ...and coverage from before the failure is permanently superseded.
-        register.observe(true, ts(10_121));
-        assert_eq!(register.since_at(recovered_at), Some(ts(10_120)));
+        register.observe(true, ts(10_121), win());
+        assert_eq!(register.since_at(recovered_at, win()), Some(ts(10_120)));
 
         // A failure after recovery starts a new episode with a fresh onset.
         let second_failure = 10_120 + window + 100;
-        register.observe(false, ts(second_failure));
-        assert!(register.failing_at(ts(second_failure)));
+        register.observe(false, ts(second_failure), win());
+        assert!(register.failing_at(ts(second_failure), win()));
         assert_eq!(register.failing_since, Some(ts(second_failure)));
+    }
+
+    /// The debounced [`Streak::failing_for`] only trips once a fault has persisted for the whole
+    /// window, and clears once no failure has been observed for the window — the symmetric hysteresis
+    /// that gates alerting.
+    #[test]
+    fn test_failing_for_debounces_both_directions() {
+        let window = chrono::Duration::minutes(5);
+        let w = window.num_seconds();
+        let mut register = streak(None, None, Some(0));
+
+        // A sustained fault: an onset at t=1000, kept alive by failures every half-window so it stays
+        // one continuous episode (failing_since pinned at 1000, failing_until advancing).
+        register.observe(false, ts(1_000), window);
+        for k in 1..=4 {
+            register.observe(false, ts(1_000 + k * (w / 2)), window);
+        }
+        assert_eq!(register.failing_since, Some(ts(1_000)), "the episode stays continuous");
+        let last_fail = 1_000 + 2 * w;
+        assert_eq!(register.failing_until, Some(ts(last_fail)));
+
+        // Not debounced-failing until the episode is a full window old; then it trips.
+        assert!(!register.failing_for(ts(1_000 + w - 1), window), "onset must not trip before the window");
+        assert!(register.healthy_at(ts(1_000 + w - 1), window));
+        assert!(register.failing_for(ts(1_000 + w), window), "a sustained fault trips at exactly the window");
+        assert_eq!(register.since_at(ts(1_000 + w), window), Some(ts(1_000)));
+
+        // Recovery is likewise debounced: it stays failing until a full window after the last failure.
+        assert!(register.failing_for(ts(last_fail + w - 1), window), "recovery must not clear before the window");
+        assert!(register.healthy_at(ts(last_fail + w + 1), window));
+    }
+
+    /// A blip shorter than the window never trips the debounced signal in either direction.
+    #[test]
+    fn test_failing_for_ignores_short_blips() {
+        let window = chrono::Duration::minutes(5);
+        let mut register = streak(None, None, Some(0));
+
+        // A single failing sample that is never repeated.
+        register.observe(false, ts(1_000), window);
+
+        // It reads raw-failing during the window, but `failing_for` is never simultaneously true with
+        // a still-failing state for a single-sample blip, so it never fires an alert.
+        for offset in [0, 60, 120, 240, 299, 300, 301, 600] {
+            let now = ts(1_000) + chrono::Duration::seconds(offset);
+            assert!(!register.failing_for(now, window), "blip must not trip at +{offset}s");
+        }
     }
 
     #[test]
     fn test_transient_subset_failure_recovers_on_its_own() {
         // One node sees a single failing sample; nobody declares a recovery.
-        let window = Streak::recovery_window().num_seconds();
+        let window = win().num_seconds();
         let mut register = streak(None, None, Some(1_000));
-        register.observe(false, ts(20_000));
+        register.observe(false, ts(20_000), win());
 
         // Other nodes' passing samples don't mask the failure...
-        register.observe(true, ts(20_030));
-        assert!(register.failing_at(ts(20_030)));
+        register.observe(true, ts(20_030), win());
+        assert!(register.failing_at(ts(20_030), win()));
 
         // ...but once the window passes without further failures, the probe recovers,
         // passing since the failing observation.
-        assert!(register.passing_at(ts(20_000 + window + 1)));
-        assert_eq!(register.since_at(ts(20_000 + window + 1)), Some(ts(20_000)));
+        assert!(register.passing_at(ts(20_000 + window + 1), win()));
+        assert_eq!(register.since_at(ts(20_000 + window + 1), win()), Some(ts(20_000)));
     }
 
     #[test]
@@ -255,8 +317,8 @@ mod tests {
         assert_eq!(ab, ba);
 
         assert_eq!(ab.covered_since, Some(ts(1_000)));
-        assert!(ab.failing_at(ts(50_100)));
-        assert_eq!(ab.since_at(ts(50_100)), Some(ts(50_000)));
+        assert!(ab.failing_at(ts(50_100), win()));
+        assert_eq!(ab.failing_since, Some(ts(50_000)), "the failure onset converges");
 
         // Joining with an empty register (a record from an older agent) is the identity.
         let mut with_empty = ab.clone();

--- a/api/src/webhook.rs
+++ b/api/src/webhook.rs
@@ -160,7 +160,7 @@ impl WebhookEvent {
                 previous: previous_token.into(),
                 healthy: probe.passing(),
                 was_healthy: previous_healthy,
-                since: probe.streak.since(),
+                since: probe.since(),
                 availability: Some(probe.availability()),
             },
             probe: Some(probe.clone()),
@@ -178,7 +178,7 @@ impl WebhookEvent {
         previous_token: impl Into<String>,
         previous_healthy: bool,
     ) -> Self {
-        let health = cron.health(now);
+        let health = cron.health(now, cron.window());
         Self {
             version: WEBHOOK_SCHEMA_VERSION.to_string(),
             id: id.into(),
@@ -215,17 +215,21 @@ mod tests {
 
     fn failing_probe(name: &str) -> Probe {
         let now = Utc::now();
-        let mut probe = Probe {
+        let window = Streak::default_recovery_window();
+        Probe {
             name: name.into(),
             tags: vec![("service".into(), "Web".into())].into_iter().collect(),
             last_updated: now,
             history: Vec::new(),
             observations: HashMap::new(),
-            streak: Streak::default(),
-        };
-        // A single failing observation flips the streak to failing.
-        probe.streak.observe(false, now);
-        probe
+            // A sustained fault older than the debounce window, so the debounced health reads failing.
+            streak: Streak {
+                failing_since: Some(now - window - chrono::Duration::seconds(1)),
+                failing_until: Some(now),
+                covered_since: None,
+            },
+            debounce: None,
+        }
     }
 
     #[test]
@@ -256,7 +260,7 @@ mod tests {
             None,
             None,
         );
-        cron.push_run(CronRun { started_at: ts(100), status: CronStatus::Failed, duration: Some(Duration::from_secs(5)) });
+        cron.push_run(CronRun { started_at: ts(100), status: CronStatus::Failed, duration: Some(Duration::from_secs(5)), reason: None });
         cron.last_checkin = Some(CheckIn { at: ts(105), status: CronStatus::Failed, message: "boom".into() });
 
         let event = WebhookEvent::for_cron("evt-2", ts(200), &cron, ts(200), "succeeded", true);

--- a/docs/guide/webhooks.md
+++ b/docs/guide/webhooks.md
@@ -42,6 +42,46 @@ When Grey starts it records the current state of every entity **silently**, so a
 replays the state your services are already in — only genuine transitions observed afterwards are
 delivered.
 
+## Tuning sensitivity: `alerting`
+By default a probe or cron is considered to have changed health only once the new state has held
+**continuously for five minutes** — both when it becomes unhealthy and when it recovers. This
+debounce suppresses brief flaps so a single failed sample, or a job that is a few seconds late, does
+not page anyone. You can tune it per entity with an `alerting` block:
+
+```yaml
+probes:
+  - name: example.web
+    policy: { interval: 5s, timeout: 2s }
+    target: !Http
+      url: https://example.com
+    alerting:
+      enabled: true      # deliver webhooks for this probe's transitions (the default)
+      debounce: 10m      # require the new state to hold for 10 minutes before reporting it
+
+crons:
+  - name: backup.nightly
+    schedule: '0 2 * * *'
+    alerting:
+      debounce: 0s       # report as soon as the state is derived (no debounce)
+```
+
+| Field | Default | Description |
+| ----- | ------- | ----------- |
+| `alerting.enabled` | `true` | Whether webhook notifications fire for this entity. When `false`, its health is still tracked and shown on the status page, but no webhook is delivered. |
+| `alerting.debounce` | `5m` | How long a new health state must hold before it is reported. Applied symmetrically to both the onset of a fault and the recovery from it. |
+
+The `debounce` also governs the entity's **displayed** health: a fault is shown (and a recovery
+cleared) only once it has held for this long, so the status page and the webhooks always agree. For a
+probe this replaces the previously fixed five-minute recovery window with your configured value; set
+a shorter `debounce` for faster, noisier alerting or a longer one to ride out routine flapping.
+
+### Missed and overrunning cron runs
+A cron that never checks in (a missed run — the deadman-switch case) or one that overruns its
+`max_duration` has no check-in to record, so Grey synthesises a placeholder run for it. These
+placeholders appear on the status page in grey (distinct from a job-reported failure) and progress
+the same health signal, so a missed run is debounced and alerted on exactly like a reported failure.
+
+
 ## The event payload
 The payload mirrors the probe/cron API representation rather than any single node's view: the
 transition is derived from the cluster-converged streak (probes) or cron health — which already fold

--- a/example/webhooks.yml
+++ b/example/webhooks.yml
@@ -35,6 +35,10 @@ probes:
     tags:
       service: Example
       team: Platform
+    # Only alert once the probe has been failing (or recovered) continuously for two minutes,
+    # riding out brief blips. `debounce` also governs the displayed health, and defaults to 5m.
+    alerting:
+      debounce: 2m
 
 crons:
   - name: backup.nightly
@@ -44,6 +48,10 @@ crons:
     tags:
       service: Backups
       team: Platform
+    # A missed nightly backup is materialised as a grey placeholder run and alerted on like a
+    # reported failure; alerting is enabled by default.
+    alerting:
+      enabled: true
 
 webhooks:
   # Page the on-call team for any *unhealthy* transition (a probe failing, or a cron that

--- a/ui/src/components/cron.rs
+++ b/ui/src/components/cron.rs
@@ -1,7 +1,7 @@
 use super::{Popover, PopoverAlign, StatusDot};
 use crate::formatters::compact_duration;
 use crate::styles::{cron_class, cron_run_class};
-use grey_api::{CronHealth, CronRun, CronSchedule, CronStatus};
+use grey_api::{CronHealth, CronRun, CronRunReason, CronSchedule, CronStatus};
 use yew::prelude::*;
 
 #[derive(Properties, PartialEq)]
@@ -16,7 +16,7 @@ pub struct CronProps {
 pub fn cron(props: &CronProps) -> Html {
     let cron = &props.cron;
     let now = chrono::Utc::now();
-    let health = cron.health(now);
+    let health = cron.health(now, cron.window());
     let class = cron_class(health);
 
     // Which run's popover is currently open (on hover).
@@ -91,7 +91,7 @@ pub fn cron(props: &CronProps) -> Html {
                         };
                         html! {
                             <span
-                                class={classes!("cron-run", cron_run_class(run.status), is_hovered.then_some("tooltip-target"))}
+                                class={classes!("cron-run", cron_run_class(run), is_hovered.then_some("tooltip-target"))}
                                 {onmouseenter}
                                 {onmouseleave}
                             >
@@ -139,11 +139,19 @@ fn render_run_popover(run: &CronRun, align: PopoverAlign) -> Html {
         None => None,
     };
 
+    // A synthesised placeholder is labelled by its detected fault (missed/stuck) rather than the
+    // underlying status it carries to progress the streak.
+    let status = match run.reason {
+        Some(CronRunReason::Missed) => "Missed run",
+        Some(CronRunReason::Stuck) => "Overrunning",
+        None => run.status.label(),
+    };
+
     html! {
         <Popover
             {align}
-            status_class={cron_run_class(run.status)}
-            status={run.status.label()}
+            status_class={cron_run_class(run)}
+            status={status}
             timestamp={timestamp}
         >
             <div class="tooltip__details">
@@ -196,6 +204,7 @@ mod tests {
             started_at: now - chrono::Duration::seconds(30),
             status: CronStatus::Succeeded,
             duration: Some(Duration::from_secs(30)),
+            reason: None,
         });
         cron.last_checkin = Some(grey_api::CheckIn {
             at: now,
@@ -226,6 +235,7 @@ mod tests {
             started_at: chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
             status: CronStatus::Succeeded,
             duration: Some(Duration::from_secs(90)),
+            reason: None,
         };
         let html = yew::ServerRenderer::<PopoverHarness>::with_props(move || PopoverHarnessProps { run })
             .render()

--- a/ui/src/components/probe.rs
+++ b/ui/src/components/probe.rs
@@ -12,15 +12,16 @@ pub struct ProbeProps {
 pub fn probe(props: &ProbeProps) -> Html {
     let recent_availability = props.probe.recent(2).success_rate();
     let streak = props.probe.streak.clone();
+    let window = props.probe.window();
 
-    // Key the status off the currently observed state so a recovery is reflected
-    // immediately, using the recent average only to grade how severe an ongoing failure is.
+    // Key the status off the currently observed (debounced) state so a recovery is reflected once it
+    // settles, using the recent average only to grade how severe an ongoing failure is.
     let probe_class = probe_class(props.probe.passing(), recent_availability);
 
     // How long the probe has held its current state, e.g. "healthy for 5d" or "unhealthy for 17m".
-    let streak_text = streak.since().map(|since| {
+    let streak_text = props.probe.since().map(|since| {
         let held_for = compact_duration(chrono::Utc::now().signed_duration_since(since));
-        if streak.passing() {
+        if props.probe.passing() {
             format!("healthy for {held_for}")
         } else {
             format!("unhealthy for {held_for}")
@@ -53,7 +54,7 @@ pub fn probe(props: &ProbeProps) -> Html {
                 }
                 <div class="probe__availability">{availability(props.probe.availability())}</div>
             </div>
-            <ProbeHistory samples={props.probe.history.clone()} streak={streak} />
+            <ProbeHistory samples={props.probe.history.clone()} streak={streak} window={window} />
         </div>
     }
 }
@@ -86,6 +87,7 @@ mod tests {
             history: vec![],
             observations: Default::default(),
             streak,
+            debounce: None,
         };
         yew::ServerRenderer::<Harness>::with_props(move || HarnessProps { probe })
             .render()
@@ -95,7 +97,7 @@ mod tests {
     #[tokio::test]
     async fn test_shows_healthy_streak_duration() {
         let mut streak = Streak::default();
-        streak.observe(true, chrono::Utc::now() - chrono::Duration::days(5));
+        streak.observe(true, chrono::Utc::now() - chrono::Duration::days(5), Streak::default_recovery_window());
 
         let html = render(streak).await;
         assert!(html.contains("healthy for 5d"), "expected the healthy streak text, got: {html}");
@@ -108,7 +110,7 @@ mod tests {
         let mut streak = Streak::default();
         let now = chrono::Utc::now();
         for minutes_ago in (2..=17).rev().step_by(3) {
-            streak.observe(false, now - chrono::Duration::minutes(minutes_ago));
+            streak.observe(false, now - chrono::Duration::minutes(minutes_ago), Streak::default_recovery_window());
         }
 
         let html = render(streak).await;

--- a/ui/src/components/probe_history.rs
+++ b/ui/src/components/probe_history.rs
@@ -23,6 +23,11 @@ pub struct ProbeHistoryProps {
     /// segment (and its tooltip) from the live state rather than the bucket's average.
     #[prop_or_default]
     pub streak: grey_api::Streak,
+
+    /// The probe's configured debounce/recovery window, so the live segment's debounced health
+    /// matches the rest of the UI. Defaults to the streak's default window.
+    #[prop_or_else(grey_api::Streak::default_recovery_window)]
+    pub window: chrono::Duration,
 }
 
 #[derive(Clone, Default, PartialEq)]
@@ -107,7 +112,7 @@ pub fn probe_history(props: &ProbeHistoryProps) -> Html {
                 // Older segments only have their averages to go on.
                 let is_current = index + 1 == props.samples.len();
                 let current_streak = (is_current && !props.streak.is_empty()).then_some(&props.streak);
-                let current_passing = current_streak.map(|s| s.passing());
+                let current_passing = current_streak.map(|s| s.healthy_at(Utc::now(), props.window));
                 let sample_class = sample_class(current_passing, sample.max_availability());
 
                 // Serialize the entire ProbeResult to JSON
@@ -125,7 +130,7 @@ pub fn probe_history(props: &ProbeHistoryProps) -> Html {
                     >
                         if is_tooltip_target {
                             if let Some(probe_result) = &tooltip_data.probe_result {
-                                {render_tooltip(probe_result, current_streak, auth_data.is_authenticated())}
+                                {render_tooltip(probe_result, current_streak, props.window, auth_data.is_authenticated())}
                             } else {
                                 // Fallback for SSR or when probe_result is None
                                 <Popover status_class="unknown" status="Loading...">
@@ -145,15 +150,17 @@ pub fn probe_history(props: &ProbeHistoryProps) -> Html {
     }
 }
 
-fn render_tooltip(probe_result: &ProbeHistoryBucket, streak: Option<&grey_api::Streak>, include_observers: bool) -> Html {
+fn render_tooltip(probe_result: &ProbeHistoryBucket, streak: Option<&grey_api::Streak>, window: chrono::Duration, include_observers: bool) -> Html {
     let (status_text, status_class) = match streak {
         Some(streak) => {
+            let now = Utc::now();
+            let healthy = streak.healthy_at(now, window);
             let since = streak
-                .since()
-                .map(|t| format!(" for {}", compact_duration(Utc::now() - t)))
+                .since_at(now, window)
+                .map(|t| format!(" for {}", compact_duration(now - t)))
                 .unwrap_or_default();
-            let label = if streak.passing() { "Passing" } else { "Failing" };
-            (format!("{label}{since}"), pass_class(streak.passing()))
+            let label = if healthy { "Passing" } else { "Failing" };
+            (format!("{label}{since}"), pass_class(healthy))
         }
         _ => (
             (if probe_result.max_availability() == 100.0 { "Passed" } else { "Failed" }).to_string(),
@@ -277,7 +284,7 @@ mod tests {
     #[function_component(Harness)]
     fn harness(props: &HarnessProps) -> Html {
         let streak = (!props.streak.is_empty()).then_some(&props.streak);
-        render_tooltip(&props.bucket, streak, true)
+        render_tooltip(&props.bucket, streak, grey_api::Streak::default_recovery_window(), true)
     }
 
     async fn render(streak: grey_api::Streak) -> String {
@@ -296,7 +303,7 @@ mod tests {
     #[tokio::test]
     async fn test_tooltip_shows_bucket_footer_and_streak_since() {
         let mut streak = grey_api::Streak::default();
-        streak.observe(true, chrono::Utc::now() - chrono::Duration::days(5));
+        streak.observe(true, chrono::Utc::now() - chrono::Duration::days(5), grey_api::Streak::default_recovery_window());
 
         let html = render(streak).await;
         assert!(html.contains("popover__time"), "expected the bucket timestamp footer, got: {html}");

--- a/ui/src/components/service_list.rs
+++ b/ui/src/components/service_list.rs
@@ -22,7 +22,7 @@ impl ServiceGroup<'_> {
         }
 
         let healthy = self.probes.iter().filter(|p| p.passing()).count()
-            + self.crons.iter().filter(|c| c.passing(now)).count();
+            + self.crons.iter().filter(|c| c.passing(now, c.window())).count();
 
         let health = if healthy == total {
             "ok"
@@ -136,6 +136,7 @@ mod tests {
             history: vec![],
             observations: Default::default(),
             streak: Default::default(),
+            debounce: None,
         }
     }
 

--- a/ui/src/styles/cron.rs
+++ b/ui/src/styles/cron.rs
@@ -1,4 +1,4 @@
-use grey_api::{CronHealth, CronStatus};
+use grey_api::{CronHealth, CronRun, CronStatus};
 
 /// The colour class for a cron's derived health: a healthy run is `ok` (green), an in-flight run is
 /// `running` (light-blue), an overdue or overrunning run is `warn` (orange), a failed run is `error`
@@ -14,9 +14,14 @@ pub fn cron_class(health: CronHealth) -> &'static str {
 }
 
 /// The colour class for a single run cell in the recent-runs strip: a successful run is `ok` (green),
-/// an in-flight run is `running` (light-blue), and a failed run is `error` (red).
-pub fn cron_run_class(status: CronStatus) -> &'static str {
-    match status {
+/// an in-flight run is `running` (light-blue), and a failed run is `error` (red). A monitor-
+/// synthesised placeholder for a missed/stuck run renders `unknown` (grey), so a detected fault is
+/// visually distinct from a job-reported failure.
+pub fn cron_run_class(run: &CronRun) -> &'static str {
+    if run.reason.is_some() {
+        return "unknown";
+    }
+    match run.status {
         CronStatus::Succeeded => "ok",
         CronStatus::Running => "running",
         CronStatus::Failed => "error",
@@ -36,8 +41,17 @@ mod tests {
         assert_eq!(cron_class(CronHealth::Missing), "warn");
         assert_eq!(cron_class(CronHealth::Pending), "unknown");
 
-        assert_eq!(cron_run_class(CronStatus::Succeeded), "ok");
-        assert_eq!(cron_run_class(CronStatus::Running), "running");
-        assert_eq!(cron_run_class(CronStatus::Failed), "error");
+        let run = |status, reason| CronRun {
+            started_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            status,
+            duration: None,
+            reason,
+        };
+        assert_eq!(cron_run_class(&run(CronStatus::Succeeded, None)), "ok");
+        assert_eq!(cron_run_class(&run(CronStatus::Running, None)), "running");
+        assert_eq!(cron_run_class(&run(CronStatus::Failed, None)), "error");
+        // A synthesised missed/stuck placeholder renders grey regardless of its underlying status.
+        assert_eq!(cron_run_class(&run(CronStatus::Failed, Some(grey_api::CronRunReason::Missed))), "unknown");
+        assert_eq!(cron_run_class(&run(CronStatus::Failed, Some(grey_api::CronRunReason::Stuck))), "unknown");
     }
 }


### PR DESCRIPTION
Reduce probe/cron alert sensitivity with a per-entity `alerting` config
(`enabled` + `debounce`, default 5m) that suppresses brief flaps in both
directions, anchored to actual transition times.

- grey_api Streak: parameterize the recovery window (was a fixed 5m constant)
  and add the symmetric debounced predicates `failing_for`/`healthy_at`.
- grey_api Probe/Cron: carry a stamped `recovery_window`; crons gain a streak
  (progressed only by terminal check-ins) and a `CronRun` missed/stuck marker;
  health is now streak-debounced everywhere (UI, API, webhooks).
- Agent: `AlertingConfig` on probes and crons; a new cron-monitor daemon
  materialises missed/stuck runs as grey placeholder runs plus a failing streak
  observation, so the deadman-switch case flows through the same interface.
- notify.rs detects confirmed crossings of the debounced health, gated per
  entity by `alerting.enabled`.
- UI greys synthesised missed/stuck runs; docs and the webhooks example cover
  the new `alerting` block.