### PR TITLE
fix: remove probes from the UI once they leave the config

### DIFF
--- a/agent/src/api/auth.rs
+++ b/agent/src/api/auth.rs
@@ -781,6 +781,7 @@ mod tests {
             observations: std::collections::HashMap::new(),
             streak: grey_api::Streak::default(),
             debounce: None,
+            retired: false,
         };
 
         // Anonymous: only the public probe survives, but the orphan (no config entry) is kept.

--- a/agent/src/engine.rs
+++ b/agent/src/engine.rs
@@ -44,6 +44,12 @@ impl Engine {
         // Start config reload watcher
         self.start_config_reloader();
 
+        // Tombstone any stored records for probes that were removed from the configuration while this
+        // node was down, so they stop appearing in the UI (and are dropped by our peers).
+        if let Err(err) = self.state.reconcile_probe_config().await {
+            error!(name: "engine.probes.reconcile", { exception = err }, "Failed to reconcile stored probe state with the configuration: {err}");
+        }
+
         {
             let state = self.state.clone();
             tokio::task::spawn_local(async move {
@@ -157,6 +163,12 @@ impl Engine {
 
                 let new_probes = state.get_config().probes.clone();
                 if new_probes != current_probes {
+                    // Retire the records of removed probes (and revive those that came back) so the
+                    // configuration remains the source of truth for what the UI shows.
+                    if let Err(err) = state.reconcile_probe_config().await {
+                        error!(name: "config.reload.probe", { action = "reconcile", exception = err }, "Failed to reconcile stored probe state with the configuration: {err}");
+                    }
+
                     let old_probes: HashMap<&str, &Probe> = current_probes
                         .iter()
                         .map(|p| (p.name.as_str(), p))

--- a/agent/src/notify.rs
+++ b/agent/src/notify.rs
@@ -479,6 +479,7 @@ mod tests {
             observations: HashMap::new(),
             streak,
             debounce: None,
+            retired: false,
         }
     }
 

--- a/agent/src/probe.rs
+++ b/agent/src/probe.rs
@@ -102,6 +102,7 @@ impl Into<grey_api::Probe> for &Probe {
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
             debounce: Some(self.alerting.debounce_std()),
+            retired: false,
         }
     }
 }

--- a/agent/src/result.rs
+++ b/agent/src/result.rs
@@ -142,6 +142,7 @@ mod tests {
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
             debounce: None,
+            retired: false,
         }
     }
 

--- a/agent/src/state/mod.rs
+++ b/agent/src/state/mod.rs
@@ -628,6 +628,7 @@ mod tests {
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
             debounce: None,
+            retired: false,
         }
     }
 

--- a/agent/src/state/probes.rs
+++ b/agent/src/state/probes.rs
@@ -27,6 +27,11 @@ pub trait ProbeStore {
     /// Persists the configured probe metadata for this node.
     async fn update_probe_config(&self, probe: &crate::Probe) -> Result<(), Box<dyn Error>>;
 
+    /// Reconciles this node's stored probe records against the current configuration, tombstoning
+    /// the records of probes that have been removed (and clearing the tombstone from any that have
+    /// returned).
+    async fn reconcile_probe_config(&self) -> Result<(), Box<dyn Error>>;
+
     /// Applies a fresh probe result to this node's stored state for the named probe.
     async fn update_probe_state(
         &self,
@@ -61,6 +66,13 @@ impl ProbeStore for State {
                 let (_node_id, probe_name) = key.value();
                 let (_, data) = value.value();
                 if let Ok(snapshot) = rmp_serde::from_slice::<ProbeState>(data) {
+                    // A retired record is an observer's tombstone for a probe it no longer runs; it
+                    // contributes nothing to the pool, so a probe disappears once every observer has
+                    // dropped it (and stays visible while any node still probes it).
+                    if snapshot.retired {
+                        continue;
+                    }
+
                     histories
                         .entry(probe_name.clone())
                         .and_modify(|existing: &mut ProbeState| {
@@ -105,6 +117,58 @@ impl ProbeStore for State {
                 (self.node_id.into(), probe.name.clone()),
                 (snapshot.version(), rmp_serde::to_vec_named(&snapshot)?.as_slice()),
             )?;
+        }
+
+        txn.commit()?;
+
+        Ok(())
+    }
+
+    #[instrument(name="state.probes.reconcile", skip(self), fields(otel.kind = "internal", node.id=%self.node_id), err(Debug))]
+    async fn reconcile_probe_config(&self) -> Result<(), Box<dyn Error>> {
+        let config = self.get_config();
+        let own_id: u128 = self.node_id.into();
+
+        let txn = self.database.begin_write()?;
+        {
+            let mut table = txn.open_table(PROBES_TABLE)?;
+
+            let mut updates: Vec<(String, ProbeState)> = Vec::new();
+            for entry in table.iter()?.filter_map(|r| r.ok()) {
+                let (key, value) = entry;
+                let (node_id, probe_name) = key.value();
+                // Only this node's own observations are ours to retire; a peer's record is retired by
+                // the peer itself and reaches us through gossip.
+                if node_id != own_id {
+                    continue;
+                }
+
+                let (_version, data) = value.value();
+                let Ok(mut snapshot) = rmp_serde::from_slice::<ProbeState>(data) else {
+                    continue;
+                };
+
+                let retired = !config.probes.iter().any(|p| p.name == probe_name);
+                if snapshot.retired == retired {
+                    continue;
+                }
+
+                snapshot.retired = retired;
+                // `last_updated` serializes with second precision, so advance by a whole second when
+                // the clock hasn't moved on yet — otherwise the version wouldn't change and peers
+                // would never pick the tombstone up.
+                snapshot.last_updated = chrono::Utc::now()
+                    .max(snapshot.last_updated + chrono::Duration::seconds(1));
+                updates.push((probe_name, snapshot));
+            }
+
+            for (probe_name, snapshot) in updates {
+                info!(name: "state.probes.reconcile", { probe.name = %probe_name, probe.retired = snapshot.retired }, "Reconciled stored probe record against the configuration");
+                table.insert(
+                    (own_id, probe_name),
+                    (snapshot.version(), rmp_serde::to_vec_named(&snapshot)?.as_slice()),
+                )?;
+            }
         }
 
         txn.commit()?;
@@ -239,6 +303,7 @@ impl Versioned for Probe {
                 observations: self.observations.clone(),
                 streak: self.streak.clone(),
                 debounce: self.debounce,
+                retired: self.retired,
             })
         } else {
             None
@@ -266,7 +331,90 @@ mod tests {
             observations: HashMap::new(),
             streak: grey_api::Streak::default(),
             debounce: None,
+            retired: false,
         }
+    }
+
+    /// A probe dropped from the configuration disappears from the pooled view (and so from the UI)
+    /// even though it has recorded history, and its record is tombstoned rather than deleted so the
+    /// removal propagates to peers holding a copy.
+    #[tokio::test]
+    async fn removing_a_probe_from_the_config_retires_its_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State::test(dir.path().to_path_buf()).await;
+        let probe_name = state.get_config().probes[0].name.clone();
+
+        assert!(
+            state.get_probe_states().await.unwrap().contains_key(&probe_name),
+            "the configured probe must be visible before it is removed"
+        );
+
+        let mut config = Config::test(&dir.path().to_path_buf());
+        config.probes.clear();
+        state.set_config_for_test(config);
+        state.reconcile_probe_config().await.unwrap();
+
+        assert!(
+            !state.get_probe_states().await.unwrap().contains_key(&probe_name),
+            "a probe removed from the configuration must not be returned, even with stored history"
+        );
+
+        let txn = state.database.begin_read().unwrap();
+        let table = txn.open_table(PROBES_TABLE).unwrap();
+        let entry = table
+            .get((state.node_id.into(), probe_name.clone()))
+            .unwrap()
+            .expect("the tombstone must be retained so it can be gossiped");
+        let (_version, data) = entry.value();
+        let stored: ProbeState = rmp_serde::from_slice(data).unwrap();
+        assert!(stored.retired, "the record must be tombstoned rather than deleted");
+    }
+
+    /// Retirement is per-observer: a peer that still runs the probe keeps it visible here (the
+    /// headless-worker topology), and re-adding it locally clears the tombstone without losing the
+    /// history that was recorded before the removal.
+    #[tokio::test]
+    async fn retirement_is_scoped_to_this_node_and_reversible() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State::test(dir.path().to_path_buf()).await;
+        let probe_name = state.get_config().probes[0].name.clone();
+
+        let empty = {
+            let mut config = Config::test(&dir.path().to_path_buf());
+            config.probes.clear();
+            config
+        };
+        state.set_config_for_test(empty);
+        state.reconcile_probe_config().await.unwrap();
+
+        // A peer still observing the probe keeps it in the pooled view.
+        let peer = NodeID::new();
+        let mut diff = crate::cluster::ClusterStateDiff::new();
+        diff.update(
+            peer,
+            probe_name.clone(),
+            crate::state::ReplicatedEntity::Probe(probe_at(&probe_name, chrono::Utc::now())),
+        );
+        crate::cluster::GossipStore::apply(&state, diff).await.unwrap();
+        assert!(
+            state.get_probe_states().await.unwrap().contains_key(&probe_name),
+            "a peer that still runs the probe must keep it visible"
+        );
+
+        // Restoring the configuration revives this node's own record.
+        state.set_config_for_test(Config::test(&dir.path().to_path_buf()));
+        state.reconcile_probe_config().await.unwrap();
+
+        let txn = state.database.begin_read().unwrap();
+        let table = txn.open_table(PROBES_TABLE).unwrap();
+        let entry = table.get((state.node_id.into(), probe_name.clone())).unwrap().unwrap();
+        let (_version, data) = entry.value();
+        let stored: ProbeState = rmp_serde::from_slice(data).unwrap();
+        assert!(!stored.retired, "re-adding the probe must clear the tombstone");
+        assert!(
+            !stored.history.is_empty(),
+            "the history recorded before the removal must survive the round trip"
+        );
     }
 
     /// Two updates within the same wall-clock second must produce distinct versions, so the later

--- a/agent/src/state/replicated.rs
+++ b/agent/src/state/replicated.rs
@@ -122,6 +122,7 @@ mod tests {
             observations: HashMap::new(),
             streak: Default::default(),
             debounce: None,
+            retired: false,
         }
     }
 

--- a/api/src/probe.rs
+++ b/api/src/probe.rs
@@ -33,6 +33,13 @@ pub struct Probe {
     /// existed.
     #[serde(default, with = "humantime_serde::option")]
     pub debounce: Option<std::time::Duration>,
+
+    /// A propagating tombstone: the observing node no longer has this probe in its configuration.
+    /// Retired records are excluded from the pooled view (and so from the API and UI) but keep
+    /// gossiping until they age out, so removing a probe from the config removes it cluster-wide
+    /// rather than leaving its history stranded on every peer.
+    #[serde(default)]
+    pub retired: bool,
 }
 
 impl Probe {
@@ -99,6 +106,7 @@ impl Mergeable for Probe {
         if other.last_updated > self.last_updated {
             self.name = other.name.clone();
             self.tags = other.tags.clone();
+            self.retired = other.retired;
         }
 
         self.last_updated = self.last_updated.max(other.last_updated);
@@ -165,6 +173,7 @@ mod tests {
             })].into_iter().collect(),
             streak: Streak::default(),
             debounce: None,
+            retired: false,
         };
 
         let probe2 = Probe {
@@ -180,6 +189,7 @@ mod tests {
             })].into_iter().collect(),
             streak: Streak::default(),
             debounce: None,
+            retired: false,
         };
 
         probe1.merge(&probe2);
@@ -214,6 +224,7 @@ mod tests {
             ].into_iter().collect(),
             streak: Streak::default(),
             debounce: None,
+            retired: false,
         };
 
         let total = probe.total();
@@ -246,6 +257,7 @@ mod tests {
             ].into_iter().collect(),
             streak: Streak::default(),
             debounce: None,
+            retired: false,
         };
 
         let availability = probe.availability();
@@ -263,6 +275,7 @@ mod tests {
             observations: HashMap::new(),
             streak: Streak::default(),
             debounce: None,
+            retired: false,
         };
 
         // With an empty streak record (e.g. data from older agents), the probe falls
@@ -330,6 +343,7 @@ mod tests {
                 covered_since: Some(chrono::DateTime::from_timestamp(1_690_000_000, 0).unwrap()),
             },
             debounce: None,
+            retired: false,
         };
 
         let packed = rmp_serde::to_vec(&probe).unwrap();

--- a/api/src/webhook.rs
+++ b/api/src/webhook.rs
@@ -229,6 +229,7 @@ mod tests {
                 covered_since: None,
             },
             debounce: None,
+            retired: false,
         }
     }
 

--- a/ui/src/components/probe.rs
+++ b/ui/src/components/probe.rs
@@ -88,6 +88,7 @@ mod tests {
             observations: Default::default(),
             streak,
             debounce: None,
+            retired: false,
         };
         yew::ServerRenderer::<Harness>::with_props(move || HarnessProps { probe })
             .render()

--- a/ui/src/components/service_list.rs
+++ b/ui/src/components/service_list.rs
@@ -137,6 +137,7 @@ mod tests {
             observations: Default::default(),
             streak: Default::default(),
             debounce: None,
+            retired: false,
         }
     }
 

--- a/ui/src/demo.rs
+++ b/ui/src/demo.rs
@@ -274,6 +274,7 @@ fn probe(
         observations,
         streak: streak(now, shape),
         debounce: None,
+        retired: false,
     }
 }
 


### PR DESCRIPTION
A probe dropped from the configuration kept rendering in the UI for as long as its recorded history survived: the pooled view returned every stored record, regardless of whether the probe was still configured anywhere.

## Changes

| Area | Change |
| --- | --- |
| `api/src/probe.rs` | New `retired: bool` on `Probe` (serde-default, so existing records decode), merged under last-writer-wins alongside `name`/`tags` |
| `agent/src/state/probes.rs` | `get_probe_states` skips retired records; new `reconcile_probe_config` sweeps this node's rows and sets/clears the tombstone from the config; `diff` carries the flag |
| `agent/src/engine.rs` | Reconciles at startup (catching removals made while the node was down) and whenever a config reload changes the probe set |

## Semantics

- Retirement is per-observer, so a probe still configured on another node (the headless-worker topology described in the clustering guide) stays visible.
- The tombstone is not deleted locally: it keeps gossiping so peers drop their copies, and is reaped by the existing `gc_probe_expiry` sweep, mirroring the incident tombstone approach.
- Re-adding a probe to the config clears the flag and its prior history returns.

## Tests

Two new tests cover removal with recorded history, a peer that still observes the probe, and the re-add path.