### PR TITLE
feat: add a debug-only UI demo mode and fix mobile status page layout

### DIFF
--- a/ui/src/client.rs
+++ b/ui/src/client.rs
@@ -124,7 +124,7 @@ pub fn app(props: &AppProps) -> Html {
 
 /// On the client the browser's history drives the router.
 #[cfg(feature = "wasm")]
-fn render_router(_url: &str) -> Html {
+pub(crate) fn render_router(_url: &str) -> Html {
     use yew_router::prelude::*;
 
     html! {
@@ -137,7 +137,7 @@ fn render_router(_url: &str) -> Html {
 /// During SSR there is no browser history, so seed an in-memory history from the request path so the
 /// correct route is server-rendered (and the client hydrates without a mismatch).
 #[cfg(not(feature = "wasm"))]
-fn render_router(url: &str) -> Html {
+pub(crate) fn render_router(url: &str) -> Html {
     use yew_router::Router;
     use yew_router::history::{AnyHistory, History, MemoryHistory};
 

--- a/ui/src/components/_cluster_status.scss
+++ b/ui/src/components/_cluster_status.scss
@@ -11,6 +11,15 @@
         opacity: 1;
         visibility: visible;
     }
+
+    // The chip collapses to its indicator dot on a phone; the popover still carries the detail.
+    @media only screen and (max-width: $mobile) {
+        padding: 0.375rem 0.5rem;
+
+        .status-text {
+            display: none;
+        }
+    }
 }
 
 .cluster-popover {
@@ -40,6 +49,12 @@
     max-width: min(40rem, 90vw);
     font-size: 0.85rem;
     font-weight: 400;
+
+    // A phone has no room for a 20rem floor; let the rows compress instead of overhanging the page.
+    @media only screen and (max-width: $mobile) {
+        min-width: 0;
+        width: min(20rem, calc(100vw - 2rem));
+    }
 
     &::after {
         content: '';

--- a/ui/src/components/_cron.scss
+++ b/ui/src/components/_cron.scss
@@ -96,7 +96,10 @@
 }
 
 .cron-run {
-    flex: 0 0 0.8rem;
+    // Cells cap at 0.8rem but compress rather than overflow once a job has accumulated a long run
+    // history; the strip is right-aligned, so an overflow would run off the left edge unseen.
+    flex: 0 1 0.8rem;
+    min-width: 4px;
     border-radius: $border-radius-small;
     cursor: pointer;
     // A positioned ancestor so the hover popover anchors to this cell, and a stacking bump while
@@ -111,6 +114,16 @@
     &.warn { background-color: $color-status-warn; }
     &.error { background-color: $color-status-error; }
     &.running { background-color: $color-status-running; }
+    // A monitor-synthesised missed/stuck placeholder, greyed so it reads as "no run happened"
+    // rather than a job-reported failure. Without this the cell renders invisible.
+    &.unknown { background-color: $color-status-offline; }
+
+    // Only the most recent runs stay on a phone, so each cell keeps a readable width.
+    @media only screen and (max-width: $mobile) {
+        &:nth-last-child(n + #{$mobile-strip-cells + 1}) {
+            display: none;
+        }
+    }
 }
 
 .cron__no-runs {
@@ -123,4 +136,50 @@
 .cron__last-checkin {
     float: right;
     clear: both;
+}
+
+// On a phone the name (with its badge, schedule and tags) claims the full width and the state and
+// last-success times share the line beneath it, rather than being squeezed into a sliver.
+@media only screen and (max-width: $mobile) {
+    .cron {
+        padding-left: 1rem;
+    }
+
+    .cron__title {
+        flex-wrap: wrap;
+        column-gap: 0.5rem;
+        row-gap: 0.35rem;
+    }
+
+    .cron__name-section {
+        flex: 1 1 100%;
+        align-items: flex-start;
+
+        > .status-dot {
+            margin-top: 0.45rem;
+        }
+    }
+
+    .cron__name {
+        font-size: 1rem;
+        overflow-wrap: anywhere;
+    }
+
+    .cron__tags {
+        margin-left: 0;
+    }
+
+    .cron__state {
+        margin-right: auto;
+    }
+
+    .cron__last-checkin {
+        margin-left: auto;
+        font-size: 0.8rem;
+        color: $color-text-muted;
+    }
+
+    .cron__runs {
+        gap: 2px;
+    }
 }

--- a/ui/src/components/_header.scss
+++ b/ui/src/components/_header.scss
@@ -12,26 +12,13 @@ header {
     border-bottom: 1px solid $color-separator;
 
     @media only screen and (max-width: $mobile) {
-        flex-direction: column;
-        align-items: stretch;
+        // Brand and controls share the first row; the nav collapses onto a second row behind the
+        // hamburger. Wrapping (rather than absolute positioning) keeps the controls from sitting on
+        // top of the brand when the title is long.
+        flex-wrap: wrap;
         position: sticky;
         top: 0;
         z-index: 1000;
-
-        // Create a top row for brand and controls
-        .header__brand,
-        .header__controls {
-            display: flex;
-        }
-
-        // On mobile, position brand and controls in a row
-        .header__brand {
-            flex: 1;
-        }
-
-        .header__menu {
-            align-items: center;
-        }
 
         &.menu-open {
             .header__nav {
@@ -66,18 +53,32 @@ header {
     color: inherit;
 
     @media only screen and (max-width: $mobile) {
-        flex: none;
+        // Shrinkable, so a long title gives way to the controls rather than pushing them off-screen.
+        flex: 0 1 auto;
+        min-width: 0;
+        padding: 0.75rem 1rem;
     }
 
     img {
         height: 2rem;
         aspect-ratio: 1/1;
         margin: 0 1rem 0 0;
+
+        @media only screen and (max-width: $mobile) {
+            margin-right: 0.6rem;
+        }
     }
 
     .header__title {
         font-size: 1.2rem;
         font-weight: 500;
+
+        @media only screen and (max-width: $mobile) {
+            font-size: 1.05rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
     }
 }
 
@@ -110,7 +111,9 @@ header {
         transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
         background-color: $background-box;
         border-top: 1px solid $color-separator;
-        order: 3; // Move below everything else on mobile
+        // A full-width row of its own, below the brand and controls.
+        order: 3;
+        flex: 1 1 100%;
         align-items: stretch;
 
         .header__nav-link {
@@ -132,12 +135,12 @@ header {
     padding: 0 1rem;
 
     @media only screen and (max-width: $mobile) {
-        gap: 0.5rem;
-        position: absolute;
-        top: 0;
-        right: 0;
-        padding: 1rem;
-        align-items: flex-start;
+        gap: 0.4rem;
+        flex: 0 0 auto;
+        order: 2;
+        // Stays on the right even when a long brand title pushes the controls onto their own row.
+        margin-left: auto;
+        padding: 0.75rem 1rem 0.75rem 0;
     }
 }
 

--- a/ui/src/components/_incidents.scss
+++ b/ui/src/components/_incidents.scss
@@ -10,6 +10,14 @@
     .incidents-section__summaries {
         padding: 1.5rem;
     }
+
+    @media only screen and (max-width: $mobile) {
+        margin: 1rem auto;
+
+        .incidents-section__summaries {
+            padding: 1rem;
+        }
+    }
 }
 
 // A title link reused by summaries and blocks.
@@ -127,6 +135,18 @@
     font: inherit;
     font-size: 0.85rem;
     white-space: nowrap;
+
+    // Long display names give way to an ellipsis rather than pushing the menu toggle off-screen.
+    @media only screen and (max-width: $mobile) {
+        padding: 0.35rem 0.6rem;
+        font-size: 0.8rem;
+        max-width: 7rem;
+
+        .user-chip__name {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+    }
 
     .user-chip__signout {
         position: absolute;

--- a/ui/src/components/_probe.scss
+++ b/ui/src/components/_probe.scss
@@ -22,11 +22,20 @@
     gap: 0.5rem;
     flex-wrap: wrap;
     margin-right: auto;
+    min-width: 0;
 }
 
 .probe__name {
     font-weight: inherit;
     margin: 0;
+    // Truncated rather than wrapped: a wrapped name is pushed onto its own line by the flex
+    // line-breaking rules, stranding the status dot above it. The zero basis keeps it on the dot's
+    // line at every width, growing only into the space the tags don't claim.
+    flex: 1 1 0;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 .probe-observers {
@@ -104,11 +113,13 @@
 .probe__availability {
     float: right;
     clear: both;
+    flex: none;
 }
 
 // How long the probe has held its current state, shown to the left of the availability %.
 .probe__streak {
     align-self: center;
+    flex: none;
     font-size: 0.8rem;
     color: $color-text-muted;
     margin-right: 0.75rem;
@@ -142,5 +153,44 @@
 
     .probe__tag-value {
         font-weight: 600;
+    }
+}
+
+// On a phone the name (with its tags) claims the full width and the streak and availability share
+// the line beneath it, so a long probe name no longer squeezes them out of the row.
+@media only screen and (max-width: $mobile) {
+    .probe {
+        padding-left: 1rem;
+    }
+
+    .probe__title {
+        flex-wrap: wrap;
+        column-gap: 0.5rem;
+        row-gap: 0.35rem;
+    }
+
+    .probe__name-section {
+        flex: 1 1 100%;
+    }
+
+    .probe__name {
+        font-size: 1rem;
+    }
+
+    .probe__tags {
+        flex: 1 1 100%;
+        margin-left: 0;
+    }
+
+    .probe__streak {
+        margin-right: auto;
+    }
+
+    .probe__availability {
+        margin-left: auto;
+    }
+
+    .service__name {
+        font-size: 1.25rem;
     }
 }

--- a/ui/src/components/_probe_history.scss
+++ b/ui/src/components/_probe_history.scss
@@ -16,7 +16,10 @@
     flex: 1;
     position: relative;
     cursor: pointer;
-    min-width: 10px;
+    // Segments share the strip's width evenly; the floor stops a full 48-hour history from
+    // overflowing its card on a narrow viewport (the strip is right-aligned, so the overflow would
+    // silently run off the left edge).
+    min-width: 4px;
 
     &:first-child {
         border-top-left-radius: $border-radius-small;
@@ -47,6 +50,20 @@
 
     &.unknown {
         background-color: $color-status-unknown;
+    }
+
+    // A phone shows the most recent day rather than two days' worth of slivers, so each segment
+    // stays wide enough to read (and tap).
+    @media only screen and (max-width: $mobile) {
+        &:nth-last-child(n + #{$mobile-strip-cells + 1}) {
+            display: none;
+        }
+
+        // The oldest still-visible segment takes over the rounded leading edge.
+        &:nth-last-child(#{$mobile-strip-cells}) {
+            border-top-left-radius: $border-radius-small;
+            border-bottom-left-radius: $border-radius-small;
+        }
     }
 }
 

--- a/ui/src/contexts/store.rs
+++ b/ui/src/contexts/store.rs
@@ -261,11 +261,25 @@ pub struct StoreProviderProps {
     pub peers: Vec<Peer>,
     #[prop_or_default]
     pub incidents: Vec<IncidentView>,
+    /// A pre-established session, used by demo mode to render the operator-only chrome. Normally
+    /// `None`: the session is discovered from the stored OIDC token on mount.
+    #[prop_or_default]
+    pub user: Option<AdminUser>,
+    /// Demo mode: serve entirely from the seeded props and never touch the API (no polling, no OIDC
+    /// bootstrap). See [`crate::demo`].
+    #[cfg(debug_assertions)]
+    #[prop_or_default]
+    pub demo: bool,
     pub children: Children,
 }
 
 #[function_component(StoreProvider)]
 pub fn store_provider(props: &StoreProviderProps) -> Html {
+    #[cfg(debug_assertions)]
+    let demo = props.demo;
+    #[cfg(not(debug_assertions))]
+    let demo = false;
+
     let auth_cfg = props.config.auth.clone();
     let client = ApiClient::new(auth_cfg.clone());
 
@@ -275,12 +289,13 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
         let crons = props.crons.clone();
         let peers = props.peers.clone();
         let incidents = props.incidents.clone();
+        let user = props.user.clone();
         move || {
             let mut incidents = incidents;
             sort_incidents(&mut incidents);
             StoreState {
                 config,
-                user: None,
+                user,
                 token: None,
                 peers,
                 incidents,
@@ -299,7 +314,7 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
         let client = client.clone();
         use_effect_with((), move |_| {
             #[cfg(feature = "wasm")]
-            if let Some(cfg) = auth_cfg {
+            if let Some(cfg) = auth_cfg.filter(|_| !demo) {
                 wasm_bindgen_futures::spawn_local(async move {
                     let mut current = crate::auth::stored_token();
                     if crate::auth::has_pending_callback() {
@@ -324,7 +339,7 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
                 });
             }
             #[cfg(not(feature = "wasm"))]
-            let _ = (&state, &auth_cfg, &client);
+            let _ = (&state, &auth_cfg, &client, &demo);
             || ()
         });
     }
@@ -347,22 +362,24 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
             let focus = focus.clone();
             let seeded = !state.probes.is_empty();
             use_effect_with((), move |_| {
-                wasm_bindgen_futures::spawn_local(async move {
-                    if !seeded {
-                        state.dispatch(load_probes(&client).await);
-                        state.dispatch(load_crons(&client).await);
-                        state.dispatch(load_incidents(&client).await);
-                    }
-                    loop {
-                        gloo::timers::future::sleep(reload).await;
-                        // Hold here while the page is unfocused; the interval that elapsed in the
-                        // background collapses into a single fetch once focus returns.
-                        focus.active().await;
-                        state.dispatch(load_probes(&client).await);
-                        state.dispatch(load_crons(&client).await);
-                        state.dispatch(load_incidents(&client).await);
-                    }
-                });
+                if !demo {
+                    wasm_bindgen_futures::spawn_local(async move {
+                        if !seeded {
+                            state.dispatch(load_probes(&client).await);
+                            state.dispatch(load_crons(&client).await);
+                            state.dispatch(load_incidents(&client).await);
+                        }
+                        loop {
+                            gloo::timers::future::sleep(reload).await;
+                            // Hold here while the page is unfocused; the interval that elapsed in
+                            // the background collapses into a single fetch once focus returns.
+                            focus.active().await;
+                            state.dispatch(load_probes(&client).await);
+                            state.dispatch(load_crons(&client).await);
+                            state.dispatch(load_incidents(&client).await);
+                        }
+                    });
+                }
                 || ()
             });
         }
@@ -374,14 +391,16 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
             let client = client.clone();
             let focus = focus.clone();
             use_effect_with((), move |_| {
-                wasm_bindgen_futures::spawn_local(async move {
-                    state.dispatch(Action::SetPeers(load_peers(&client).await));
-                    loop {
-                        gloo::timers::future::sleep(reload).await;
-                        focus.active().await;
+                if !demo {
+                    wasm_bindgen_futures::spawn_local(async move {
                         state.dispatch(Action::SetPeers(load_peers(&client).await));
-                    }
-                });
+                        loop {
+                            gloo::timers::future::sleep(reload).await;
+                            focus.active().await;
+                            state.dispatch(Action::SetPeers(load_peers(&client).await));
+                        }
+                    });
+                }
                 || ()
             });
         }
@@ -397,7 +416,7 @@ pub fn store_provider(props: &StoreProviderProps) -> Html {
             let client = client.clone();
             let first = use_mut_ref(|| true);
             use_effect_with(state.token.is_some(), move |_| {
-                if std::mem::replace(&mut *first.borrow_mut(), false) {
+                if std::mem::replace(&mut *first.borrow_mut(), false) || demo {
                     // Mount: the initial fetch is handled by the effects above.
                 } else {
                     wasm_bindgen_futures::spawn_local(async move {

--- a/ui/src/demo.rs
+++ b/ui/src/demo.rs
@@ -1,0 +1,569 @@
+//! Demo mode: a self-contained fixture that renders the whole SPA without an agent behind it.
+//!
+//! Append `?demo` to the URL of a `trunk serve` build and the app boots from the fixtures below
+//! instead of hydrating the server-rendered payload; the store's polling and OIDC bootstrap are
+//! disabled, so nothing ever reaches the network. The dataset deliberately covers the awkward cases
+//! — long probe names, many tags, a full 48-bucket history strip, a full 50-cell cron run strip, and
+//! every health state — because those are what break on narrow viewports.
+//!
+//! Compiled only under `debug_assertions`, so release builds carry neither the fixtures nor the
+//! query-string check.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use chrono::{DateTime, Duration as Delta, Utc};
+use grey_api::{
+    AdminUser, CheckIn, Cron, CronRun, CronRunReason, CronSchedule, CronStatus, Identifier, Impact,
+    Incident, IncidentUpdate, IncidentUpdateId, IncidentView, Observation, Peer, PeerHealth, Probe,
+    ProbeHistoryBucket, Streak, UiConfig, UiLink, ValidationResult,
+};
+use yew::prelude::*;
+
+use crate::contexts::StoreProvider;
+
+/// Whether the page was loaded with the `?demo` trigger.
+#[cfg(feature = "wasm")]
+pub fn enabled() -> bool {
+    web_sys::window()
+        .and_then(|window| window.location().search().ok())
+        .map(|search| {
+            search
+                .trim_start_matches('?')
+                .split('&')
+                .any(|param| param == "demo" || param.starts_with("demo="))
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(not(feature = "wasm"))]
+pub fn enabled() -> bool {
+    false
+}
+
+/// The demo app root: the same component tree as [`crate::App`], seeded from the fixtures and with
+/// the store told never to contact the API.
+#[function_component(DemoApp)]
+pub fn demo_app() -> Html {
+    html! {
+        <div id="app">
+            <StoreProvider
+                demo=true
+                config={config()}
+                probes={probes()}
+                crons={crons()}
+                incidents={incidents()}
+                peers={peers()}
+                user={Some(user())}
+            >
+                { crate::client::render_router("/") }
+            </StoreProvider>
+        </div>
+    }
+}
+
+// --- Fixtures -------------------------------------------------------------------------------
+
+pub fn config() -> UiConfig {
+    UiConfig {
+        title: "Grey Demo".into(),
+        links: vec![
+            UiLink {
+                title: "Documentation".into(),
+                url: "https://github.com/SierraSoftworks/grey".into(),
+            },
+            UiLink {
+                title: "Support".into(),
+                url: "https://github.com/SierraSoftworks/grey/issues".into(),
+            },
+        ],
+        ..Default::default()
+    }
+}
+
+/// A signed-in administrator, so the operator-only chrome (cluster status, observer breakdowns,
+/// incident editing) renders too.
+pub fn user() -> AdminUser {
+    AdminUser {
+        subject: "demo|000000".into(),
+        email: Some("operator@example.com".into()),
+        name: Some("Demo Operator".into()),
+    }
+}
+
+pub fn peers() -> Vec<Peer> {
+    let now = Utc::now();
+    vec![
+        peer("grey-syd-1", PeerHealth::Online, now, true),
+        peer("grey-lhr-1", PeerHealth::Online, now - Delta::seconds(3), false),
+        peer("grey-iad-1", PeerHealth::Transitive, now - Delta::seconds(45), false),
+        peer("grey-fra-1", PeerHealth::Suspect, now - Delta::minutes(4), false),
+        peer("grey-sea-1", PeerHealth::Offline, now - Delta::hours(9), false),
+    ]
+}
+
+pub fn probes() -> Vec<Probe> {
+    let now = Utc::now();
+    vec![
+        probe(
+            now,
+            "api.sierrasoftworks.com/healthz",
+            &[("service", "Public API"), ("region", "global"), ("tier", "critical")],
+            Shape::Solid,
+            1,
+        ),
+        probe(
+            now,
+            "api.sierrasoftworks.com/v1/accounts",
+            &[("service", "Public API"), ("region", "au-east"), ("protocol", "https")],
+            Shape::Flaky,
+            2,
+        ),
+        probe(
+            now,
+            "identity.sierrasoftworks.com/.well-known/openid-configuration",
+            &[("service", "Identity"), ("region", "global")],
+            Shape::Recovered,
+            3,
+        ),
+        probe(
+            now,
+            "identity.sierrasoftworks.com/token",
+            &[("service", "Identity"), ("region", "eu-west"), ("tier", "critical")],
+            Shape::Solid,
+            4,
+        ),
+        probe(
+            now,
+            "storage.sierrasoftworks.com/blobs",
+            &[("service", "Storage"), ("region", "us-east")],
+            Shape::Failing,
+            5,
+        ),
+        probe(now, "cdn.sierrasoftworks.com", &[("service", "Storage")], Shape::Solid, 6),
+    ]
+}
+
+pub fn crons() -> Vec<Cron> {
+    let now = Utc::now();
+    vec![
+        healthy_cron(now),
+        running_cron(now),
+        missed_cron(now),
+        failed_cron(now),
+        pending_cron(),
+    ]
+}
+
+pub fn incidents() -> Vec<IncidentView> {
+    let now = Utc::now();
+    vec![
+        incident(
+            7_002,
+            "Elevated error rates on blob storage reads",
+            &[
+                (
+                    Impact::Offline,
+                    now - Delta::minutes(95),
+                    "We are investigating a complete loss of read availability for the `storage` service in `us-east`. Writes are unaffected.",
+                ),
+                (
+                    Impact::Degraded,
+                    now - Delta::minutes(40),
+                    "A failed storage node has been drained and traffic is being served from the remaining replicas. Reads are succeeding, with elevated latency.",
+                ),
+            ],
+        ),
+        incident(
+            7_001,
+            "Scheduled maintenance: identity provider upgrade",
+            &[
+                (
+                    Impact::Degraded,
+                    now - Delta::days(3),
+                    "Token issuance will be briefly interrupted while we roll out the new identity provider release.",
+                ),
+                (
+                    Impact::None,
+                    now - Delta::days(3) + Delta::minutes(50),
+                    "The upgrade completed successfully and all services are operating normally.",
+                ),
+            ],
+        ),
+    ]
+}
+
+// --- Fixture builders -----------------------------------------------------------------------
+
+/// The number of hourly history buckets a probe accumulates before the agent trims them — the widest
+/// the availability strip ever gets.
+const HISTORY_BUCKETS: i64 = 48;
+
+/// How a probe's history behaves across the window.
+#[derive(Clone, Copy, PartialEq)]
+enum Shape {
+    /// Uninterrupted success.
+    Solid,
+    /// Occasional single-sample blips that never trip the debounce.
+    Flaky,
+    /// A sustained outage part-way through the window which has since recovered.
+    Recovered,
+    /// Currently failing.
+    Failing,
+}
+
+/// A tiny deterministic PRNG, so the fixture looks organic but renders identically on every load.
+struct Rng(u64);
+
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6_364_136_223_846_793_005)
+            .wrapping_add(1_442_695_040_888_963_407);
+        self.0 >> 33
+    }
+
+    fn below(&mut self, bound: u64) -> u64 {
+        self.next() % bound.max(1)
+    }
+}
+
+fn tags(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+        .collect()
+}
+
+fn peer(id: &str, health: PeerHealth, last_seen: DateTime<Utc>, current: bool) -> Peer {
+    Peer {
+        id: id.into(),
+        last_seen,
+        health,
+        current,
+    }
+}
+
+fn probe(
+    now: DateTime<Utc>,
+    name: &str,
+    tag_pairs: &[(&str, &str)],
+    shape: Shape,
+    seed: u64,
+) -> Probe {
+    let history = history(now, shape, seed);
+
+    // The probe's headline availability is the sum of everything its observers reported.
+    let mut observations: HashMap<String, Observation> = HashMap::new();
+    for bucket in &history {
+        for (observer, observation) in &bucket.observations {
+            let entry = observations.entry(observer.clone()).or_default();
+            entry.total_samples += observation.total_samples;
+            entry.successful_samples += observation.successful_samples;
+            entry.total_retries += observation.total_retries;
+            entry.total_latency += observation.total_latency;
+        }
+    }
+
+    Probe {
+        name: name.into(),
+        tags: tags(tag_pairs),
+        last_updated: now,
+        history,
+        observations,
+        streak: streak(now, shape),
+        debounce: None,
+    }
+}
+
+/// The observers reporting on every probe, with the baseline latency each contributes.
+const OBSERVERS: [(&str, u64); 3] = [("grey-syd-1", 42), ("grey-lhr-1", 180), ("grey-iad-1", 96)];
+
+fn history(now: DateTime<Utc>, shape: Shape, seed: u64) -> Vec<ProbeHistoryBucket> {
+    let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    // Buckets are hour-aligned, oldest first, ending with the hour currently in progress.
+    let latest = now - Delta::seconds(now.timestamp().rem_euclid(3600));
+
+    (0..HISTORY_BUCKETS)
+        .map(|index| {
+            let start_time = latest - Delta::hours(HISTORY_BUCKETS - 1 - index);
+            let failure_rate = failure_rate(shape, index, &mut rng);
+
+            let observations: HashMap<String, Observation> = OBSERVERS
+                .iter()
+                .map(|(observer, base_latency)| {
+                    let total_samples = 60;
+                    let failed = (total_samples as f64 * failure_rate).round() as u64;
+                    let jitter = rng.below(30);
+                    (
+                        (*observer).to_string(),
+                        Observation {
+                            total_samples,
+                            successful_samples: total_samples - failed.min(total_samples),
+                            total_retries: failed / 2,
+                            total_latency: Duration::from_millis(
+                                (base_latency + jitter) * total_samples,
+                            ),
+                        },
+                    )
+                })
+                .collect();
+
+            let pass = failure_rate == 0.0;
+            ProbeHistoryBucket {
+                start_time,
+                pass,
+                message: if pass {
+                    String::new()
+                } else {
+                    "upstream returned HTTP 503".into()
+                },
+                validations: [
+                    ("http.status_code == 200".to_string(), if pass {
+                        ValidationResult::pass()
+                    } else {
+                        ValidationResult::fail("http.status_code was 503")
+                    }),
+                    ("http.body.status == 'ok'".to_string(), ValidationResult::pass()),
+                ]
+                .into_iter()
+                .collect(),
+                observations,
+            }
+        })
+        .collect()
+}
+
+/// The fraction of samples that failed in a bucket, by position in the window.
+fn failure_rate(shape: Shape, index: i64, rng: &mut Rng) -> f64 {
+    match shape {
+        Shape::Solid => 0.0,
+        Shape::Flaky if rng.below(9) == 0 => 0.02,
+        Shape::Flaky => 0.0,
+        Shape::Recovered if (26..=31).contains(&index) => 0.55,
+        Shape::Recovered => 0.0,
+        Shape::Failing if index >= HISTORY_BUCKETS - 3 => 0.75,
+        Shape::Failing => 0.0,
+    }
+}
+
+fn streak(now: DateTime<Utc>, shape: Shape) -> Streak {
+    match shape {
+        Shape::Solid => Streak {
+            covered_since: Some(now - Delta::days(23)),
+            ..Default::default()
+        },
+        Shape::Flaky => Streak {
+            failing_since: Some(now - Delta::hours(5)),
+            failing_until: Some(now - Delta::hours(5) + Delta::seconds(20)),
+            covered_since: Some(now - Delta::days(23)),
+        },
+        Shape::Recovered => Streak {
+            failing_since: Some(now - Delta::hours(21)),
+            failing_until: Some(now - Delta::hours(16)),
+            covered_since: Some(now - Delta::days(23)),
+        },
+        Shape::Failing => Streak {
+            failing_since: Some(now - Delta::minutes(94)),
+            failing_until: Some(now - Delta::seconds(20)),
+            covered_since: Some(now - Delta::days(23)),
+        },
+    }
+}
+
+/// A nightly backup that has been running cleanly — and has accumulated the full run strip.
+fn healthy_cron(now: DateTime<Utc>) -> Cron {
+    let mut cron = Cron::from_config(
+        "backups.nightly-snapshot",
+        tags(&[("service", "Storage"), ("owner", "platform"), ("retention", "30d")]),
+        CronSchedule::Cron("0 2 * * *".into()),
+        Some(Duration::from_secs(45 * 60)),
+        None,
+    );
+    cron.last_updated = now;
+    cron.runs = (0..50)
+        .map(|index| CronRun {
+            started_at: now - Delta::hours(24 * (49 - index)) - Delta::minutes(18),
+            status: CronStatus::Succeeded,
+            duration: Some(Duration::from_secs(600 + (index as u64 % 7) * 45)),
+            reason: None,
+        })
+        .collect();
+    cron.last_checkin = Some(CheckIn {
+        at: now - Delta::minutes(8),
+        status: CronStatus::Succeeded,
+        message: "snapshot uploaded (12.4 GiB)".into(),
+    });
+    cron.streak.covered_since = Some(now - Delta::days(49));
+    cron
+}
+
+/// A job that is in flight right now.
+fn running_cron(now: DateTime<Utc>) -> Cron {
+    let mut cron = Cron::from_config(
+        "search.index-rebuild",
+        tags(&[("service", "Public API"), ("owner", "search")]),
+        CronSchedule::Every(Duration::from_secs(6 * 3600)),
+        Some(Duration::from_secs(2 * 3600)),
+        None,
+    );
+    cron.last_updated = now;
+    cron.runs = (0..11)
+        .map(|index| CronRun {
+            started_at: now - Delta::hours(6 * (10 - index)) - Delta::minutes(24),
+            status: if index == 10 {
+                CronStatus::Running
+            } else {
+                CronStatus::Succeeded
+            },
+            duration: (index != 10).then(|| Duration::from_secs(1_400 + index as u64 * 30)),
+            reason: None,
+        })
+        .collect();
+    cron.last_checkin = Some(CheckIn {
+        at: now - Delta::minutes(12),
+        status: CronStatus::Running,
+        message: "rebuilding shard 4 of 8".into(),
+    });
+    cron.streak.covered_since = Some(now - Delta::days(12));
+    cron
+}
+
+/// A job that never checked in, so the monitor synthesised a missed-run placeholder.
+fn missed_cron(now: DateTime<Utc>) -> Cron {
+    let mut cron = Cron::from_config(
+        "billing.usage-rollup",
+        tags(&[("service", "Public API"), ("owner", "billing"), ("tier", "critical")]),
+        CronSchedule::Every(Duration::from_secs(3600)),
+        None,
+        None,
+    );
+    cron.last_updated = now;
+    cron.runs = (0..24)
+        .map(|index| {
+            let missed = index >= 22;
+            CronRun {
+                started_at: now - Delta::hours(23 - index) - Delta::hours(2),
+                status: if missed {
+                    CronStatus::Failed
+                } else {
+                    CronStatus::Succeeded
+                },
+                duration: (!missed).then(|| Duration::from_secs(95)),
+                reason: missed.then_some(CronRunReason::Missed),
+            }
+        })
+        .collect();
+    cron.streak = Streak {
+        failing_since: Some(now - Delta::hours(2)),
+        failing_until: Some(now - Delta::minutes(3)),
+        covered_since: Some(now - Delta::days(30)),
+    };
+    cron
+}
+
+/// A job whose most recent run reported a failure.
+fn failed_cron(now: DateTime<Utc>) -> Cron {
+    let mut cron = Cron::from_config(
+        "identity.key-rotation",
+        tags(&[("service", "Identity"), ("owner", "security")]),
+        CronSchedule::Cron("30 3 * * 0".into()),
+        Some(Duration::from_secs(15 * 60)),
+        None,
+    );
+    cron.last_updated = now;
+    cron.runs = (0..8)
+        .map(|index| CronRun {
+            started_at: now - Delta::days(7 * (7 - index)) - Delta::hours(5),
+            status: if index == 7 {
+                CronStatus::Failed
+            } else {
+                CronStatus::Succeeded
+            },
+            duration: Some(Duration::from_secs(48)),
+            reason: None,
+        })
+        .collect();
+    cron.last_checkin = Some(CheckIn {
+        at: now - Delta::hours(5),
+        status: CronStatus::Failed,
+        message: "HSM refused the rotation request".into(),
+    });
+    cron.streak = Streak {
+        failing_since: Some(now - Delta::hours(5)),
+        failing_until: Some(now - Delta::minutes(1)),
+        covered_since: Some(now - Delta::days(56)),
+    };
+    cron
+}
+
+/// A newly configured job that has never checked in.
+fn pending_cron() -> Cron {
+    Cron::from_config(
+        "reports.monthly-invoice-export",
+        tags(&[("service", "Other"), ("owner", "finance")]),
+        CronSchedule::Cron("0 6 1 * *".into()),
+        None,
+        None,
+    )
+}
+
+fn incident(id: u64, title: &str, updates: &[(Impact, DateTime<Utc>, &str)]) -> IncidentView {
+    let incident_id = Identifier::new(id);
+    IncidentView::new(
+        Incident {
+            id: incident_id,
+            title: title.into(),
+            version: 1,
+            deleted: false,
+        },
+        updates
+            .iter()
+            .enumerate()
+            .map(|(index, (impact, timestamp, message))| IncidentUpdate {
+                id: IncidentUpdateId::compose(incident_id, index as u64 + 1),
+                impact: *impact,
+                timestamp: *timestamp,
+                message: (*message).to_string(),
+                version: 1,
+                deleted: false,
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The fixture must exercise every health state the UI can render, since that is the whole point
+    /// of demo mode.
+    #[test]
+    fn fixtures_cover_every_health_state() {
+        let now = Utc::now();
+
+        let probes = probes();
+        assert!(probes.iter().any(|p| p.passing()), "expected a passing probe");
+        assert!(probes.iter().any(|p| !p.passing()), "expected a failing probe");
+        assert!(
+            probes.iter().all(|p| p.history.len() == HISTORY_BUCKETS as usize),
+            "every probe should carry a full history strip"
+        );
+
+        let healths: Vec<_> = crons().iter().map(|c| c.health(now, c.window())).collect();
+        for expected in [
+            grey_api::CronHealth::Succeeded,
+            grey_api::CronHealth::Running,
+            grey_api::CronHealth::Missing,
+            grey_api::CronHealth::Failed,
+            grey_api::CronHealth::Pending,
+        ] {
+            assert!(healths.contains(&expected), "missing {expected:?} in {healths:?}");
+        }
+
+        let incidents = incidents();
+        assert!(incidents.iter().any(|i| i.is_active()), "expected an active incident");
+        assert!(incidents.iter().any(|i| !i.is_active()), "expected a resolved incident");
+    }
+}

--- a/ui/src/lib.rs
+++ b/ui/src/lib.rs
@@ -3,6 +3,8 @@ mod auth;
 mod client;
 mod components;
 mod contexts;
+#[cfg(debug_assertions)]
+pub mod demo;
 pub mod formatters;
 pub mod routes;
 mod styles;

--- a/ui/src/main.rs
+++ b/ui/src/main.rs
@@ -3,6 +3,8 @@ mod auth;
 mod client;
 mod components;
 mod contexts;
+#[cfg(debug_assertions)]
+pub mod demo;
 pub mod formatters;
 pub mod routes;
 mod styles;
@@ -18,6 +20,14 @@ pub use contexts::*;
 fn main() {
     #[cfg(target_arch = "wasm32")]
     wasm_logger::init(wasm_logger::Config::default());
+
+    // `?demo` renders the app from a local fixture with the API disabled, so the layout can be
+    // iterated on with nothing but `trunk serve`.
+    #[cfg(all(feature = "wasm", debug_assertions))]
+    if demo::enabled() {
+        yew::Renderer::<demo::DemoApp>::new().render();
+        return;
+    }
 
     #[cfg(feature = "wasm")]
     if let Ok(props) = AppProps::from_dom() {

--- a/ui/src/styles/_layout.scss
+++ b/ui/src/styles/_layout.scss
@@ -2,7 +2,9 @@
 
 // App layout and content containers
 #app {
-    width: 100vw;
+    // `100%` rather than `100vw`: the viewport unit includes the scrollbar gutter, which shows up as
+    // a sliver of horizontal scroll on narrow screens.
+    width: 100%;
     margin: 0;
     display: flex;
     flex-direction: column;
@@ -107,5 +109,17 @@
 @media screen and (max-width: $tablet) {
     body {
         background-color: $background-box;
+    }
+}
+
+// A phone has no room for the desktop gutters; trimming them back is what lets the history strips
+// and title rows fit inside the card.
+@media screen and (max-width: $mobile) {
+    .section {
+        padding: 1rem;
+
+        &.fill {
+            padding: 1.5rem 1rem;
+        }
     }
 }

--- a/ui/src/styles/_page.scss
+++ b/ui/src/styles/_page.scss
@@ -13,6 +13,11 @@
         font-weight: 200;
         margin-top: 0;
     }
+
+    @media only screen and (max-width: $mobile) {
+        margin: 1rem auto;
+        padding: 1rem;
+    }
 }
 
 // Muted "nothing to show" text.

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -49,6 +49,10 @@ $color-tooltip-border: var(--tooltip-border);
 $mobile: 600px;
 $tablet: 980px;
 
+// How many cells of a right-aligned history strip (probe availability, cron runs) stay visible on a
+// phone. The remainder are the oldest, and are hidden rather than squeezed into unreadable slivers.
+$mobile-strip-cells: 24;
+
 // Common measurements
 $border-radius: 5px;
 $border-radius-small: 4px;


### PR DESCRIPTION
## Demo mode

Appending `?demo` to a `trunk serve` build boots the SPA from a local fixture instead of hydrating the server-rendered payload, so the layout can be iterated on without building and running an agent. The store's polling and OIDC bootstrap are skipped in this mode, so nothing reaches the network.

Compiled only under `debug_assertions` — release builds carry neither the fixtures nor the query-string check.

The fixture deliberately covers the awkward cases: every probe/cron health state, long probe names, multiple tags, a full 48-bucket history strip, a full 50-cell cron run strip, an active and a resolved incident, and a signed-in operator (so the cluster chip and observer breakdowns render).

## Mobile layout fixes

Found with the demo build; at 375px the status page overflowed the viewport by ~136px.

| Problem | Fix |
| --- | --- |
| 48 history buckets at `min-width: 10px` overflowed the card (off the *left* edge, since the strip is right-aligned) | `min-width: 4px`, and phones show the most recent 24 buckets with the leading radius moved to the oldest visible segment |
| 50 cron run cells were fixed-width (`flex: 0 0 0.8rem`) and ran off-screen at every width below ~980px | cells shrink (`flex: 0 1 0.8rem`, floor 4px) and phones cap the strip at 24 cells |
| A long probe name wrapped onto its own line, stranding the status dot above it | name truncates with an ellipsis (`flex: 1 1 0` + `text-overflow`); streak and availability are `flex: none` so the name absorbs the squeeze |
| Absolutely positioned mobile header controls sat on top of the brand title | header wraps instead: brand + controls on row one, nav on row two; cluster chip collapses to its dot and the user chip ellipsizes |
| `#app { width: 100vw }` included the scrollbar gutter | `width: 100%` |
| Monitor-synthesised missed/stuck cron runs rendered invisible (`.cron-run.unknown` had no colour) | greyed, matching the documented intent |

Desktop gutters are also trimmed on phones (`.section`, `.probe`, `.cron`, `.page`, incidents) to buy the strips room.

Verified at 320 / 375 / 480 / 640 / 718 / 900 / 1280px: no page-level overflow, dot and name share a line at every width.

### Known issue, not addressed here

Between 601–980px the header still overflows by ~54px when signed in: brand + full nav + cluster chip + user chip exceed the width, and the hamburger only appears below 600px. Pre-existing; the fix is either raising the nav collapse breakpoint to `$tablet` or letting `header` wrap the nav onto its own row.
