### PR TITLE
feat: Add TLS certificate probe target

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
         "!Http mapping",
         "!Script mapping",
         "!Tcp mapping",
+        "!TlsCert mapping",
         "!Grpc mapping",
     ],
     "cSpell.words": [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,6 +337,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -510,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1288,6 +1336,20 @@ dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2258,16 +2320,22 @@ dependencies = [
  "openssl-sys",
  "radix_fmt",
  "rand 0.10.2",
+ "rcgen",
  "redb",
  "reqwest 0.13.4",
  "rmp-serde",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_yaml",
  "sha2 0.11.0",
  "sys_traits",
  "tempfile",
+ "time",
  "tokio",
+ "tokio-rustls",
  "tonic",
  "tonic-health",
  "tracing",
@@ -2275,6 +2343,7 @@ dependencies = [
  "trust-dns-resolver",
  "uuid",
  "wiremock",
+ "x509-parser",
  "yew",
 ]
 
@@ -3141,6 +3210,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3172,6 +3247,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3281,7 +3366,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3310,6 +3395,15 @@ name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
+]
 
 [[package]]
 name = "once_cell"
@@ -3999,6 +4093,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redb"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4239,6 +4347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver 1.0.28",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -4922,7 +5039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -6033,10 +6150,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "xsum"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0637d3a5566a82fa5214bae89087bc8c9fb94cd8e8a3c07feb691bb8d9c632db"
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec",
+ "time",
+]
 
 [[package]]
 name = "yew"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,12 @@ rand = "0.10"
 redb = { version = "4.1.0" }
 reqwest = { version = "0.13", features = ["rustls"] }
 rmp-serde = "1.3.1"
+# The `ring` backend is selected explicitly at runtime (see targets/tls_cert.rs) because
+# both it and `aws-lc-rs` end up enabled by other crates in the graph, which would otherwise
+# leave rustls without an unambiguous default provider.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-native-certs = "0.8"
+rustls-pki-types = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = "0.9"
@@ -72,8 +78,10 @@ tracing-batteries = { git = "https://github.com/sierrasoftworks/tracing-batterie
   "analytics",
   "opentelemetry",
 ] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12", "logging"] }
 trust-dns-resolver = { version = "0.23", features = ["tokio-runtime"] }
 uuid = { version = "1", features = ["v4"] }
+x509-parser = "0.18"
 yew = { version = "0.23", features = ["ssr"] }
 yew-router = { version = "0.20" }
 pulldown-cmark = { version = "0.13" }
@@ -88,7 +96,9 @@ wasm-logger = { version = "0.2" }
 web-sys = { version = "0.3" }
 
 # Test dependencies
+rcgen = "0.14"
 tempfile = "3.25"
+time = "0.3"
 
 [profile.release]
 debug = 1

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -50,15 +50,20 @@ lazy_static.workspace = true
 openssl-sys = { workspace = true, optional = true }
 rand.workspace = true
 reqwest.workspace = true
+rustls.workspace = true
+rustls-native-certs.workspace = true
+rustls-pki-types.workspace = true
 serde_yaml.workspace = true
 sha2.workspace = true
 tonic.workspace = true
 tonic-health.workspace = true
 tokio.workspace = true
+tokio-rustls.workspace = true
 tracing.workspace = true
 tracing-batteries.workspace = true
 trust-dns-resolver.workspace = true
 uuid.workspace = true
+x509-parser.workspace = true
 
 [features]
 default = ["scripts"]
@@ -67,7 +72,9 @@ scripts = ["dep:boa_engine", "dep:boa_gc", "dep:boa_runtime"]
 openssl_src = ["dep:openssl-sys"]
 
 [dev-dependencies]
+rcgen.workspace = true
 tempfile.workspace = true
+time.workspace = true
 wiremock = "0.6"
 
 

--- a/agent/src/config.rs
+++ b/agent/src/config.rs
@@ -559,6 +559,25 @@ mod tests {
         );
     }
 
+    /// The shipped `tls_cert` example must parse through the real configuration
+    /// loader, guarding the example — and the `!TlsCert` target's optional
+    /// fields — against drift.
+    #[tokio::test]
+    async fn loads_tls_cert_example() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../example/tls-cert.yml");
+        let config = Config::load_from_path(&path)
+            .await
+            .expect("example/tls-cert.yml should load");
+
+        let probe = config
+            .probes
+            .iter()
+            .find(|p| p.name == "tls.pinned")
+            .expect("tls.pinned probe should be present");
+        assert_eq!(probe.checks.len(), 3);
+        assert_eq!(probe.target.to_string(), "TLS 1.1.1.1:443 (cloudflare-dns.com)");
+    }
+
     /// The shipped `crons` example must parse through the real configuration loader, guarding the
     /// example against drift and exercising the `CronConfig` (humantime) deserialization.
     #[tokio::test]

--- a/agent/src/sample.rs
+++ b/agent/src/sample.rs
@@ -1,5 +1,6 @@
 use std::{borrow::Cow, collections::HashMap, fmt::Display};
 
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
 use serde::{Deserialize, Serialize, de::Visitor};
 
 #[derive(Debug, Clone, Default)]
@@ -31,6 +32,8 @@ pub enum SampleValue {
     Double(f64),
     Int(i64),
     Bool(bool),
+    DateTime(DateTime<Utc>),
+    Duration(Duration),
     List(Vec<SampleValue>),
 }
 
@@ -42,6 +45,8 @@ impl SampleValue {
             SampleValue::Double(_) => "double",
             SampleValue::Int(_) => "int",
             SampleValue::Bool(_) => "bool",
+            SampleValue::DateTime(_) => "datetime",
+            SampleValue::Duration(_) => "duration",
             SampleValue::List(_) => "list",
         }
     }
@@ -84,9 +89,27 @@ impl From<&str> for SampleValue {
     }
 }
 
+impl From<DateTime<Utc>> for SampleValue {
+    fn from(value: DateTime<Utc>) -> Self {
+        SampleValue::DateTime(value)
+    }
+}
+
+impl From<Duration> for SampleValue {
+    fn from(value: Duration) -> Self {
+        SampleValue::Duration(value)
+    }
+}
+
 impl<T: Into<SampleValue>> From<Vec<T>> for SampleValue {
     fn from(value: Vec<T>) -> Self {
         SampleValue::List(value.into_iter().map(|v| v.into()).collect())
+    }
+}
+
+impl<T: Into<SampleValue>> From<Option<T>> for SampleValue {
+    fn from(value: Option<T>) -> Self {
+        value.map_or(SampleValue::None, Into::into)
     }
 }
 
@@ -98,9 +121,23 @@ impl Display for SampleValue {
             SampleValue::Double(value) => write!(f, "{}", value),
             SampleValue::Int(value) => write!(f, "{}", value),
             SampleValue::Bool(value) => write!(f, "{}", value),
+            SampleValue::DateTime(value) => write!(f, "{}", format_datetime(value)),
+            SampleValue::Duration(value) => write!(f, "{}", format_duration(value)),
             SampleValue::List(value) => write!(f, "[{}]", value.iter().map(SampleValue::to_string).collect::<Vec<_>>().join(", ")),
         }
     }
+}
+
+/// Renders a timestamp in the same RFC 3339 form that `filt-rs` uses for its
+/// own datetime values, so check failures and expression literals agree.
+fn format_datetime(value: &DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::AutoSi, true)
+}
+
+/// Renders a duration in `filt-rs`'s compact form (e.g. `30d`, `1h30m`) so it
+/// matches the duration literals a check would compare it against.
+fn format_duration(value: &Duration) -> String {
+    filt_rs::FilterValue::Duration(*value).to_string()
 }
 
 impl filt_rs::Filterable for Sample {
@@ -123,6 +160,8 @@ impl<'a> From<&'a SampleValue> for filt_rs::FilterValue<'a> {
             SampleValue::Double(value) => filt_rs::FilterValue::Number(*value),
             SampleValue::Int(value) => filt_rs::FilterValue::Number(*value as f64),
             SampleValue::Bool(value) => filt_rs::FilterValue::Bool(*value),
+            SampleValue::DateTime(value) => filt_rs::FilterValue::DateTime(*value),
+            SampleValue::Duration(value) => filt_rs::FilterValue::Duration(*value),
             SampleValue::List(value) => {
                 filt_rs::FilterValue::Tuple(value.iter().map(filt_rs::FilterValue::from).collect())
             }
@@ -141,12 +180,17 @@ impl Serialize for SampleValue {
             SampleValue::Double(value) => serializer.serialize_f64(*value),
             SampleValue::Int(value) => serializer.serialize_i64(*value),
             SampleValue::Bool(value) => serializer.serialize_bool(*value),
+            SampleValue::DateTime(value) => serializer.serialize_str(&format_datetime(value)),
+            SampleValue::Duration(value) => serializer.serialize_str(&format_duration(value)),
             SampleValue::List(value) => serializer.collect_seq(value),
         }
     }
 }
 
 impl<'de> Deserialize<'de> for SampleValue {
+    /// Datetimes and durations serialize to their string forms and are read
+    /// back as [`SampleValue::String`]; samples are only ever deserialized for
+    /// debugging, never round-tripped through storage or the cluster.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
@@ -242,6 +286,11 @@ impl<'de> Visitor<'de> for SampleValueVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
+
+    fn datetime() -> DateTime<Utc> {
+        Utc.with_ymd_and_hms(2026, 6, 12, 13, 30, 45).unwrap()
+    }
 
     #[test]
     fn test_sample_value_from() {
@@ -256,6 +305,12 @@ mod tests {
 
         let sv: SampleValue = true.into();
         assert_eq!(sv, SampleValue::Bool(true));
+
+        let sv: SampleValue = datetime().into();
+        assert_eq!(sv, SampleValue::DateTime(datetime()));
+
+        let sv: SampleValue = Duration::days(30).into();
+        assert_eq!(sv, SampleValue::Duration(Duration::days(30)));
 
         let sv: SampleValue = vec![1, 2, 3].into();
         assert_eq!(
@@ -282,6 +337,12 @@ mod tests {
         let sv = SampleValue::Bool(true);
         assert_eq!(sv.get_type(), "bool");
 
+        let sv = SampleValue::DateTime(datetime());
+        assert_eq!(sv.get_type(), "datetime");
+
+        let sv = SampleValue::Duration(Duration::days(30));
+        assert_eq!(sv.get_type(), "duration");
+
         let sv = SampleValue::None;
         assert_eq!(sv.get_type(), "null");
 
@@ -301,6 +362,20 @@ mod tests {
 
         let display = format!("{}", sv);
         assert_eq!(display, "[42, 3.14, \"hello\", true, null]");
+    }
+
+    /// Temporal values render exactly as `filt-rs` renders its own, so a failing
+    /// check reports a value in the same notation its expression is written in.
+    #[test]
+    fn test_sample_value_display_temporal() {
+        assert_eq!(
+            SampleValue::DateTime(datetime()).to_string(),
+            "2026-06-12T13:30:45Z"
+        );
+        assert_eq!(
+            SampleValue::Duration(Duration::minutes(90)).to_string(),
+            "1h30m"
+        );
     }
 
     #[test]
@@ -330,6 +405,20 @@ mod tests {
         assert_eq!(round_trip(&sv), sv);
     }
 
+    /// Temporal values are written out in their string form, which is all the
+    /// debug-oriented serialization of a sample needs to convey.
+    #[test]
+    fn test_sample_value_serialize_temporal() {
+        assert_eq!(
+            round_trip(&SampleValue::DateTime(datetime())),
+            SampleValue::String("2026-06-12T13:30:45Z".to_string())
+        );
+        assert_eq!(
+            round_trip(&SampleValue::Duration(Duration::minutes(90))),
+            SampleValue::String("1h30m".to_string())
+        );
+    }
+
     fn round_trip(value: &SampleValue) -> SampleValue {
         let serialized = serde_json::to_string(value).unwrap();
         println!("Serialized: {serialized} (from {value})");
@@ -356,6 +445,14 @@ mod tests {
         assert_eq!(
             FilterValue::from(&SampleValue::String("hello".into())),
             FilterValue::String("hello".into())
+        );
+        assert_eq!(
+            FilterValue::from(&SampleValue::DateTime(datetime())),
+            FilterValue::DateTime(datetime())
+        );
+        assert_eq!(
+            FilterValue::from(&SampleValue::Duration(Duration::days(30))),
+            FilterValue::Duration(Duration::days(30))
         );
         assert_eq!(
             FilterValue::from(&SampleValue::List(vec![
@@ -394,5 +491,31 @@ mod tests {
 
         let failing = Filter::new("http.status == 500").expect("parse filter");
         assert!(!failing.matches(&sample).expect("evaluate filter"));
+    }
+
+    /// Temporal fields are what make expiry checks readable, so verify they can
+    /// be compared against `now()` and against duration literals like `30d`.
+    #[test]
+    fn test_sample_temporal_checks() {
+        use filt_rs::Filter;
+
+        let sample = Sample::default()
+            .with("tls.not_after", Utc::now() + Duration::days(60))
+            .with("tls.expires_in", Duration::days(60));
+
+        for check in [
+            "tls.not_after > now() + 30d",
+            "tls.expires_in > 30d",
+            "tls.expires_in < 90d",
+        ] {
+            let filter = Filter::new(check).expect("parse filter");
+            assert!(
+                filter.matches(&sample).expect("evaluate filter"),
+                "expected {check} to match"
+            );
+        }
+
+        let filter = Filter::new("tls.expires_in < 30d").expect("parse filter");
+        assert!(!filter.matches(&sample).expect("evaluate filter"));
     }
 }

--- a/agent/src/targets/mod.rs
+++ b/agent/src/targets/mod.rs
@@ -9,6 +9,7 @@ mod grpc;
 mod http;
 mod script;
 mod tcp;
+mod tls_cert;
 
 pub trait Target: Display {
     fn run(
@@ -31,6 +32,7 @@ pub enum TargetType {
     #[cfg(feature = "scripts")]
     Script(script::ScriptTarget),
     Tcp(tcp::TcpTarget),
+    TlsCert(tls_cert::TlsCertTarget),
 }
 
 impl TargetType {
@@ -53,6 +55,7 @@ impl TargetType {
             #[cfg(feature = "scripts")]
             TargetType::Script(target) => target.run(cancel).await,
             TargetType::Tcp(target) => target.run(cancel).await,
+            TargetType::TlsCert(target) => target.run(cancel).await,
         }
     }
 }
@@ -70,6 +73,7 @@ impl Display for TargetType {
             #[cfg(feature = "scripts")]
             TargetType::Script(target) => write!(f, "{}", target),
             TargetType::Tcp(target) => write!(f, "{}", target),
+            TargetType::TlsCert(target) => write!(f, "{}", target),
         }
     }
 }
@@ -87,6 +91,7 @@ impl Target for TargetType {
             #[cfg(feature = "scripts")]
             TargetType::Script(target) => target.run(cancel).await,
             TargetType::Tcp(target) => target.run(cancel).await,
+            TargetType::TlsCert(target) => target.run(cancel).await,
         }
     }
 }

--- a/agent/src/targets/tls_cert.rs
+++ b/agent/src/targets/tls_cert.rs
@@ -1,0 +1,613 @@
+use std::{
+    fmt::Display,
+    net::IpAddr,
+    sync::{Arc, Mutex, atomic::AtomicBool},
+};
+
+use chrono::{DateTime, Utc};
+use rustls::{
+    ClientConfig, DigitallySignedStruct, RootCertStore, SignatureScheme,
+    client::{
+        WebPkiServerVerifier,
+        danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
+    },
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, ServerName, UnixTime, pem::PemObject},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpSocket, lookup_host};
+use tokio_rustls::TlsConnector;
+use tracing_batteries::prelude::opentelemetry::trace::SpanKind as OpenTelemetrySpanKind;
+use tracing_batteries::prelude::*;
+use x509_parser::prelude::*;
+
+use crate::{Sample, Target};
+
+lazy_static! {
+    /// Both the `ring` and `aws-lc-rs` backends are enabled somewhere in the dependency
+    /// graph, so rustls has no unambiguous default provider and one must be named here.
+    static ref PROVIDER: Arc<CryptoProvider> = Arc::new(rustls::crypto::ring::default_provider());
+    static ref NATIVE_ROOTS: Arc<RootCertStore> = {
+        let mut roots = RootCertStore::empty();
+        let loaded = rustls_native_certs::load_native_certs();
+        for cert in loaded.certs {
+            let _ = roots.add(cert);
+        }
+
+        for error in loaded.errors {
+            warn!("Failed to load a system CA certificate: {error}");
+        }
+
+        Arc::new(roots)
+    };
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct TlsCertTarget {
+    pub host: String,
+    #[serde(default)]
+    pub server_name: Option<String>,
+    #[serde(default)]
+    pub ca_cert: Option<String>,
+    #[serde(default)]
+    pub alpn: Vec<String>,
+}
+
+impl TlsCertTarget {
+    fn server_name(&self) -> &str {
+        self.server_name.as_deref().unwrap_or(host_of(&self.host))
+    }
+
+    fn roots(&self) -> Result<Arc<RootCertStore>, Box<dyn std::error::Error>> {
+        let Some(pem) = &self.ca_cert else {
+            return Ok(NATIVE_ROOTS.clone());
+        };
+
+        let mut roots = RootCertStore::empty();
+        for cert in CertificateDer::pem_slice_iter(pem.as_bytes()) {
+            roots.add(cert?)?;
+        }
+
+        if roots.is_empty() {
+            return Err(
+                "The provided 'ca_cert' did not contain any PEM encoded certificates.".into(),
+            );
+        }
+
+        Ok(Arc::new(roots))
+    }
+}
+
+impl Target for TlsCertTarget {
+    #[tracing::instrument(
+        "target.tls_cert",
+        skip(self, _cancel), err(Debug),
+        fields(
+            otel.kind=?OpenTelemetrySpanKind::Client,
+            tls.host = %self.host,
+            tls.server_name = %self.server_name(),
+            tls.version = EmptyField,
+            tls.trusted = EmptyField,
+            tls.not_after = EmptyField,
+    ))]
+    async fn run(&self, _cancel: &AtomicBool) -> Result<Sample, Box<dyn std::error::Error>> {
+        let server_name = ServerName::try_from(self.server_name().to_string())?;
+
+        let verifier = CapturingVerifier::new(
+            WebPkiServerVerifier::builder_with_provider(self.roots()?, PROVIDER.clone()).build()?,
+        );
+        let capture = verifier.capture.clone();
+
+        let mut config = ClientConfig::builder_with_provider(PROVIDER.clone())
+            .with_safe_default_protocol_versions()?
+            .dangerous()
+            .with_custom_certificate_verifier(Arc::new(verifier))
+            .with_no_client_auth();
+        config.alpn_protocols = self.alpn.iter().map(|p| p.as_bytes().to_vec()).collect();
+
+        let addr = lookup_host(&self.host)
+            .await?
+            .next()
+            .ok_or(format!("Could not resolve the hostname '{}'.", self.host))?;
+
+        let sock = if addr.is_ipv4() {
+            TcpSocket::new_v4()?
+        } else {
+            TcpSocket::new_v6()?
+        };
+
+        let mut stream = TlsConnector::from(Arc::new(config))
+            .connect(server_name, sock.connect(addr).await?)
+            .await?;
+
+        let connection = stream.get_ref().1;
+        let captured = capture
+            .lock()
+            .expect("the certificate capture mutex is never held across a panic")
+            .take()
+            .ok_or("The server did not present a TLS certificate.")?;
+
+        let sample = Sample::default()
+            .with("net.ip", addr.ip().to_string())
+            .with(
+                "tls.version",
+                connection
+                    .protocol_version()
+                    .map(|v| format!("{v:?}").replace('_', ".")),
+            )
+            .with(
+                "tls.cipher_suite",
+                connection
+                    .negotiated_cipher_suite()
+                    .map(|s| format!("{:?}", s.suite())),
+            )
+            .with(
+                "tls.alpn",
+                connection
+                    .alpn_protocol()
+                    .map(|p| String::from_utf8_lossy(p).into_owned()),
+            );
+
+        // Send `close_notify` so the server can release the connection immediately
+        // rather than waiting for it to time out. The probe has everything it needs
+        // by this point, so a peer which has already hung up is not a failure.
+        if let Err(err) = stream.shutdown().await {
+            debug!(
+                "Failed to cleanly close the connection to '{}': {err}",
+                self.host
+            );
+        }
+
+        captured.describe(sample, self.server_name())
+    }
+}
+
+impl Display for TlsCertTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.server_name {
+            Some(name) => write!(f, "TLS {} ({})", self.host, name),
+            None => write!(f, "TLS {}", self.host),
+        }
+    }
+}
+
+/// The certificate chain a server presented, together with the verdict the real
+/// verifier reached on it.
+#[derive(Debug)]
+struct CapturedChain {
+    leaf: CertificateDer<'static>,
+    intermediates: Vec<CertificateDer<'static>>,
+    verification: Result<(), rustls::Error>,
+}
+
+impl CapturedChain {
+    /// Adds the certificate's details to `sample`, deriving expiry and hostname
+    /// validity from the certificate itself so that each is independently
+    /// assertable rather than collapsed into a single verification error.
+    fn describe(
+        &self,
+        sample: Sample,
+        server_name: &str,
+    ) -> Result<Sample, Box<dyn std::error::Error>> {
+        let (_, leaf) = X509Certificate::from_der(&self.leaf)?;
+
+        let not_before = asn1_to_datetime(leaf.validity().not_before)?;
+        let not_after = asn1_to_datetime(leaf.validity().not_after)?;
+        let now = Utc::now();
+        let sans = subject_alternative_names(&leaf);
+
+        let mut chain_subjects = vec![leaf.subject().to_string()];
+        let mut chain_issuers = vec![leaf.issuer().to_string()];
+        for intermediate in &self.intermediates {
+            let (_, cert) = X509Certificate::from_der(intermediate)?;
+            chain_subjects.push(cert.subject().to_string());
+            chain_issuers.push(cert.issuer().to_string());
+        }
+
+        Ok(sample
+            .with("tls.trusted", self.verification.is_ok())
+            .with(
+                "tls.error",
+                self.verification.as_ref().err().map(|e| e.to_string()),
+            )
+            .with(
+                "tls.hostname_valid",
+                matches_hostname(&sans, common_name(leaf.subject()).as_deref(), server_name),
+            )
+            .with("tls.expired", now < not_before || now > not_after)
+            .with("tls.not_before", not_before)
+            .with("tls.not_after", not_after)
+            .with("tls.expires_in", not_after - now)
+            .with("tls.subject", leaf.subject().to_string())
+            .with("tls.subject_cn", common_name(leaf.subject()))
+            .with("tls.issuer", leaf.issuer().to_string())
+            .with("tls.issuer_cn", common_name(leaf.issuer()))
+            .with("tls.serial", hex::encode(leaf.raw_serial()))
+            .with("tls.thumbprint", hex::encode(Sha256::digest(&self.leaf)))
+            .with("tls.signature_algorithm", signature_algorithm(&leaf))
+            .with("tls.sans", sans)
+            .with("tls.chain.length", chain_subjects.len() as i64)
+            .with("tls.chain.subjects", chain_subjects)
+            .with("tls.chain.issuers", chain_issuers))
+    }
+}
+
+/// A [`ServerCertVerifier`] which records what the server presented and what the
+/// real verifier made of it, but always reports success so that the handshake
+/// completes and the certificate's details can be reported as probe fields.
+#[derive(Debug)]
+struct CapturingVerifier {
+    inner: Arc<WebPkiServerVerifier>,
+    capture: Arc<Mutex<Option<CapturedChain>>>,
+}
+
+impl CapturingVerifier {
+    fn new(inner: Arc<WebPkiServerVerifier>) -> Self {
+        Self {
+            inner,
+            capture: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl ServerCertVerifier for CapturingVerifier {
+    fn verify_server_cert(
+        &self,
+        end_entity: &CertificateDer<'_>,
+        intermediates: &[CertificateDer<'_>],
+        server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        let verification = self
+            .inner
+            .verify_server_cert(end_entity, intermediates, server_name, ocsp_response, now)
+            .map(|_| ());
+
+        if let Ok(mut capture) = self.capture.lock() {
+            *capture = Some(CapturedChain {
+                leaf: end_entity.clone().into_owned(),
+                intermediates: intermediates
+                    .iter()
+                    .map(|c| c.clone().into_owned())
+                    .collect(),
+                verification,
+            });
+        }
+
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls12_signature(message, cert, dss)
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        self.inner.verify_tls13_signature(message, cert, dss)
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.inner.supported_verify_schemes()
+    }
+}
+
+/// Strips the port (and any IPv6 brackets) from a `host:port` pair.
+fn host_of(host: &str) -> &str {
+    if let Some(rest) = host.strip_prefix('[') {
+        return rest.split(']').next().unwrap_or(rest);
+    }
+
+    host.rsplit_once(':').map(|(host, _)| host).unwrap_or(host)
+}
+
+fn common_name(name: &X509Name<'_>) -> Option<String> {
+    name.iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(|cn| cn.to_string())
+}
+
+fn subject_alternative_names(cert: &X509Certificate<'_>) -> Vec<String> {
+    let Ok(Some(san)) = cert.subject_alternative_name() else {
+        return Vec::new();
+    };
+
+    san.value
+        .general_names
+        .iter()
+        .filter_map(|name| match name {
+            GeneralName::DNSName(name) => Some((*name).to_string()),
+            GeneralName::IPAddress(bytes) => match bytes.len() {
+                4 => <[u8; 4]>::try_from(*bytes)
+                    .ok()
+                    .map(|b| IpAddr::from(b).to_string()),
+                16 => <[u8; 16]>::try_from(*bytes)
+                    .ok()
+                    .map(|b| IpAddr::from(b).to_string()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect()
+}
+
+fn signature_algorithm(cert: &X509Certificate<'_>) -> String {
+    let oid = cert.signature_algorithm.oid();
+    x509_parser::objects::oid2sn(oid, x509_parser::objects::oid_registry())
+        .map(|sn| sn.to_string())
+        .unwrap_or_else(|_| oid.to_id_string())
+}
+
+fn asn1_to_datetime(time: ASN1Time) -> Result<DateTime<Utc>, Box<dyn std::error::Error>> {
+    DateTime::from_timestamp(time.timestamp(), 0).ok_or_else(|| {
+        format!("The certificate contained an out-of-range timestamp '{time}'.").into()
+    })
+}
+
+/// Reports whether the certificate is valid for `server_name`, applying the usual
+/// rule that a wildcard matches exactly one leading label. Falls back to the
+/// common name only when the certificate carries no subject alternative names.
+fn matches_hostname(sans: &[String], common_name: Option<&str>, server_name: &str) -> bool {
+    let candidates: Vec<&str> = if sans.is_empty() {
+        common_name.into_iter().collect()
+    } else {
+        sans.iter().map(String::as_str).collect()
+    };
+
+    candidates
+        .iter()
+        .any(|candidate| matches_name(candidate, server_name))
+}
+
+fn matches_name(candidate: &str, server_name: &str) -> bool {
+    let Some(suffix) = candidate.strip_prefix("*.") else {
+        return candidate.eq_ignore_ascii_case(server_name);
+    };
+
+    match server_name.split_once('.') {
+        Some((_, rest)) => rest.eq_ignore_ascii_case(suffix),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SampleValue;
+    use rustls::pki_types::PrivateKeyDer;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+    use tokio::task::JoinHandle;
+
+    /// Serves a single TLS connection using a freshly minted self-signed
+    /// certificate, returning the address to probe, the CA PEM which vouches for
+    /// it, the exact (second-precision) expiry that was baked into it, and a
+    /// handle reporting whether the client closed the connection gracefully.
+    async fn serve_self_signed(
+        expires_in: chrono::Duration,
+    ) -> (String, String, DateTime<Utc>, JoinHandle<bool>) {
+        let not_after = DateTime::from_timestamp((Utc::now() + expires_in).timestamp(), 0)
+            .expect("build an in-range expiry");
+
+        let mut params =
+            rcgen::CertificateParams::new(vec!["localhost".to_string(), "*.localhost".to_string()])
+                .expect("build certificate parameters");
+        params
+            .distinguished_name
+            .push(rcgen::DnType::CommonName, "grey-test");
+        params.not_before = rcgen::date_time_ymd(2020, 1, 1);
+        params.not_after = ::time::OffsetDateTime::from_unix_timestamp(not_after.timestamp())
+            .expect("convert the expiry");
+
+        let key = rcgen::KeyPair::generate().expect("generate key pair");
+        let cert = params.self_signed(&key).expect("sign certificate");
+        let pem = cert.pem();
+
+        let server = rustls::ServerConfig::builder_with_provider(PROVIDER.clone())
+            .with_safe_default_protocol_versions()
+            .expect("select protocol versions")
+            .with_no_client_auth()
+            .with_single_cert(
+                vec![cert.der().clone()],
+                PrivateKeyDer::try_from(key.serialize_der()).expect("encode private key"),
+            )
+            .expect("build server config");
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("read local address");
+
+        // Reading past the end of the client's data distinguishes a graceful
+        // close (`close_notify`, surfacing as EOF) from a dropped connection.
+        let closed_cleanly = tokio::spawn(async move {
+            let acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server));
+            let Ok((stream, _)) = listener.accept().await else {
+                return false;
+            };
+            let Ok(mut stream) = acceptor.accept(stream).await else {
+                return false;
+            };
+
+            matches!(stream.read(&mut [0u8; 1]).await, Ok(0))
+        });
+
+        (
+            format!("127.0.0.1:{}", addr.port()),
+            pem,
+            not_after,
+            closed_cleanly,
+        )
+    }
+
+    fn target(host: &str, ca_cert: Option<String>) -> TlsCertTarget {
+        TlsCertTarget {
+            host: host.to_string(),
+            server_name: Some("localhost".to_string()),
+            ca_cert,
+            alpn: Vec::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_reports_certificate_details() {
+        let (host, pem, expiry, closed_cleanly) =
+            serve_self_signed(chrono::Duration::days(60)).await;
+
+        let sample = target(&host, Some(pem))
+            .run(&AtomicBool::new(false))
+            .await
+            .expect("probe the test server");
+
+        assert_eq!(sample.get("tls.trusted"), &SampleValue::Bool(true));
+        assert_eq!(sample.get("tls.error"), &SampleValue::None);
+        assert_eq!(sample.get("tls.hostname_valid"), &SampleValue::Bool(true));
+        assert_eq!(sample.get("tls.expired"), &SampleValue::Bool(false));
+        assert_eq!(
+            sample.get("tls.subject_cn"),
+            &SampleValue::from("grey-test")
+        );
+        assert_eq!(sample.get("tls.chain.length"), &SampleValue::from(1));
+        assert_eq!(
+            sample.get("tls.sans"),
+            &SampleValue::from(vec!["localhost", "*.localhost"])
+        );
+        assert_eq!(sample.get("tls.version"), &SampleValue::from("TLSv1.3"));
+        assert!(
+            matches!(sample.get("tls.thumbprint"), SampleValue::String(s) if s.len() == 64),
+            "expected a hex-encoded SHA-256 thumbprint, got {}",
+            sample.get("tls.thumbprint")
+        );
+
+        // The expiry is exposed both absolutely and relatively, so checks can be
+        // written against `now()` or against a duration literal such as `30d`.
+        assert!(matches!(sample.get("tls.not_after"), SampleValue::DateTime(d) if *d == expiry));
+        assert!(
+            matches!(sample.get("tls.expires_in"), SampleValue::Duration(d) if *d > chrono::Duration::days(59))
+        );
+
+        assert!(
+            closed_cleanly.await.expect("the test server should finish"),
+            "the probe should send close_notify so the server can release the connection"
+        );
+    }
+
+    /// An untrusted certificate must still yield a full sample, so that a probe
+    /// can alert on the loss of trust rather than simply erroring out.
+    #[tokio::test]
+    async fn test_untrusted_certificate_still_reports_details() {
+        let (host, _, _, _) = serve_self_signed(chrono::Duration::days(60)).await;
+
+        let sample = target(&host, None)
+            .run(&AtomicBool::new(false))
+            .await
+            .expect("probe the test server");
+
+        assert_eq!(sample.get("tls.trusted"), &SampleValue::Bool(false));
+        assert!(matches!(sample.get("tls.error"), SampleValue::String(e) if !e.is_empty()));
+        assert_eq!(sample.get("tls.hostname_valid"), &SampleValue::Bool(true));
+        assert_eq!(
+            sample.get("tls.subject_cn"),
+            &SampleValue::from("grey-test")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_expired_certificate_is_reported() {
+        let (host, pem, _, _) = serve_self_signed(chrono::Duration::days(-1)).await;
+
+        let sample = target(&host, Some(pem))
+            .run(&AtomicBool::new(false))
+            .await
+            .expect("probe the test server");
+
+        assert_eq!(sample.get("tls.expired"), &SampleValue::Bool(true));
+        assert_eq!(sample.get("tls.trusted"), &SampleValue::Bool(false));
+        assert!(
+            matches!(sample.get("tls.expires_in"), SampleValue::Duration(d) if d.num_seconds() < 0)
+        );
+    }
+
+    #[test]
+    fn test_display() {
+        let target = TlsCertTarget {
+            host: "example.com:443".to_string(),
+            server_name: None,
+            ca_cert: None,
+            alpn: Vec::new(),
+        };
+        assert_eq!(target.to_string(), "TLS example.com:443");
+
+        let target = TlsCertTarget {
+            server_name: Some("internal.example.com".to_string()),
+            ..target
+        };
+        assert_eq!(
+            target.to_string(),
+            "TLS example.com:443 (internal.example.com)"
+        );
+    }
+
+    #[test]
+    fn test_host_of() {
+        assert_eq!(host_of("example.com:443"), "example.com");
+        assert_eq!(host_of("example.com"), "example.com");
+        assert_eq!(host_of("127.0.0.1:443"), "127.0.0.1");
+        assert_eq!(host_of("[::1]:443"), "::1");
+    }
+
+    #[test]
+    fn test_matches_hostname() {
+        let sans = vec!["example.com".to_string(), "*.example.com".to_string()];
+
+        assert!(matches_hostname(&sans, None, "example.com"));
+        assert!(matches_hostname(&sans, None, "EXAMPLE.COM"));
+        assert!(matches_hostname(&sans, None, "api.example.com"));
+        assert!(!matches_hostname(&sans, None, "a.b.example.com"));
+        assert!(!matches_hostname(&sans, None, "example.org"));
+
+        // The common name is only consulted when there are no SANs at all.
+        assert!(matches_hostname(&[], Some("example.com"), "example.com"));
+        assert!(!matches_hostname(&sans, Some("example.org"), "example.org"));
+    }
+
+    /// Exercises a real, publicly trusted endpoint, which is the only way to
+    /// cover chain building against the system trust store and a server which
+    /// sends intermediates.
+    #[tokio::test]
+    #[cfg(not(feature = "pure_tests"))]
+    async fn test_public_endpoint() {
+        let target = TlsCertTarget {
+            host: "sierrasoftworks.com:443".to_string(),
+            server_name: None,
+            ca_cert: None,
+            alpn: vec!["h2".to_string(), "http/1.1".to_string()],
+        };
+
+        let sample = target
+            .run(&AtomicBool::new(false))
+            .await
+            .expect("probe a public endpoint");
+
+        assert_eq!(sample.get("tls.trusted"), &SampleValue::Bool(true));
+        assert_eq!(sample.get("tls.hostname_valid"), &SampleValue::Bool(true));
+        assert_eq!(sample.get("tls.expired"), &SampleValue::Bool(false));
+        assert!(
+            matches!(sample.get("tls.chain.length"), SampleValue::Int(n) if *n > 1),
+            "a public endpoint should send its intermediates, got {}",
+            sample.get("tls.chain.length")
+        );
+        assert!(matches!(sample.get("tls.expires_in"), SampleValue::Duration(d) if !d.is_zero()));
+        assert!(matches!(sample.get("tls.alpn"), SampleValue::String(_)));
+    }
+}

--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -59,6 +59,7 @@ export default defineUserConfig({
           '/targets/http.md',
           '/targets/script.md',
           '/targets/tcp.md',
+          '/targets/tls_cert.md',
         ]
       },
       {

--- a/docs/checks/README.md
+++ b/docs/checks/README.md
@@ -47,6 +47,7 @@ The most useful operators are summarised below — see the
 | `matches`                      | Regular-expression match.                                   |
 | `+`, `-`                       | Arithmetic on numbers, datetimes, and durations.            |
 | `now()`                        | The current UTC time, for relative-time comparisons.        |
+| `30d`, `1h30m`                 | Duration literals, for comparing against durations.         |
 
 The string operators are case-insensitive by default; each has a case-sensitive `_cs`
 variant (`contains_cs`, `startswith_cs`, …). String literals use double quotes (`"text"`),

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -7,7 +7,7 @@ For a quick introduction to using Grey to probe a service, take a look at the
 [Usage Guide](../guide/README.md).
 :::
 
-When defining a probe, you can specify the target type using the `!Http`, `!Grpc`, `!Tcp`, `!Dns`, or `!Script` syntax. These
+When defining a probe, you can specify the target type using the `!Http`, `!Grpc`, `!Tcp`, `!TlsCert`, `!Dns`, or `!Script` syntax. These
 target types each accept a distinct set of configuration options which are documented
 on their respective pages.
 
@@ -47,6 +47,17 @@ probes:
       host: example.com:6379
     checks:
       - net.ip == "127.0.0.1"
+
+  - name: tls.example
+    policy:
+      interval: 1h
+      timeout: 10s
+      retries: 3
+    target: !TlsCert
+      host: example.com:443
+    checks:
+      - tls.trusted == true
+      - tls.expires_in > 30d
 
   - name: dns.example
     policy:

--- a/docs/targets/README.md
+++ b/docs/targets/README.md
@@ -68,7 +68,7 @@ probes:
       domain: example.com
       record_type: MX
     checks:
-      - "10 smtp.example.com" in dns.answers
+      - '"10 smtp.example.com" in dns.answers'
 
   - name: script.example
     policy:

--- a/docs/targets/dns.md
+++ b/docs/targets/dns.md
@@ -17,7 +17,7 @@ probes:
       domain: example.com.
       record_type: MX
     checks:
-      - "10 smtp.example.com" in dns.answers
+      - '"10 smtp.example.com" in dns.answers'
 ```
 
 ## Inputs

--- a/docs/targets/tls_cert.md
+++ b/docs/targets/tls_cert.md
@@ -1,0 +1,172 @@
+# TLS Certificate
+The `!TlsCert` target type establishes a TLS connection with a remote service and reports
+the certificate it presents, so that you can alert on impending expiry, unexpected issuers,
+or a loss of trust.
+
+It performs no application-level handshake of its own, which means it works against anything
+that speaks TLS over TCP — HTTPS, gRPC, SMTPS, message brokers, or a raw socket.
+
+::: tip
+The probe deliberately **does not fail** when a certificate is untrusted, expired, or issued
+for the wrong hostname. Those conditions are reported as fields so that you can decide, in
+your `checks`, which of them should raise an incident.
+:::
+
+## Example
+An example of this would be alerting a month before a certificate is due to expire.
+
+```yaml{7-9}
+probes:
+  - name: tls.example
+    policy:
+      interval: 1h
+      timeout: 10s
+      retries: 3
+    target: !TlsCert
+      host: example.com:443
+      alpn: [h2, http/1.1]
+    checks:
+      - tls.trusted == true
+      - tls.hostname_valid == true
+      - tls.expires_in > 30d
+      - tls.issuer_cn contains "Let's Encrypt"
+```
+
+The same target can be pointed at a privately-signed internal service by supplying the
+certificate authority which should be trusted for it.
+
+```yaml{9-15}
+probes:
+  - name: tls.internal
+    policy:
+      interval: 1h
+      timeout: 10s
+      retries: 3
+    target: !TlsCert
+      host: broker.internal:9093
+      ca_cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCB+wIJAJ...
+        -----END CERTIFICATE-----
+    checks:
+      - tls.trusted == true
+      - tls.not_after > now() + 90d
+```
+
+## Inputs
+
+### host <Badge text="required" type="danger" />
+The `host` property is used to specify the `host:port` pair that you wish to connect to.
+Unlike the [`!Http`](./http.md) target, no scheme is used and no default port is assumed,
+so the port must always be provided.
+
+### server_name
+The `server_name` property overrides the hostname sent in the TLS Server Name Indication
+extension and used to validate the certificate. By default the host portion of `host` is
+used, which is usually what you want — set this when you are connecting to a specific
+node by IP address, but expect a certificate issued for a shared service name.
+
+### ca_cert
+The `ca_cert` property is used to provide a PEM-encoded certificate authority which should
+be used to validate the server's certificate. When this is provided it **replaces** the
+system's `ca-certificates` bundle rather than adding to it, so a certificate signed by a
+public authority will be reported as untrusted.
+
+### alpn
+The `alpn` property is used to specify a list of protocols to offer during ALPN
+negotiation (for example `[h2, http/1.1]`). Some servers require ALPN to be offered before
+they will complete a handshake, and the protocol that was agreed upon is reported as
+`tls.alpn`.
+
+## Outputs
+
+### tls.trusted
+The `tls.trusted` field is `true` when the certificate chain was successfully validated
+against the trusted authorities (either the system's `ca-certificates` bundle or the
+`ca_cert` you supplied), including its validity period and the hostname it was issued for.
+
+### tls.error
+The `tls.error` field contains a description of why validation failed, or `null` when the
+certificate was trusted. It is useful for including the underlying cause in an alert.
+
+### tls.hostname_valid
+The `tls.hostname_valid` field is `true` when the certificate was issued for the hostname
+being connected to, honouring wildcard names such as `*.example.com`.
+
+### tls.expired
+The `tls.expired` field is `true` when the current time falls outside the certificate's
+validity period, whether because it has expired or because it is not yet valid.
+
+### tls.not_before / tls.not_after
+The `tls.not_before` and `tls.not_after` fields contain the bounds of the certificate's
+validity period as timestamps, which can be compared against the current time using the
+`now()` function.
+
+```yaml
+checks:
+  - tls.not_after > now() + 30d
+```
+
+### tls.expires_in
+The `tls.expires_in` field contains the time remaining until the certificate expires, as a
+duration which can be compared against duration literals directly. It is negative once the
+certificate has expired.
+
+```yaml
+checks:
+  - tls.expires_in > 30d
+```
+
+### tls.subject / tls.issuer
+The `tls.subject` and `tls.issuer` fields contain the full distinguished names of the
+certificate's subject and of the authority which issued it.
+
+### tls.subject_cn / tls.issuer_cn
+The `tls.subject_cn` and `tls.issuer_cn` fields contain just the common name portion of the
+subject and issuer, which is usually the more convenient thing to assert against.
+
+### tls.sans
+The `tls.sans` field contains the list of subject alternative names (DNS names and IP
+addresses) which the certificate is valid for.
+
+```yaml
+checks:
+  - '"api.example.com" in tls.sans'
+```
+
+### tls.serial
+The `tls.serial` field contains the certificate's serial number in its lowercase
+hex-encoded form.
+
+### tls.thumbprint
+The `tls.thumbprint` field contains the lowercase hex-encoded SHA-256 digest of the
+certificate, which can be used to pin a specific certificate.
+
+### tls.signature_algorithm
+The `tls.signature_algorithm` field contains the name of the algorithm used to sign the
+certificate, such as `ecdsa-with-SHA384`.
+
+### tls.chain.length
+The `tls.chain.length` field contains the number of certificates the server presented,
+including its own. A server which does not send its intermediates will report `1`, which
+often works in browsers (which cache intermediates) but fails elsewhere.
+
+### tls.chain.subjects / tls.chain.issuers
+The `tls.chain.subjects` and `tls.chain.issuers` fields contain the distinguished names of
+every certificate in the presented chain, in the order the server sent them.
+
+### tls.version
+The `tls.version` field contains the protocol version that was negotiated, such as
+`TLSv1.3`.
+
+### tls.cipher_suite
+The `tls.cipher_suite` field contains the name of the cipher suite that was negotiated,
+such as `TLS13_AES_256_GCM_SHA384`.
+
+### tls.alpn
+The `tls.alpn` field contains the protocol agreed upon during ALPN negotiation, or `null`
+when no ALPN protocols were offered or none were agreed.
+
+### net.ip
+The `net.ip` field contains the IP address that the hostname resolved to and which the
+connection was made to.

--- a/example/tls-cert.yml
+++ b/example/tls-cert.yml
@@ -1,0 +1,57 @@
+# Example TLS certificate monitoring configuration
+probes:
+  # Alert well before a public certificate is due to expire.
+  - name: tls.expiry
+    policy:
+      interval: 1h
+      timeout: 10s
+      retries: 3
+    target: !TlsCert
+      host: sierrasoftworks.com:443
+      alpn: [h2, http/1.1]
+    checks:
+      - tls.trusted == true
+      - tls.hostname_valid == true
+      - tls.expires_in > 30d
+
+  # The same target works against anything speaking TLS over TCP, not just HTTPS.
+  - name: tls.smtp
+    policy:
+      interval: 1h
+      timeout: 10s
+      retries: 3
+    target: !TlsCert
+      host: smtp.gmail.com:465
+    checks:
+      - tls.trusted == true
+      - tls.not_after > now() + 14d
+
+  # Connect to a specific node by IP, but validate the shared service name.
+  - name: tls.pinned
+    policy:
+      interval: 1h
+      timeout: 10s
+      retries: 3
+    target: !TlsCert
+      host: 1.1.1.1:443
+      server_name: cloudflare-dns.com
+    checks:
+      - tls.trusted == true
+      - '"cloudflare-dns.com" in tls.sans'
+      - tls.chain.length > 1
+
+  # A privately signed service, validated against its own certificate authority.
+  # - name: tls.internal
+  #   policy:
+  #     interval: 1h
+  #     timeout: 10s
+  #     retries: 3
+  #   target: !TlsCert
+  #     host: broker.internal:9093
+  #     ca_cert: |
+  #       -----BEGIN CERTIFICATE-----
+  #       ...
+  #       -----END CERTIFICATE-----
+  #   checks:
+  #     - tls.trusted == true
+  #     - tls.expires_in > 90d


### PR DESCRIPTION
Adds a TlsCert probe target which establishes a TLS connection with a remote
server, collects its certificate details, and exposes them so that assertions
can be made about them.

## Why

There was no way to alert on an impending certificate expiry, an unexpected
issuer, or a loss of trust. Doing this through the Http target would only work
for HTTPS services, and would fail outright on exactly the conditions worth
alerting on.

## How it works

The target performs no application-protocol handshake of its own, so it works
against anything exposing TLS over TCP - HTTPS, gRPC, SMTPS, brokers, or a raw
socket.

Verification runs through the real rustls verifier, wrapped so that it records
the presented chain and the resulting verdict but always reports success. The
handshake therefore completes even when the certificate is untrusted, expired,
or issued for another hostname, and those conditions surface as fields rather
than as probe errors - leaving the policy decision to the checks. Expiry and
hostname validity are derived from the certificate itself rather than from the
single collapsed webpki error, so each is independently assertable.

The connection is closed with close_notify once the sample is collected, so
servers release the slot immediately instead of waiting for an idle timeout.

## Inputs

host, server_name (SNI override), ca_cert (PEM, replaces the system trust
store), and alpn.

## Outputs

tls.trusted, tls.error, tls.hostname_valid, tls.expired, tls.not_before,
tls.not_after, tls.expires_in, tls.subject, tls.issuer, tls.subject_cn,
tls.issuer_cn, tls.sans, tls.serial, tls.thumbprint (SHA-256),
tls.signature_algorithm, tls.chain.length, tls.chain.subjects,
tls.chain.issuers, tls.version, tls.cipher_suite, tls.alpn, and net.ip.

## Temporal sample values

SampleValue gained datetime and duration variants mapped onto the native
filt-rs types, so expiry can be asserted either way:

    checks:
      - tls.expires_in > 30d
      - tls.not_after > now() + 30d

## Notes

The rustls crypto provider is named explicitly (ring) because both it and
aws-lc-rs are enabled elsewhere in the dependency graph, which leaves no
unambiguous default and would otherwise panic at runtime.

## Testing

Tests mint self-signed certificates with rcgen and serve them locally, covering
the trusted, untrusted, and expired cases, plus delivery of close_notify. A
live public-endpoint test covers real intermediate chains and is gated behind
the pure_tests feature. The shipped example config is guarded by a loader test.