### PR TITLE
feat: Show time since last successful cron run

### DIFF
--- a/api/src/cron.rs
+++ b/api/src/cron.rs
@@ -340,6 +340,20 @@ impl Cron {
         self.runs.last().map(|run| run.started_at)
     }
 
+    /// The reference the UI ages as the job's "time since last success". It follows the converged
+    /// [`Streak`]'s debounced health so it stays consistent with the status dot: while the job reads
+    /// failing it is the failure onset ([`Streak::failing_since`]), so the figure climbs from the
+    /// moment the job went bad; while it reads healthy it is the start of the most recent run
+    /// ([`Cron::last_start`]), so it resets as fresh runs land. `None` for a job that is neither
+    /// failing nor has any run yet — there is nothing to age.
+    pub fn last_success(&self, now: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        if self.streak.failing_for(now, self.window()) {
+            self.streak.failing_since
+        } else {
+            self.last_start()
+        }
+    }
+
     /// The grace applied before a late run reads `Missing`: the configured value, or a
     /// schedule-derived default (a tenth of an `Every` interval, or [`DEFAULT_CRON_GRACE`] for a
     /// crontab schedule).
@@ -718,6 +732,42 @@ mod tests {
         assert!(every(60).is_valid());
         assert!(CronSchedule::Cron("* * * * *".into()).is_valid());
         assert!(!CronSchedule::Cron("not a cron".into()).is_valid());
+    }
+
+    #[test]
+    fn last_success_follows_the_streak_health() {
+        let window = win();
+
+        // Neither failing nor any run yet → nothing to age.
+        let empty = cron_with(every(60), vec![], None, None);
+        assert_eq!(empty.last_success(ts(2_000)), None);
+
+        // Healthy (empty or passing streak): the most recent run start, so it resets as runs land.
+        let mut c = cron_with(
+            every(60),
+            vec![run(1_000, CronStatus::Succeeded, Some(5)), run(1_100, CronStatus::Succeeded, Some(5))],
+            None,
+            None,
+        );
+        assert_eq!(c.last_success(ts(1_150)), Some(ts(1_100)));
+
+        // A fresh fault younger than the window has not tripped the debounced health yet, so it
+        // still tracks the last run (matching the dot, which is still healthy).
+        let base = ts(2_000);
+        c.streak = Streak { failing_since: Some(base), failing_until: Some(base), covered_since: Some(ts(500)) };
+        assert!(!c.streak.failing_for(base, window));
+        assert_eq!(c.last_success(base), Some(ts(1_100)));
+
+        // Once it has been failing for the window the reference becomes the onset and climbs from
+        // there rather than tracking the runs.
+        c.streak.failing_until = Some(base + window);
+        assert!(c.streak.failing_for(base + window, window));
+        assert_eq!(c.last_success(base + window), Some(base));
+
+        // Recovered (no failure within the window) → back to the most recent run start.
+        let recovered = base + window + window + chrono::Duration::seconds(1);
+        assert!(!c.streak.failing_for(recovered, window));
+        assert_eq!(c.last_success(recovered), Some(ts(1_100)));
     }
 
     #[test]

--- a/ui/src/components/_cron.scss
+++ b/ui/src/components/_cron.scss
@@ -118,7 +118,7 @@
     color: $color-text-muted;
 }
 
-// The time since the last check-in, shown on the far right of the title (mirrors
+// How long ago the job last succeeded, shown on the far right of the title (mirrors
 // `.probe__availability`).
 .cron__last-checkin {
     float: right;

--- a/ui/src/components/cron.rs
+++ b/ui/src/components/cron.rs
@@ -10,8 +10,8 @@ pub struct CronProps {
 }
 
 /// A single cron card, rendered "as if it were an active probe": a status dot + health, the expected
-/// schedule, a recent-runs strip, and the last reported check-in. Each run shows a hover popover in
-/// the same style as the probe history.
+/// schedule, a recent-runs strip, and how long ago the job last succeeded. Each run shows a hover
+/// popover in the same style as the probe history.
 #[function_component(Cron)]
 pub fn cron(props: &CronProps) -> Html {
     let cron = &props.cron;
@@ -42,9 +42,12 @@ pub fn cron(props: &CronProps) -> Html {
         CronSchedule::Cron(expr) => Some(expr.clone()),
     };
 
-    // The time since the last check-in, shown terse ("22m ago") on the right of the title.
-    let last_checkin = cron.last_checkin.as_ref().map(|checkin| {
-        format!("{} ago", compact_duration(now.signed_duration_since(checkin.at)))
+    // How stale the job's last success is, shown terse ("22m ago") on the right of the title.
+    // Derived from the converged streak (see `Cron::last_success`): it ages from the most recent run
+    // while the job is healthy (resetting as runs land) and from the failure onset while it is
+    // failing/stuck/missing (climbing), so it stays consistent with the streak-derived status dot.
+    let last_success = cron.last_success(now).map(|at| {
+        format!("{} ago", compact_duration(now.signed_duration_since(at)))
     });
 
     let run_count = cron.runs.len();
@@ -71,8 +74,8 @@ pub fn cron(props: &CronProps) -> Html {
                     }
                 </div>
                 <div class="cron__state">{state_text}</div>
-                if let Some(last_checkin) = last_checkin {
-                    <div class="cron__last-checkin">{last_checkin}</div>
+                if let Some(last_success) = last_success {
+                    <div class="cron__last-checkin">{last_success}</div>
                 }
             </div>
 
@@ -203,8 +206,49 @@ mod tests {
         });
         let html = render(cron).await;
         assert!(html.contains("cron-run"), "expected a run cell, got: {html}");
-        assert!(html.contains("cron__last-checkin"), "expected the last check-in time, got: {html}");
+        assert!(html.contains("cron__last-checkin"), "expected the since-last-success time, got: {html}");
         assert!(html.contains("healthy for"), "{html}");
+    }
+
+    /// While the job reads healthy the since-last-success block ages from the most recent run, so it
+    /// resets as fresh runs land.
+    #[tokio::test]
+    async fn since_last_success_tracks_the_last_run_while_healthy() {
+        let mut cron = cron("job");
+        let now = chrono::Utc::now();
+        cron.runs.push(CronRun {
+            started_at: now - chrono::Duration::minutes(2),
+            status: CronStatus::Succeeded,
+            duration: Some(Duration::from_secs(5)),
+            reason: None,
+        });
+        let html = render(cron).await;
+        assert!(html.contains("cron__last-checkin"), "expected the since-last-success time, got: {html}");
+        assert!(html.contains("2m ago"), "expected time since the last run, got: {html}");
+    }
+
+    /// While the streak reads failing, the since-last-success block ages from the failure onset, so a
+    /// job that has gone bad shows this figure climbing.
+    #[tokio::test]
+    async fn since_last_success_climbs_from_the_failure_onset() {
+        let mut cron = cron("job");
+        let now = chrono::Utc::now();
+        // A fault that began three hours ago and is still being observed → debounced-failing.
+        cron.streak = grey_api::Streak {
+            failing_since: Some(now - chrono::Duration::hours(3)),
+            failing_until: Some(now - chrono::Duration::minutes(1)),
+            covered_since: Some(now - chrono::Duration::days(1)),
+        };
+        let html = render(cron).await;
+        assert!(html.contains("cron__last-checkin"), "expected the since-last-success time, got: {html}");
+        assert!(html.contains("3h ago"), "expected time since the failure onset, got: {html}");
+    }
+
+    /// A pending job (no runs and no fault) has nothing to age, so the block is omitted entirely.
+    #[tokio::test]
+    async fn since_last_success_is_absent_when_pending() {
+        let html = render(cron("job")).await;
+        assert!(!html.contains("cron__last-checkin"), "expected no since-last-success block, got: {html}");
     }
 
     /// The run popover itself only appears on hover (which SSR can't reach), so render it directly to


### PR DESCRIPTION
The .cron__last-checkin block now displays how long ago the cron job last
succeeded rather than time since the last check-in. Jobs that are failing,
stuck, or missing check-ins see this figure climb steadily, while healthy jobs
reset it to a small value on each success, indicating result staleness.

Adds Cron::last_success() (completion time of the most recent genuine succeeded
run, excluding synthetic missed/stuck placeholders) and points the UI at it.