### PR TITLE
fix: make status glyphs legible on filled backgrounds

### DIFF
--- a/ui/src/components/_incidents.scss
+++ b/ui/src/components/_incidents.scss
@@ -268,7 +268,7 @@
         }
         &:focus {
             outline: none;
-            border-color: $color-status-unknown;
+            border-color: $color-accent;
             background-color: $background-base;
         }
     }
@@ -280,7 +280,7 @@
         background: none;
         padding: 0.1rem;
         margin: 0.3rem 0 0 0.5rem;
-        color: $color-status-unknown;
+        color: $color-accent;
         display: inline-flex;
         align-items: center;
 

--- a/ui/src/styles/_buttons.scss
+++ b/ui/src/styles/_buttons.scss
@@ -18,13 +18,13 @@
 }
 
 .primary-button {
-    background-color: $color-status-unknown;
+    background-color: $color-accent;
     color: $color-status-text;
-    border-color: $color-status-unknown;
+    border-color: $color-accent;
 
     &:hover {
         opacity: 0.9;
-        background-color: $color-status-unknown;
+        background-color: $color-accent;
     }
 
     &:disabled {

--- a/ui/src/styles/_buttons.scss
+++ b/ui/src/styles/_buttons.scss
@@ -11,6 +11,7 @@
     border-radius: $border-radius-small;
     padding: 0.4rem 0.9rem;
     font-size: 0.85rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
 
     &:hover {
         background-color: $color-separator;
@@ -21,6 +22,7 @@
     background-color: $color-accent;
     color: $color-status-text;
     border-color: $color-accent;
+    transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
 
     &:hover {
         opacity: 0.9;
@@ -45,6 +47,7 @@
     border: 1px solid $color-status-warn;
     border-radius: $border-radius-small;
     padding: 0.4rem 0.85rem;
+    transition: background-color 0.2s ease, color 0.2s ease;
 
     &:hover {
         color: $color-status-text;
@@ -62,6 +65,7 @@
     font-size: 0.8rem;
     color: $color-text-muted;
     text-decoration: underline;
+    transition: background-color 0.2s ease, color 0.2s ease, opacity 0.2s ease;
 
     &:hover {
         color: $color-text;

--- a/ui/src/styles/_status.scss
+++ b/ui/src/styles/_status.scss
@@ -36,42 +36,50 @@
     letter-spacing: 0.025em;
 }
 
-// Status icons with backgrounds
+// Status icons: a solid silhouette in the inherited text colour, with no disc or ring behind it. The
+// shape alone carries the status, so it stays legible on a background of its own status colour (a
+// filled banner) where a coloured disc would disappear. Each status supplies its silhouette as a
+// mask, which is why the artwork's own fill colour is irrelevant — only its coverage matters.
 .status {
     &::before {
         content: "";
         display: inline-block;
         width: 1em;
         height: 1em;
-        border-radius: 50%;
         margin-right: 0.5rem;
         vertical-align: middle;
-        background-repeat: no-repeat;
-        background-position: center center;
-        background-size: 60% auto;
-        box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+        background-color: currentColor;
+        -webkit-mask: var(--status-glyph) center / contain no-repeat;
+        mask: var(--status-glyph) center / contain no-repeat;
+        // `vertical-align: middle` centres the box on the text's midline, but each silhouette carries
+        // its ink differently within that box (a triangle is bottom-heavy, a question mark top-heavy),
+        // so each nudges itself onto that midline. One viewBox unit is 1/16em; shifting the box rather
+        // than the artwork avoids clipping it.
+        transform: translateY(var(--status-glyph-shift, 0));
     }
 
     &.ok::before {
-        background-color: $color-status-ok;
-        color: $color-status-text;
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z' fill='%23fff'/%3E%3C/svg%3e");
+        --status-glyph: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.4 13.2 1.2 8l2.1-2.1 3.1 3.1 6.3-6.3L14.8 4.8z' fill='%23000'/%3E%3C/svg%3E");
     }
 
+    // The exclamation is knocked out of the triangle (evenodd), so it reads as the background colour
+    // rather than as a second, differently coloured mark. The cut-out is still read as part of the
+    // triangle's body, so it balances between its mass centre and its geometric centre rather than
+    // riding the mass centre alone, which sits it too high.
     &.warn::before {
-        background-color: $color-status-warn;
-        color: $color-status-text;
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M8.22 1.754a.25.25 0 00-.44 0L1.698 13.132a.25.25 0 00.22.368h12.164a.25.25 0 00.22-.368L8.22 1.754zm-1.763-.707c.659-1.234 2.427-1.234 3.086 0l6.082 11.378A1.75 1.75 0 0114.082 15H1.918a1.75 1.75 0 01-1.543-2.575L6.457 1.047zM9 11a1 1 0 11-2 0 1 1 0 012 0zm-.25-5.25a.75.75 0 00-1.5 0v2.5a.75.75 0 001.5 0v-2.5z' fill='%23fff'/%3E%3C/svg%3e");
+        --status-glyph-shift: -0.072em;
+        --status-glyph: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' d='M8.87 1.9a1 1 0 0 0-1.74 0l-6.8 11.6A1 1 0 0 0 1.2 15h13.6a1 1 0 0 0 .87-1.5zM7 5.6h2v4.6H7zm0 5.7h2v2.1H7z' fill='%23000'/%3E%3C/svg%3E");
     }
 
     &.error::before {
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='24' height='24' viewBox='0 0 24 24' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='m12 24c6.6274 0 12-5.3726 12-12 0-6.62744-5.3726-12-12-12-6.62744 0-12 5.37256-12 12 0 6.6274 5.37256 12 12 12zm0-17.5c.4141 0 .75.33582.75.75v4.5c0 .4142-.3359.75-.75.75s-.75-.3358-.75-.75v-4.5c0-.41418.3359-.75.75-.75zm.8242 9.5658c.0635-.0919.1118-.195.1416-.3054.0132-.0482.0225-.0979.0283-.1487.0039-.0366.0059-.074.0059-.1117 0-.5522-.4478-1-1-1s-1 .4478-1 1 .4478 1 1 1c.3423 0 .644-.172.8242-.4342z' fill='%23d73a49'/%3E%3C/svg%3e");
-        background-size: 100% auto;
+        --status-glyph-shift: -0.127em;
+        --status-glyph: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 .6c1.9 2.5 1.6 4.2.7 5.4c-.5.7-1.5.4-1.3-.5c.1-.6.1-1.1-.2-1.6C4.6 5.9 2.9 8.2 2.9 10.7c0 2.8 2.3 4.7 5.1 4.7s5.1-1.9 5.1-4.7C13.1 7.9 11.2 5.2 8 .6z' fill='%23000'/%3E%3C/svg%3E");
     }
 
+    // Centred on its geometric middle, not its mass: it reads as a character, so sitting it off-centre
+    // beside text looks like a typo rather than an icon.
     &.unknown::before {
-        background-color: $color-status-unknown;
-        color: $color-status-text;
-        background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill-rule='evenodd' clip-rule='evenodd' d='M5.433 2.304A4.494 4.494 0 003.5 6c0 1.598.832 3.002 2.09 3.802.518.328.929.923.902 1.64v.008l-.164 3.337a.75.75 0 11-1.498-.073l.163-3.33c.002-.085-.05-.216-.207-.316A5.996 5.996 0 012 6a5.994 5.994 0 012.567-4.92 1.482 1.482 0 011.673-.04c.462.296.76.827.76 1.423v2.82c0 .082.041.16.11.206l.75.51a.25.25 0 00.28 0l.75-.51A.25.25 0 009 5.282V2.463c0-.596.298-1.127.76-1.423a1.482 1.482 0 011.673.04A5.994 5.994 0 0114 6a5.996 5.996 0 01-2.786 5.068c-.157.1-.209.23-.207.315l.163 3.33a.75.75 0 11-1.498.074l-.164-3.345c-.027-.717.384-1.312.902-1.64A4.496 4.496 0 0012.5 6a4.494 4.494 0 00-1.933-3.696c-.024.017-.067.067-.067.16v2.818a1.75 1.75 0 01-.767 1.448l-.75.51a1.75 1.75 0 01-1.966 0l-.75-.51A1.75 1.75 0 015.5 5.282V2.463c0-.092-.043-.142-.067-.159zm.01-.005z' fill='%23fff'/%3E%3C/svg%3e");
+        --status-glyph-shift: -0.012em;
+        --status-glyph: url("data:image/svg+xml;charset=utf8,%3Csvg width='16' height='16' viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8 1.1C5.5 1.1 3.6 2.7 3.4 5.1h2.4C6 3.9 6.8 3.2 8 3.2c1.2 0 2 .7 2 1.7c0 .8-.4 1.3-1.5 2C7.2 7.8 6.7 8.7 6.8 10.1v.6h2.3v-.5c0-1 .4-1.4 1.5-2.1c1.3-.9 2-1.9 2-3.3C12.6 2.6 10.7 1.1 8 1.1z' fill='%23000'/%3E%3Cpath d='M8 12.1a1.6 1.6 0 1 0 0 3.2a1.6 1.6 0 0 0 0-3.2z' fill='%23000'/%3E%3C/svg%3E");
     }
 }

--- a/ui/src/styles/_variables.scss
+++ b/ui/src/styles/_variables.scss
@@ -15,8 +15,14 @@
     --color-status-warn: #e67e22;
     --color-status-error: #e74c3c;
     --color-status-running: #5dade2;
-    --color-status-unknown: #3498db;
+    // Grey rather than blue, so "no data yet" reads as absent rather than as an in-flight run, and
+    // stays distinct from the lighter `offline` grey used for drafts.
+    --color-status-unknown: #7f8c8d;
     --color-status-offline: #95a5a6;
+
+    /* Interactive accent for primary actions, focus rings and the save affordance. Kept out of the
+       status palette so changing a status colour can't restyle unrelated controls. */
+    --color-accent: #3498db;
 
     /* Tooltip theme */
     --tooltip-background: #111; /* near-black for readability */
@@ -47,8 +53,10 @@
         --color-status-warn: #e67e22;
         --color-status-error: #e74c3c;
         --color-status-running: #5dade2;
-        --color-status-unknown: #3498db;
+        --color-status-unknown: #7f8c8d;
         --color-status-offline: #95a5a6;
+
+        --color-accent: #3498db;
 
         /* Tooltip theme */
         --tooltip-background: #111; /* near-black for readability */
@@ -76,6 +84,7 @@ $color-status-error: var(--color-status-error);
 $color-status-running: var(--color-status-running);
 $color-status-unknown: var(--color-status-unknown);
 $color-status-offline: var(--color-status-offline);
+$color-accent: var(--color-accent);
 
 // Tooltip theme variables
 $color-tooltip-background: var(--tooltip-background);


### PR DESCRIPTION
The status glyphs were a coloured disc on a background of the same status colour, so on a filled banner the disc vanished and the glyph had almost nothing to read against.

- Glyphs are now a single solid silhouette masked in the inherited text colour, with no disc, ring or shadow, so they stay legible on a fill of their own status colour
- Redrawn on one 16-unit grid as silhouettes rather than thin outlines, which survive being scaled down to 12px: a bold tick, a triangle with the exclamation knocked out, a flame, and a question mark replacing the old circuit glyph
- Each glyph is nudged so its centre lands on the text midline; the offsets come from the measured ink of each shape
- The unknown status moves from blue to grey, so it reads as absent rather than as an in-flight run and is no longer confusable with the running colour
- Primary actions, focus rings and the save affordance borrowed that same blue, so they move to a dedicated accent token rather than tracking a status colour
- Button hover transition tweak

Verified against the control gallery at /controls across every status, on filled, tinted and plain backgrounds, at both 1em and 2.5rem.