### PR TITLE
feat(ui): Allow incidents and updates to be backdated

### DIFF
--- a/agent/src/api/admin.rs
+++ b/agent/src/api/admin.rs
@@ -28,7 +28,7 @@ fn not_found() -> HttpResponse {
 fn bad_timestamp() -> HttpResponse {
     ApiError::bad_request("The supplied update timestamp is not valid.")
         .with_advice_lines([
-            "An update may be backdated, but it cannot be dated in the future.",
+            "An update may be backdated to any time since 1970, but never dated in the future.",
             "Check that the time is in UTC and that your clock is correct.",
         ])
         .into()

--- a/agent/src/api/admin.rs
+++ b/agent/src/api/admin.rs
@@ -1,7 +1,8 @@
 use actix_web::{HttpMessage, HttpRequest, HttpResponse, Result, http::header, web};
+use chrono::{DateTime, Utc};
 use grey_api::{
     AdminUser, ApiError, CreateIncident, CreateUpdate, Identifier, IncidentUpdateId, PutIncident,
-    PutUpdate, parse_if_match, version_etag,
+    PutUpdate, is_valid_update_timestamp, parse_if_match, version_etag,
 };
 use serde_json::{Map, Value};
 use std::str::FromStr;
@@ -22,6 +23,21 @@ fn not_found() -> HttpResponse {
             "It may have been deleted since you last loaded the page.",
         ])
         .into()
+}
+
+fn bad_timestamp() -> HttpResponse {
+    ApiError::bad_request("The supplied update timestamp is not valid.")
+        .with_advice_lines([
+            "An update may be backdated, but it cannot be dated in the future.",
+            "Check that the time is in UTC and that your clock is correct.",
+        ])
+        .into()
+}
+
+/// Whether an operator-supplied timestamp (if any) may be accepted — see
+/// [`grey_api::is_valid_update_timestamp`]. `None` always passes: the server stamps the update itself.
+fn timestamp_allowed(timestamp: Option<DateTime<Utc>>) -> bool {
+    timestamp.is_none_or(|ts| is_valid_update_timestamp(ts, Utc::now()))
 }
 
 fn too_large() -> HttpResponse {
@@ -111,7 +127,8 @@ pub async fn get_incident(
     }
 }
 
-/// `POST /api/v1/admin/incidents` — create an incident from a title and its opening update.
+/// `POST /api/v1/admin/incidents` — create an incident from a title and its opening update. The
+/// opening update may carry a `timestamp` to declare an outage that started in the past.
 pub async fn create_incident(
     data: web::Data<AppState>,
     body: web::Json<CreateIncident>,
@@ -120,7 +137,10 @@ pub async fn create_incident(
     if input.message.len() > MAX_MESSAGE_BYTES {
         return Ok(too_large());
     }
-    let view = data.state.create_incident(input.title, input.impact, input.message).await?;
+    if !timestamp_allowed(input.timestamp) {
+        return Ok(bad_timestamp());
+    }
+    let view = data.state.create_incident(input).await?;
     Ok(HttpResponse::Created()
         .insert_header((header::ETAG, version_etag(view.incident.version)))
         .json(view))
@@ -169,8 +189,9 @@ pub async fn delete_incident(
     }
 }
 
-/// `POST /api/v1/admin/incidents/{id}/updates` — add a new update to an incident. 404 if the incident
-/// does not exist. The ETag is the new update's version.
+/// `POST /api/v1/admin/incidents/{id}/updates` — add a new update to an incident, optionally
+/// backdated via the body's `timestamp`. 404 if the incident does not exist. The ETag is the new
+/// update's version.
 pub async fn create_update(
     data: web::Data<AppState>,
     path: web::Path<String>,
@@ -183,6 +204,9 @@ pub async fn create_update(
     if input.message.len() > MAX_MESSAGE_BYTES {
         return Ok(too_large());
     }
+    if !timestamp_allowed(input.timestamp) {
+        return Ok(bad_timestamp());
+    }
     match data.state.create_update(id, input).await? {
         Some((version, view)) => Ok(HttpResponse::Created()
             .insert_header((header::ETAG, version_etag(version)))
@@ -191,8 +215,9 @@ pub async fn create_update(
     }
 }
 
-/// `PUT /api/v1/admin/incidents/{id}/updates/{uid}` — replace an update's message (check-and-set
-/// against the update's version). The update's impact is fixed once posted.
+/// `PUT /api/v1/admin/incidents/{id}/updates/{uid}` — replace an update's message, and its timestamp
+/// when the body supplies one (check-and-set against the update's version). The update's impact is
+/// fixed once posted.
 pub async fn put_update(
     req: HttpRequest,
     data: web::Data<AppState>,
@@ -209,6 +234,9 @@ pub async fn put_update(
     let input = body.into_inner();
     if input.message.len() > MAX_MESSAGE_BYTES {
         return Ok(too_large());
+    }
+    if !timestamp_allowed(input.timestamp) {
+        return Ok(bad_timestamp());
     }
     match data.state.put_update(uid, expected, input).await? {
         CasOutcome::Updated(version, view) => Ok(HttpResponse::Ok()
@@ -338,6 +366,82 @@ mod tests {
         assert_eq!(test::call_service(&app, req).await.status(), StatusCode::NO_CONTENT);
         let req = test::TestRequest::get().uri(&format!("/incidents/{}", created.id())).to_request();
         assert_eq!(test::call_service(&app, req).await.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[actix_web::test]
+    async fn updates_may_be_backdated_but_never_future_dated() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::test(dir.path().to_path_buf()).await;
+        let app = test::init_service(
+            App::new()
+                .app_data(web::Data::new(state))
+                .route("/incidents", web::post().to(create_incident))
+                .route("/incidents/{id}/updates", web::post().to(create_update))
+                .route("/incidents/{id}/updates/{uid}", web::put().to(put_update)),
+        )
+        .await;
+
+        let now = Utc::now().timestamp();
+        let (started, mitigated) = (now - 7_200, now - 3_600);
+
+        // Declaring an outage that began two hours ago backdates its opening update.
+        let req = test::TestRequest::post()
+            .uri("/incidents")
+            .set_json(serde_json::json!({
+                "title": "Outage", "impact": "offline", "message": "Investigating", "timestamp": started,
+            }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let created: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(created.started_at().map(|t| t.timestamp()), Some(started));
+
+        // A future-dated one is refused: the newest update sets the incident's current impact.
+        let req = test::TestRequest::post()
+            .uri("/incidents")
+            .set_json(serde_json::json!({
+                "title": "Later", "impact": "offline", "message": "Not yet", "timestamp": now + 3_600,
+            }))
+            .to_request();
+        assert_eq!(test::call_service(&app, req).await.status(), StatusCode::BAD_REQUEST);
+
+        // Recording when mitigation completed, an hour after the incident began.
+        let req = test::TestRequest::post()
+            .uri(&format!("/incidents/{}/updates", created.id()))
+            .set_json(serde_json::json!({ "impact": "none", "message": "Mitigated", "timestamp": mitigated }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::CREATED);
+        let resolved: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(resolved.current_impact(), Impact::None);
+        assert_eq!(resolved.ended_at().map(|t| t.timestamp()), Some(mitigated));
+
+        let req = test::TestRequest::post()
+            .uri(&format!("/incidents/{}/updates", created.id()))
+            .set_json(serde_json::json!({ "impact": "none", "message": "Soon", "timestamp": now + 3_600 }))
+            .to_request();
+        assert_eq!(test::call_service(&app, req).await.status(), StatusCode::BAD_REQUEST);
+
+        // A mistimed update can be corrected in place (check-and-set on its own version).
+        let posted = resolved.updates.iter().find(|u| u.impact == Impact::None).unwrap().clone();
+        let req = test::TestRequest::put()
+            .uri(&format!("/incidents/{}/updates/{}", created.id(), posted.id))
+            .insert_header(("If-Match", version_etag(posted.version)))
+            .set_json(serde_json::json!({ "message": "Mitigated", "timestamp": mitigated - 600 }))
+            .to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+        let corrected: IncidentView = serde_json::from_slice(&test::read_body(resp).await).unwrap();
+        assert_eq!(corrected.ended_at().map(|t| t.timestamp()), Some(mitigated - 600));
+
+        // ...but not into the future, and the stored update is left as it was.
+        let posted = corrected.updates.iter().find(|u| u.impact == Impact::None).unwrap().clone();
+        let req = test::TestRequest::put()
+            .uri(&format!("/incidents/{}/updates/{}", created.id(), posted.id))
+            .insert_header(("If-Match", version_etag(posted.version)))
+            .set_json(serde_json::json!({ "message": "Mitigated", "timestamp": now + 3_600 }))
+            .to_request();
+        assert_eq!(test::call_service(&app, req).await.status(), StatusCode::BAD_REQUEST);
     }
 
     #[actix_web::test]

--- a/agent/src/api/incidents.rs
+++ b/agent/src/api/incidents.rs
@@ -31,7 +31,7 @@ pub async fn get_incidents(
 mod tests {
     use actix_web::body::MessageBody;
     use actix_web::http::StatusCode;
-    use grey_api::{Impact, IncidentsPage};
+    use grey_api::{CreateIncident, Impact, IncidentsPage};
     use tempfile::tempdir;
 
     use super::*;
@@ -59,12 +59,22 @@ mod tests {
 
         let visible = app_state
             .state
-            .create_incident("Visible".into(), Impact::Offline, "down".into())
+            .create_incident(CreateIncident {
+                title: "Visible".into(),
+                impact: Impact::Offline,
+                message: "down".into(),
+                timestamp: None,
+            })
             .await
             .unwrap();
         app_state
             .state
-            .create_incident("Hidden".into(), Impact::Hidden, "draft".into())
+            .create_incident(CreateIncident {
+                title: "Hidden".into(),
+                impact: Impact::Hidden,
+                message: "draft".into(),
+                timestamp: None,
+            })
             .await
             .unwrap();
 

--- a/agent/src/api/page.rs
+++ b/agent/src/api/page.rs
@@ -142,11 +142,12 @@ mod tests {
 
         app_state
             .state
-            .create_incident(
-                "Database outage".into(),
-                grey_api::Impact::Offline,
-                "Investigating".into(),
-            )
+            .create_incident(grey_api::CreateIncident {
+                title: "Database outage".into(),
+                impact: grey_api::Impact::Offline,
+                message: "Investigating".into(),
+                timestamp: None,
+            })
             .await
             .unwrap();
 

--- a/agent/src/state/incidents.rs
+++ b/agent/src/state/incidents.rs
@@ -12,8 +12,8 @@ use std::error::Error;
 
 use chrono::{DateTime, Utc};
 use grey_api::{
-    CreateUpdate, Identifier, Impact, Incident, IncidentUpdate, IncidentUpdateId, IncidentView,
-    IncidentsPage, PutIncident, PutUpdate,
+    CreateIncident, CreateUpdate, Identifier, Incident, IncidentUpdate, IncidentUpdateId,
+    IncidentView, IncidentsPage, PutIncident, PutUpdate,
 };
 use redb::{ReadableDatabase, ReadableTable, TableDefinition};
 use tracing_batteries::prelude::*;
@@ -125,13 +125,12 @@ pub trait IncidentStore {
     /// Fetches a single (live) incident with its visible updates.
     async fn get_incident(&self, id: Identifier) -> Result<Option<IncidentView>, Box<dyn Error>>;
 
-    /// Creates an incident with a single opening update, minting snowflake ids for both.
-    async fn create_incident(
-        &self,
-        title: String,
-        impact: Impact,
-        message: String,
-    ) -> Result<IncidentView, Box<dyn Error>>;
+    /// Creates an incident with a single opening update, minting snowflake ids for both. A
+    /// `timestamp` on the input backdates the opening update, and with it the incident's id — so a
+    /// retroactively declared outage sorts into the (id-ordered) list at the time it began rather
+    /// than at the time it was declared.
+    async fn create_incident(&self, input: CreateIncident)
+    -> Result<IncidentView, Box<dyn Error>>;
 
     /// Replaces an incident's editable header fields (its title) if `expected_version` matches.
     async fn put_incident(
@@ -148,15 +147,17 @@ pub trait IncidentStore {
         expected_version: u64,
     ) -> Result<CasOutcome<()>, Box<dyn Error>>;
 
-    /// Adds a new update to an existing incident. `None` when the incident does not exist (a 404). The
-    /// returned tuple is `(new update version, refreshed view)`.
+    /// Adds a new update to an existing incident, backdated to the input's `timestamp` when it carries
+    /// one. `None` when the incident does not exist (a 404). The returned tuple is `(new update
+    /// version, refreshed view)`.
     async fn create_update(
         &self,
         incident_id: Identifier,
         update: CreateUpdate,
     ) -> Result<Option<(u64, IncidentView)>, Box<dyn Error>>;
 
-    /// Replaces an update's editable field (its message) if `expected_version` matches.
+    /// Replaces an update's editable fields (its message, plus its timestamp when the edit supplies
+    /// one) if `expected_version` matches.
     async fn put_update(
         &self,
         update_id: IncidentUpdateId,
@@ -296,24 +297,22 @@ impl IncidentStore for State {
         read_view(&txn, id)
     }
 
-    async fn create_incident(
-        &self,
-        title: String,
-        impact: Impact,
-        message: String,
-    ) -> Result<IncidentView, Box<dyn Error>> {
+    async fn create_incident(&self, input: CreateIncident) -> Result<IncidentView, Box<dyn Error>> {
         let now = Utc::now();
+        // `version` is the gossip/ETag clock and always tracks wall-clock now; `started` is when the
+        // event itself began, which an operator may backdate.
         let version = now.timestamp_millis() as u64;
-        let incident_id = Identifier::from(snowflake_half(now));
+        let started = input.timestamp.unwrap_or(now);
+        let incident_id = Identifier::from(snowflake_half(started));
         let update = IncidentUpdate {
-            id: IncidentUpdateId::compose(incident_id, snowflake_half(now)),
-            impact,
-            timestamp: now,
-            message,
+            id: IncidentUpdateId::compose(incident_id, snowflake_half(started)),
+            impact: input.impact,
+            timestamp: started,
+            message: input.message,
             version,
             deleted: false,
         };
-        let incident = Incident { id: incident_id, title, version, deleted: false };
+        let incident = Incident { id: incident_id, title: input.title, version, deleted: false };
 
         let update_bytes = rmp_serde::to_vec_named(&update)?;
         if update_bytes.len() > MAX_UPDATE_BYTES {
@@ -409,10 +408,13 @@ impl IncidentStore for State {
     ) -> Result<Option<(u64, IncidentView)>, Box<dyn Error>> {
         let now = Utc::now();
         let version = now.timestamp_millis() as u64;
+        // An update may record a moment that has already passed (when mitigation completed, say)
+        // rather than the moment it is posted.
+        let occurred = update.timestamp.unwrap_or(now);
         let new_update = IncidentUpdate {
-            id: IncidentUpdateId::compose(incident_id, snowflake_half(now)),
+            id: IncidentUpdateId::compose(incident_id, snowflake_half(occurred)),
             impact: update.impact,
-            timestamp: now,
+            timestamp: occurred,
             message: update.message,
             version,
             deleted: false,
@@ -465,8 +467,13 @@ impl IncidentStore for State {
                     CasOutcome::VersionMismatch(existing.version)
                 }
                 Some(mut existing) => {
-                    // `impact` and `timestamp` are fixed once posted; only the message is editable.
+                    // `impact` is fixed once posted; the message is editable, and so is the timestamp
+                    // (a backdated update recorded at the wrong moment can be corrected) whenever the
+                    // edit supplies one.
                     existing.message = edit.message;
+                    if let Some(timestamp) = edit.timestamp {
+                        existing.timestamp = timestamp;
+                    }
                     existing.version = new_version;
                     updates.insert(u128::from(update_id), (new_version, own, rmp_serde::to_vec_named(&existing)?.as_slice()))?;
                     CasOutcome::Updated(new_version, ())
@@ -521,6 +528,18 @@ impl IncidentStore for State {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use grey_api::Impact;
+
+    /// A whole-second timestamp `hours` in the past. Update timestamps ride the wire (and the gossip
+    /// snapshot) as unix seconds, so tests that compare a stored time use second precision.
+    fn hours_ago(hours: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(Utc::now().timestamp() - hours * 3600, 0).unwrap()
+    }
+
+    /// The opening update for a freshly declared (not backdated) incident.
+    fn opening(title: &str, impact: Impact, message: &str) -> CreateIncident {
+        CreateIncident { title: title.into(), impact, message: message.into(), timestamp: None }
+    }
 
     async fn test_state(dir: &std::path::Path) -> State {
         State::test(dir.to_path_buf()).await
@@ -531,8 +550,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = test_state(dir.path()).await;
 
-        let public = state.create_incident("Public".into(), Impact::Offline, "down".into()).await.unwrap();
-        let hidden = state.create_incident("Hidden".into(), Impact::Hidden, "draft".into()).await.unwrap();
+        let public = state.create_incident(opening("Public", Impact::Offline, "down")).await.unwrap();
+        let hidden = state.create_incident(opening("Hidden", Impact::Hidden, "draft")).await.unwrap();
 
         assert_ne!(public.id(), hidden.id());
         assert_eq!(public.updates.len(), 1);
@@ -549,11 +568,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn an_incident_can_be_declared_after_it_started() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        // An outage noticed late: declared now, but recorded as having started two hours ago.
+        let started = hours_ago(2);
+        let backdated = state
+            .create_incident(CreateIncident {
+                title: "Backdated".into(),
+                impact: Impact::Offline,
+                message: "down since 2h ago".into(),
+                timestamp: Some(started),
+            })
+            .await
+            .unwrap();
+        assert_eq!(backdated.started_at(), Some(started));
+
+        // Its id is minted from the start time, so it sorts into the (newest-first) list where the
+        // event actually happened rather than at the top.
+        let fresh = state.create_incident(opening("Fresh", Impact::Offline, "down now")).await.unwrap();
+        let listed = state.list_incidents(true, 10, None).await.unwrap();
+        assert_eq!(
+            listed.incidents.iter().map(|v| v.id()).collect::<Vec<_>>(),
+            vec![fresh.id(), backdated.id()],
+            "the incident declared for two hours ago sorts behind the one starting now"
+        );
+
+        // Its gossip/ETag version is still wall-clock now, not the backdated time — replication and
+        // check-and-set must not be dragged into the past.
+        assert!(backdated.incident.version as i64 >= started.timestamp_millis() + 3_600_000);
+    }
+
+    #[tokio::test]
+    async fn updates_can_be_recorded_at_a_past_moment_and_corrected() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = test_state(dir.path()).await;
+
+        let started = hours_ago(3);
+        let created = state
+            .create_incident(CreateIncident {
+                title: "Outage".into(),
+                impact: Impact::Offline,
+                message: "down".into(),
+                timestamp: Some(started),
+            })
+            .await
+            .unwrap();
+
+        // Mitigation completed an hour ago — record it at that moment, not at the moment we post it.
+        let mitigated = hours_ago(1);
+        let (version, view) = state
+            .create_update(
+                created.id(),
+                CreateUpdate {
+                    impact: Impact::None,
+                    message: "mitigated".into(),
+                    timestamp: Some(mitigated),
+                },
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(view.current_impact(), Impact::None);
+        assert_eq!(view.ended_at(), Some(mitigated), "the incident ended when mitigation completed");
+        assert_eq!(view.started_at(), Some(started));
+
+        // The time was an hour out: correct it, leaving the message alone.
+        let corrected = hours_ago(2);
+        let outcome = state
+            .put_update(
+                view.updates.last().unwrap().id,
+                version,
+                PutUpdate { message: "mitigated".into(), timestamp: Some(corrected) },
+            )
+            .await
+            .unwrap();
+        let (version, view) = match outcome {
+            CasOutcome::Updated(v, view) => (v, view),
+            _ => panic!("expected Updated"),
+        };
+        assert_eq!(view.ended_at(), Some(corrected));
+
+        // An edit without a timestamp leaves the (corrected) one in place.
+        let outcome = state
+            .put_update(
+                view.updates.last().unwrap().id,
+                version,
+                PutUpdate { message: "mitigation complete".into(), timestamp: None },
+            )
+            .await
+            .unwrap();
+        let view = match outcome {
+            CasOutcome::Updated(_, view) => view,
+            _ => panic!("expected Updated"),
+        };
+        assert_eq!(view.ended_at(), Some(corrected));
+        assert_eq!(view.updates.last().unwrap().message, "mitigation complete");
+    }
+
+    #[tokio::test]
     async fn put_and_delete_are_check_and_set() {
         let dir = tempfile::tempdir().unwrap();
         let state = test_state(dir.path()).await;
 
-        let created = state.create_incident("Outage".into(), Impact::Offline, "down".into()).await.unwrap();
+        let created = state.create_incident(opening("Outage", Impact::Offline, "down")).await.unwrap();
         let v0 = created.incident.version;
 
         // Correct version -> updated + bumped version.
@@ -578,11 +697,11 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = test_state(dir.path()).await;
 
-        let created = state.create_incident("Outage".into(), Impact::Offline, "down".into()).await.unwrap();
+        let created = state.create_incident(opening("Outage", Impact::Offline, "down")).await.unwrap();
         let incident_version = created.incident.version;
 
         // Adding an update does NOT bump the incident entity's version (they are separate entities).
-        let (uv, view) = state.create_update(created.id(), CreateUpdate { impact: Impact::None, message: "fixed".into() }).await.unwrap().unwrap();
+        let (uv, view) = state.create_update(created.id(), CreateUpdate { impact: Impact::None, message: "fixed".into(), timestamp: None }).await.unwrap().unwrap();
         assert_eq!(view.updates.len(), 2);
         assert!(
             view.updates.iter().any(|u| u.impact == Impact::Offline)
@@ -594,7 +713,7 @@ mod tests {
         // The new (None) update has its own version and is editable by CAS.
         let new_update = view.updates.iter().find(|u| u.impact == Impact::None).unwrap().clone();
         assert_eq!(new_update.version, uv);
-        let edited = state.put_update(new_update.id, uv, PutUpdate { message: "resolved".into() }).await.unwrap();
+        let edited = state.put_update(new_update.id, uv, PutUpdate { message: "resolved".into(), timestamp: None }).await.unwrap();
         match edited {
             CasOutcome::Updated(_, v) => {
                 let msg = v.updates.iter().find(|u| u.id == new_update.id).unwrap().message.clone();
@@ -610,7 +729,7 @@ mod tests {
         assert_eq!(after.current_impact(), Impact::Offline);
 
         // Adding an update to a missing incident is a 404 (None).
-        assert!(state.create_update(Identifier::from(424242u64), CreateUpdate { impact: Impact::None, message: "x".into() }).await.unwrap().is_none());
+        assert!(state.create_update(Identifier::from(424242u64), CreateUpdate { impact: Impact::None, message: "x".into(), timestamp: None }).await.unwrap().is_none());
     }
 
     // Helper: the current stored version of an update (it bumps on each edit).
@@ -627,7 +746,7 @@ mod tests {
         // Create several incidents; their snowflake ids are time-ordered.
         let mut ids = Vec::new();
         for i in 0..5 {
-            let v = state.create_incident(format!("Incident {i}"), Impact::Offline, "x".into()).await.unwrap();
+            let v = state.create_incident(opening(&format!("Incident {i}"), Impact::Offline, "x")).await.unwrap();
             ids.push(v.id());
         }
 
@@ -688,7 +807,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let state = test_state(dir.path()).await;
 
-        let created = state.create_incident("Original".into(), Impact::Offline, "x".into()).await.unwrap();
+        let created = state.create_incident(opening("Original", Impact::Offline, "x")).await.unwrap();
         let id = created.id();
         let base = created.incident.version;
 
@@ -752,8 +871,8 @@ mod tests {
         let a = test_state(dir_a.path()).await;
         let b = test_state(dir_b.path()).await;
 
-        let created = a.create_incident("Round".into(), Impact::Offline, "down".into()).await.unwrap();
-        a.create_update(created.id(), CreateUpdate { impact: Impact::None, message: "up".into() }).await.unwrap();
+        let created = a.create_incident(opening("Round", Impact::Offline, "down")).await.unwrap();
+        a.create_update(created.id(), CreateUpdate { impact: Impact::None, message: "up".into(), timestamp: None }).await.unwrap();
 
         // B pulls from A: A diffs against B's digest, B applies the delta.
         let delta = a.diff(b.digest().await.unwrap()).await.unwrap();
@@ -787,7 +906,7 @@ mod tests {
         let state = test_state(dir.path()).await;
 
         // A fresh, locally-created incident.
-        let fresh = state.create_incident("Fresh".into(), Impact::Offline, "x".into()).await.unwrap();
+        let fresh = state.create_incident(opening("Fresh", Impact::Offline, "x")).await.unwrap();
 
         // An incident whose version is far older than any probe/cron expiry, delivered via gossip.
         let aged_id = Identifier::from(0x7000_0000_0000_0002u64);

--- a/agent/src/state/incidents.rs
+++ b/agent/src/state/incidents.rs
@@ -644,25 +644,22 @@ mod tests {
             )
             .await
             .unwrap();
-        let (version, view) = match outcome {
-            CasOutcome::Updated(v, view) => (v, view),
-            _ => panic!("expected Updated"),
-        };
+        assert!(matches!(outcome, CasOutcome::Updated(..)));
+        let view = state.get_incident(created.id()).await.unwrap().unwrap();
         assert_eq!(view.ended_at(), Some(corrected));
 
         // An edit without a timestamp leaves the (corrected) one in place.
+        let latest = view.updates.last().unwrap();
         let outcome = state
             .put_update(
-                view.updates.last().unwrap().id,
-                version,
+                latest.id,
+                latest.version,
                 PutUpdate { message: "mitigation complete".into(), timestamp: None },
             )
             .await
             .unwrap();
-        let view = match outcome {
-            CasOutcome::Updated(_, view) => view,
-            _ => panic!("expected Updated"),
-        };
+        assert!(matches!(outcome, CasOutcome::Updated(..)));
+        let view = state.get_incident(created.id()).await.unwrap().unwrap();
         assert_eq!(view.ended_at(), Some(corrected));
         assert_eq!(view.updates.last().unwrap().message, "mitigation complete");
     }

--- a/api/src/incident.rs
+++ b/api/src/incident.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{Identifier, IncidentUpdateId};
@@ -71,6 +71,20 @@ impl std::str::FromStr for Impact {
             _ => Impact::Hidden,
         })
     }
+}
+
+/// How far ahead of the server's clock an operator-supplied update timestamp may sit before it is
+/// rejected. Updates are meant to record what already happened — the incident's current impact is
+/// that of its newest update, so a future-dated one would take effect immediately — but a little
+/// slack keeps a client whose clock runs slightly fast from being turned away.
+pub const MAX_TIMESTAMP_SKEW: Duration = Duration::minutes(5);
+
+/// Whether an operator-supplied update timestamp may be accepted: it must be no further ahead of
+/// `now` than [`MAX_TIMESTAMP_SKEW`], and no earlier than the unix epoch (ids are minted from the
+/// timestamp's unix seconds, which a pre-epoch time would wrap). Shared by the API (which answers a
+/// rejected timestamp with a `400`) and the UI (which checks before submitting).
+pub fn is_valid_update_timestamp(timestamp: DateTime<Utc>, now: DateTime<Utc>) -> bool {
+    timestamp.timestamp() >= 0 && timestamp <= now + MAX_TIMESTAMP_SKEW
 }
 
 /// A single update posted against an incident — a **standalone, gossip-replicated entity** in its own
@@ -200,12 +214,19 @@ impl IncidentView {
 }
 
 /// The body for creating an incident: a title plus its first update (impact + markdown message). The
-/// server assigns the ids and timestamps.
+/// server assigns the ids. `timestamp` backdates the opening update (and with it the incident's
+/// start) to when the event actually began; omit it to stamp the update with the current time.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateIncident {
     pub title: String,
     pub impact: Impact,
     pub message: String,
+    #[serde(
+        default,
+        with = "chrono::serde::ts_seconds_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp: Option<DateTime<Utc>>,
 }
 
 /// The body for replacing an incident's editable header fields (its title). Applied as a check-and-set
@@ -215,18 +236,34 @@ pub struct PutIncident {
     pub title: String,
 }
 
-/// The body for adding a new update to an incident (the server assigns the id and timestamp).
+/// The body for adding a new update to an incident (the server assigns the id). `timestamp` records
+/// the update at a specific past moment — when mitigation actually completed, say — rather than at
+/// the time it is posted; omit it to use the current time.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct CreateUpdate {
     pub impact: Impact,
     pub message: String,
+    #[serde(
+        default,
+        with = "chrono::serde::ts_seconds_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp: Option<DateTime<Utc>>,
 }
 
-/// The body for replacing an existing update's editable field (its message). Applied as a
-/// check-and-set against the update's `version`; the `impact` is fixed once posted.
+/// The body for replacing an existing update's editable fields (its message and, when supplied, its
+/// `timestamp` — so a mistimed backdated update can be corrected). Applied as a check-and-set against
+/// the update's `version`; the `impact` is fixed once posted, and an omitted `timestamp` leaves the
+/// stored one untouched.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct PutUpdate {
     pub message: String,
+    #[serde(
+        default,
+        with = "chrono::serde::ts_seconds_option",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub timestamp: Option<DateTime<Utc>>,
 }
 
 /// A page of incidents, newest-first, each carrying its updates. `next_cursor` is the id to pass as
@@ -332,6 +369,54 @@ mod tests {
         assert_eq!(v.started_at(), None);
         assert_eq!(v.ended_at(), None);
         assert_eq!(v.impact_since(), None);
+    }
+
+    #[test]
+    fn create_bodies_carry_an_optional_backdated_timestamp() {
+        // Omitted on the wire when absent, so an existing client's payload is unchanged...
+        let body = CreateIncident {
+            title: "Outage".into(),
+            impact: Impact::Offline,
+            message: "down".into(),
+            timestamp: None,
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert!(json.get("timestamp").is_none());
+        // ...and a body without the field still decodes (older clients keep working).
+        let decoded: CreateIncident =
+            serde_json::from_value(serde_json::json!({ "title": "Outage", "impact": "offline", "message": "down" }))
+                .unwrap();
+        assert_eq!(decoded, body);
+
+        // When present it rides as unix seconds, matching `IncidentUpdate::timestamp`.
+        let backdated = CreateIncident { timestamp: Some(ts(1_700_000_100)), ..body };
+        let json = serde_json::to_value(&backdated).unwrap();
+        assert_eq!(json["timestamp"], 1_700_000_100);
+        assert_eq!(serde_json::from_value::<CreateIncident>(json).unwrap(), backdated);
+
+        let update = CreateUpdate { impact: Impact::None, message: "fixed".into(), timestamp: Some(ts(1_700_000_500)) };
+        let json = serde_json::to_value(&update).unwrap();
+        assert_eq!(json["timestamp"], 1_700_000_500);
+        assert_eq!(serde_json::from_value::<CreateUpdate>(json).unwrap(), update);
+
+        let edit = PutUpdate { message: "fixed".into(), timestamp: None };
+        let json = serde_json::to_value(&edit).unwrap();
+        assert!(json.get("timestamp").is_none(), "an omitted timestamp leaves the stored one alone");
+        assert_eq!(serde_json::from_value::<PutUpdate>(serde_json::json!({ "message": "fixed" })).unwrap(), edit);
+    }
+
+    #[test]
+    fn timestamps_may_be_backdated_but_not_future_dated() {
+        let now = ts(1_700_000_000);
+        assert!(is_valid_update_timestamp(now, now), "the current time is fine");
+        assert!(is_valid_update_timestamp(ts(1_600_000_000), now), "backdating is the whole point");
+        assert!(is_valid_update_timestamp(ts(0), now), "the epoch itself is the earliest allowed");
+        assert!(
+            is_valid_update_timestamp(now + Duration::minutes(4), now),
+            "a slightly fast client clock is tolerated"
+        );
+        assert!(!is_valid_update_timestamp(now + Duration::minutes(6), now), "future-dating is not");
+        assert!(!is_valid_update_timestamp(ts(-1), now), "nor is a pre-epoch time, which would wrap ids");
     }
 
     #[test]

--- a/docs/ui/incidents.md
+++ b/docs/ui/incidents.md
@@ -118,6 +118,10 @@ drafts), and each incident's own page becomes editable:
   for a title and the incident's opening update (an impact and a markdown
   message). Saving creates the incident with that first update and takes you to
   its page.
+- **Declare an outage that already started** — the **Started (UTC)** field on that
+  page backdates the opening update to when the problem actually began, rather
+  than to when you got round to declaring it. Leave it blank to start the incident
+  now.
 - **Edit the title or a message** — on an incident's page, click the title to
   change it, and click an update's edit (pencil) icon to switch its message from
   the rendered markdown to a textarea. A **Save** icon appears at the top-right as
@@ -125,20 +129,35 @@ drafts), and each incident's own page becomes editable:
   edit made against a stale version is rejected rather than overwriting a
   concurrent change.
 - **An update's impact is fixed once posted** — you choose an update's impact
-  when you add it; after it has been saved, only its message can be changed (the
-  impact records what the status was at that point on the timeline). The latest
-  update sets the incident's current impact, so adding a visible update publishes
-  a draft and adding a `none` update resolves the incident.
+  when you add it; after it has been saved, only its message and its time can be
+  changed (the impact records what the status was at that point on the timeline).
+  The latest update sets the incident's current impact, so adding a visible update
+  publishes a draft and adding a `none` update resolves the incident.
 - **Add / remove updates** — add a new update (pick its impact and write its
   message), or remove an unsaved one, then save.
+- **Post an update for a past moment** — the time field beside a new update's
+  impact records it at the moment it happened rather than the moment you post it,
+  so you can retroactively declare when mitigation completed or when a service came
+  back. Leave it blank to use the current time. Editing a posted update also opens
+  its time, so a mistimed one can be corrected — the timeline (and the incident's
+  duration, start and resolution times) re-sorts around the new time.
 - **Delete** — remove the incident permanently.
 
 Signing in is via the **Sign in** button in the header; once signed in, hover the
 user chip to reveal **Sign out**.
 
 ::: tip
-Each update is timestamped automatically when you add it, and all times are
-displayed in UTC.
+Times are both displayed and entered in **UTC**, not your local timezone. An
+update whose time you leave blank is stamped automatically when you add it, and
+no update may be dated in the future — an incident records what has already
+happened, and its newest update is what sets its current impact.
+:::
+
+::: tip
+An incident's id is minted from its start time, so a backdated incident sorts
+into the list at the point it began rather than at the top. Correcting an
+update's time afterwards moves it along the timeline but leaves the incident's
+place in the list (and its permalink) as it was.
 :::
 
 ## Pages and links

--- a/ui/src/components/_incidents.scss
+++ b/ui/src/components/_incidents.scss
@@ -323,6 +323,25 @@
         }
     }
 
+    // The UTC timestamp field on a new or posted update. It reads as the small, muted time text it
+    // sits beside (or replaces while editing) rather than as a full-height form control.
+    .incident-edit__time-input {
+        font: inherit;
+        font-size: 0.8rem;
+        vertical-align: text-bottom;
+        padding: 0.1rem 0.35rem;
+        color: $color-text-muted;
+        background-color: $background-base;
+        border: 1px solid $color-separator;
+        border-radius: $border-radius-small;
+
+        &:focus {
+            outline: none;
+            color: $color-text;
+            border-color: $color-accent;
+        }
+    }
+
     // A posted update's card header: the fixed impact pill, with the edit/done icon at the far right.
     .incident-timeline__card-head {
         display: flex;

--- a/ui/src/formatters/datetime.rs
+++ b/ui/src/formatters/datetime.rs
@@ -1,4 +1,5 @@
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDateTime, Utc};
+use grey_api::{ApiError, is_valid_update_timestamp};
 
 /// Formats a timestamp as a date only (`YYYY-MM-DD`).
 pub fn date_format(time: DateTime<Utc>) -> String {
@@ -8,4 +9,81 @@ pub fn date_format(time: DateTime<Utc>) -> String {
 /// Formats a timestamp to the minute, in UTC (`YYYY-MM-DD HH:MM UTC`).
 pub fn time_format(time: DateTime<Utc>) -> String {
     time.format("%Y-%m-%d %H:%M UTC").to_string()
+}
+
+/// The `value` for an `<input type="datetime-local">`, in UTC (`YYYY-MM-DDTHH:MM`). The admin
+/// incident forms treat these inputs as UTC — as the rest of the UI displays times — rather than in
+/// the browser's local zone, so this is the exact inverse of [`parse_datetime_local`].
+pub fn datetime_local_value(time: DateTime<Utc>) -> String {
+    time.format("%Y-%m-%dT%H:%M").to_string()
+}
+
+/// Parses an `<input type="datetime-local">` value as a UTC timestamp, accepting the minute- and
+/// second-precision forms browsers emit. `None` for a blank or unparseable value (the caller then
+/// leaves the timestamp to the server).
+pub fn parse_datetime_local(value: &str) -> Option<DateTime<Utc>> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+
+    ["%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M"]
+        .iter()
+        .find_map(|format| NaiveDateTime::parse_from_str(value, format).ok())
+        .map(|naive| naive.and_utc())
+}
+
+/// Resolves an `<input type="datetime-local">` value into the optional `timestamp` an incident
+/// update carries: `None` when the field is blank (the server stamps the update as it is posted), and
+/// an [`ApiError`] describing the problem when the value is unusable — unparseable, or dated in the
+/// future, which the API would refuse since the newest update sets an incident's current impact.
+pub fn resolve_update_timestamp(value: &str) -> Result<Option<DateTime<Utc>>, ApiError> {
+    match parse_datetime_local(value) {
+        None if value.trim().is_empty() => Ok(None),
+        None => Err(ApiError::new(
+            "Enter the time as a date and time, or leave it blank to use the current time.",
+        )),
+        Some(timestamp) if !is_valid_update_timestamp(timestamp, Utc::now()) => Err(ApiError::new(
+            "That time is in the future — an incident can only record what has already happened.",
+        )),
+        Some(timestamp) => Ok(Some(timestamp)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(secs, 0).unwrap()
+    }
+
+    #[test]
+    fn datetime_local_round_trips_through_utc() {
+        let time = ts(1_700_000_100); // 2023-11-14 22:15:00 UTC
+        assert_eq!(datetime_local_value(time), "2023-11-14T22:15");
+        assert_eq!(parse_datetime_local(&datetime_local_value(time)), Some(time));
+    }
+
+    #[test]
+    fn resolving_a_timestamp_allows_blank_and_past_but_not_future() {
+        assert_eq!(resolve_update_timestamp("   "), Ok(None), "blank leaves the stamping to the server");
+        assert_eq!(
+            resolve_update_timestamp("2023-11-14T22:15"),
+            Ok(Some(ts(1_700_000_100))),
+            "a past time backdates the update"
+        );
+        assert!(resolve_update_timestamp("last tuesday").is_err(), "an unparseable value is refused");
+
+        let future = datetime_local_value(Utc::now() + chrono::Duration::days(1));
+        assert!(resolve_update_timestamp(&future).is_err(), "a future-dated update is refused");
+    }
+
+    #[test]
+    fn parse_accepts_seconds_and_rejects_junk() {
+        assert_eq!(parse_datetime_local("2023-11-14T22:15:30"), Some(ts(1_700_000_130)));
+        assert_eq!(parse_datetime_local("  2023-11-14T22:15  "), Some(ts(1_700_000_100)));
+        assert_eq!(parse_datetime_local(""), None, "a blank input leaves the time to the server");
+        assert_eq!(parse_datetime_local("yesterday"), None);
+    }
 }

--- a/ui/src/formatters/datetime.rs
+++ b/ui/src/formatters/datetime.rs
@@ -50,6 +50,22 @@ pub fn resolve_update_timestamp(value: &str) -> Result<Option<DateTime<Utc>>, Ap
     }
 }
 
+/// The `timestamp` to send when saving an edited update: `None` while the field still shows the time
+/// the update already carries, so that saving a message edit alone leaves the stored time exactly as
+/// it was. The input renders minute precision while a stored timestamp is second-precise, so echoing
+/// an untouched value back would silently truncate it. Anything the operator did change is resolved
+/// by [`resolve_update_timestamp`].
+pub fn changed_update_timestamp(
+    value: &str,
+    posted_at: DateTime<Utc>,
+) -> Result<Option<DateTime<Utc>>, ApiError> {
+    if value.trim() == datetime_local_value(posted_at) {
+        return Ok(None);
+    }
+
+    resolve_update_timestamp(value)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -77,6 +93,25 @@ mod tests {
 
         let future = datetime_local_value(Utc::now() + chrono::Duration::days(1));
         assert!(resolve_update_timestamp(&future).is_err(), "a future-dated update is refused");
+    }
+
+    #[test]
+    fn an_untouched_field_leaves_a_stored_timestamp_alone() {
+        // A stored update carries seconds the minute-precision input cannot show...
+        let posted_at = ts(1_700_000_137);
+        assert_eq!(datetime_local_value(posted_at), "2023-11-14T22:15");
+        assert_eq!(
+            changed_update_timestamp("2023-11-14T22:15", posted_at),
+            Ok(None),
+            "saving a message edit alone must not truncate the stored seconds"
+        );
+
+        // ...but a time the operator actually moved is sent as the new timestamp.
+        assert_eq!(
+            changed_update_timestamp("2023-11-14T21:00", posted_at),
+            Ok(Some(ts(1_699_995_600)))
+        );
+        assert!(changed_update_timestamp("nonsense", posted_at).is_err());
     }
 
     #[test]

--- a/ui/src/styles/_forms.scss
+++ b/ui/src/styles/_forms.scss
@@ -37,6 +37,12 @@
         color: $color-text;
     }
 
+    // Guidance beneath an optional field, such as the incident's (backdate-able) start time.
+    .incident-form__hint {
+        font-size: 0.75rem;
+        opacity: 0.8;
+    }
+
     .incident-form__actions {
         display: flex;
         gap: 0.5rem;

--- a/ui/src/views/incident_detail.rs
+++ b/ui/src/views/incident_detail.rs
@@ -59,9 +59,10 @@ struct AdminIncidentDetailProps {
 fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
     use crate::components::icons::{check_icon, edit_icon, save_icon, trash_icon};
     use crate::components::markdown::render_markdown;
-    use crate::formatters::{datetime_local_value, resolve_update_timestamp};
+    use crate::formatters::{changed_update_timestamp, datetime_local_value, resolve_update_timestamp};
     use crate::routes::Route;
     use crate::styles::impact_class;
+    use chrono::{DateTime, Utc};
     use grey_api::{CreateUpdate, Impact, IncidentUpdateId, IncidentView, PutIncident, PutUpdate};
     use web_sys::{HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement};
     use yew_router::prelude::*;
@@ -202,7 +203,7 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
         })
     };
 
-    let on_save_update = |uid: IncidentUpdateId, version: u64| {
+    let on_save_update = |uid: IncidentUpdateId, version: u64, posted_at: DateTime<Utc>| {
         let message_draft = message_draft.clone();
         let timestamp_draft = timestamp_draft.clone();
         let editing = editing.clone();
@@ -210,9 +211,9 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
         let store = store.clone();
         let apply_saved = apply_saved.clone();
         Callback::from(move |_| {
-            // A blank (or unchanged) time leaves the stored timestamp alone; an edited one moves the
+            // A blank or untouched time leaves the stored timestamp alone; an edited one moves the
             // update along the timeline.
-            let timestamp = match resolve_update_timestamp(&timestamp_draft) {
+            let timestamp = match changed_update_timestamp(&timestamp_draft, posted_at) {
                 Ok(timestamp) => timestamp,
                 Err(e) => {
                     store.set_error(e);
@@ -392,7 +393,7 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                                                 oninput={on_draft_timestamp.clone()}
                                             />
                                             <button type="button" class="incident-edit__icon-button" title="Save update"
-                                                disabled={*saving} onclick={on_save_update(uid, version)}>
+                                                disabled={*saving} onclick={on_save_update(uid, version, update.timestamp)}>
                                                 { check_icon() }
                                             </button>
                                         } else {

--- a/ui/src/views/incident_detail.rs
+++ b/ui/src/views/incident_detail.rs
@@ -59,6 +59,7 @@ struct AdminIncidentDetailProps {
 fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
     use crate::components::icons::{check_icon, edit_icon, save_icon, trash_icon};
     use crate::components::markdown::render_markdown;
+    use crate::formatters::{datetime_local_value, resolve_update_timestamp};
     use crate::routes::Route;
     use crate::styles::impact_class;
     use grey_api::{CreateUpdate, Impact, IncidentUpdateId, IncidentView, PutIncident, PutUpdate};
@@ -68,12 +69,16 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
     // The canonical incident (with its updates + versions) plus the editable draft fields.
     let loaded = use_state(|| Option::<IncidentView>::None);
     let title = use_state(String::new);
-    // The update whose message is open in a textarea (by id), plus that textarea's draft.
+    // The update whose message is open in a textarea (by id), plus that textarea's draft and the
+    // draft of its timestamp (as a UTC `datetime-local` value, so a mistimed update can be corrected).
     let editing = use_state(|| Option::<IncidentUpdateId>::None);
     let message_draft = use_state(String::new);
-    // The "add update" form.
+    let timestamp_draft = use_state(String::new);
+    // The "add update" form. Its timestamp is blank unless the update is being backdated — to when
+    // mitigation actually completed, say — in which case the server records that moment instead of now.
     let new_impact = use_state(|| "offline".to_string());
     let new_message = use_state(String::new);
+    let new_timestamp = use_state(String::new);
     let saving = use_state(|| false);
     let navigator = use_navigator();
     let store = use_store();
@@ -155,6 +160,7 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
         let id = current.id().to_string();
         let new_impact = new_impact.clone();
         let new_message = new_message.clone();
+        let new_timestamp = new_timestamp.clone();
         let saving = saving.clone();
         let store = store.clone();
         let apply_saved = apply_saved.clone();
@@ -164,13 +170,31 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                 store.set_error(grey_api::ApiError::new("An update message is required."));
                 return;
             }
-            let input = CreateUpdate { impact: new_impact.parse().unwrap_or_default(), message };
-            let (id, new_message, saving, store, apply_saved) =
-                (id.clone(), new_message.clone(), saving.clone(), store.clone(), apply_saved.clone());
+            let timestamp = match resolve_update_timestamp(&new_timestamp) {
+                Ok(timestamp) => timestamp,
+                Err(e) => {
+                    store.set_error(e);
+                    return;
+                }
+            };
+            let input =
+                CreateUpdate { impact: new_impact.parse().unwrap_or_default(), message, timestamp };
+            let (id, new_message, new_timestamp, saving, store, apply_saved) = (
+                id.clone(),
+                new_message.clone(),
+                new_timestamp.clone(),
+                saving.clone(),
+                store.clone(),
+                apply_saved.clone(),
+            );
             saving.set(true);
             wasm_bindgen_futures::spawn_local(async move {
                 match store.create_update(id, input).await {
-                    Ok(view) => { apply_saved(view); new_message.set(String::new()); }
+                    Ok(view) => {
+                        apply_saved(view);
+                        new_message.set(String::new());
+                        new_timestamp.set(String::new());
+                    }
                     Err(e) => store.set_error(e),
                 }
                 saving.set(false);
@@ -180,12 +204,22 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
 
     let on_save_update = |uid: IncidentUpdateId, version: u64| {
         let message_draft = message_draft.clone();
+        let timestamp_draft = timestamp_draft.clone();
         let editing = editing.clone();
         let saving = saving.clone();
         let store = store.clone();
         let apply_saved = apply_saved.clone();
         Callback::from(move |_| {
-            let edit = PutUpdate { message: (*message_draft).clone() };
+            // A blank (or unchanged) time leaves the stored timestamp alone; an edited one moves the
+            // update along the timeline.
+            let timestamp = match resolve_update_timestamp(&timestamp_draft) {
+                Ok(timestamp) => timestamp,
+                Err(e) => {
+                    store.set_error(e);
+                    return;
+                }
+            };
+            let edit = PutUpdate { message: (*message_draft).clone(), timestamp };
             let (editing, saving, store, apply_saved) =
                 (editing.clone(), saving.clone(), store.clone(), apply_saved.clone());
             saving.set(true);
@@ -252,11 +286,25 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
             new_message.set(el.value());
         })
     };
+    let on_new_timestamp = {
+        let new_timestamp = new_timestamp.clone();
+        Callback::from(move |e: InputEvent| {
+            let el: HtmlInputElement = e.target_unchecked_into();
+            new_timestamp.set(el.value());
+        })
+    };
     let on_draft_message = {
         let message_draft = message_draft.clone();
         Callback::from(move |e: InputEvent| {
             let el: HtmlTextAreaElement = e.target_unchecked_into();
             message_draft.set(el.value());
+        })
+    };
+    let on_draft_timestamp = {
+        let timestamp_draft = timestamp_draft.clone();
+        Callback::from(move |e: InputEvent| {
+            let el: HtmlInputElement = e.target_unchecked_into();
+            timestamp_draft.set(el.value());
         })
     };
 
@@ -299,6 +347,14 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                                     }) }
                                 </select>
 
+                                <input
+                                    class="incident-edit__time-input"
+                                    type="datetime-local"
+                                    title="When this update happened (UTC) — leave blank to post it as of now"
+                                    value={(*new_timestamp).clone()}
+                                    oninput={on_new_timestamp}
+                                />
+
                                 <button type="button" class="incident-edit__icon-button" disabled={*saving} onclick={on_add_update}>{check_icon()}</button>
                             </div>
                             <div class={classes!("incident-timeline__card", status_class)}>
@@ -327,15 +383,22 @@ fn admin_incident_detail(props: &AdminIncidentDetailProps) -> Html {
                                 <div class="incident-timeline__body">
                                     <div class="incident-timeline__time">
                                         <span class={classes!("incident-status-pill", class)}>{update.impact.label()}</span>
-                                        <time datetime={update.timestamp.to_rfc3339()}>{time_format(update.timestamp)}</time>
                                         if is_editing {
-                                            <button type="button" class="incident-edit__icon-button" title="Save message"
+                                            <input
+                                                class="incident-edit__time-input"
+                                                type="datetime-local"
+                                                title="When this update happened (UTC)"
+                                                value={(*timestamp_draft).clone()}
+                                                oninput={on_draft_timestamp.clone()}
+                                            />
+                                            <button type="button" class="incident-edit__icon-button" title="Save update"
                                                 disabled={*saving} onclick={on_save_update(uid, version)}>
                                                 { check_icon() }
                                             </button>
                                         } else {
-                                            <button type="button" class="incident-edit__icon-button" title="Edit message"
-                                                onclick={ let editing = editing.clone(); let message_draft = message_draft.clone(); let msg = update.message.clone(); Callback::from(move |_| { message_draft.set(msg.clone()); editing.set(Some(uid)); }) }>
+                                            <time datetime={update.timestamp.to_rfc3339()}>{time_format(update.timestamp)}</time>
+                                            <button type="button" class="incident-edit__icon-button" title="Edit update"
+                                                onclick={ let editing = editing.clone(); let message_draft = message_draft.clone(); let timestamp_draft = timestamp_draft.clone(); let msg = update.message.clone(); let at = datetime_local_value(update.timestamp); Callback::from(move |_| { message_draft.set(msg.clone()); timestamp_draft.set(at.clone()); editing.set(Some(uid)); }) }>
                                                 { edit_icon() }
                                             </button>
                                             <button type="button" class="incident-edit__icon-button danger" title="Remove update" disabled={*saving} onclick={on_remove_update(uid, version)}>{ trash_icon() }</button>

--- a/ui/src/views/new_incident.rs
+++ b/ui/src/views/new_incident.rs
@@ -2,8 +2,9 @@ use yew::prelude::*;
 
 use crate::contexts::use_store;
 
-/// The `/incidents/new` page (admin only): a title plus the incident's opening update (impact +
-/// message). Saving creates the incident and navigates to its page.
+/// The `/incidents/new` page (admin only): a title plus the incident's opening update (impact,
+/// message, and optionally the time it started, so an outage can be declared after the fact). Saving
+/// creates the incident and navigates to its page.
 #[function_component(NewIncident)]
 pub fn new_incident() -> Html {
     let store = use_store();
@@ -34,6 +35,7 @@ struct NewIncidentFormProps {
 #[cfg(feature = "wasm")]
 #[function_component(NewIncidentForm)]
 fn new_incident_form(props: &NewIncidentFormProps) -> Html {
+    use crate::formatters::resolve_update_timestamp;
     use crate::routes::Route;
     use grey_api::Impact;
     use web_sys::{HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement};
@@ -54,6 +56,9 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
     let title = use_state(String::new);
     let impact = use_state(|| "offline".to_string());
     let message = use_state(String::new);
+    // When the incident started, as a UTC `datetime-local` value. Blank means "now" — the server
+    // stamps the opening update itself.
+    let started = use_state(String::new);
     let saving = use_state(|| false);
     let navigator = use_navigator();
     // The shared store, whose `create_incident` performs the API call and reflects the new incident
@@ -74,6 +79,13 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
             impact.set(el.value());
         })
     };
+    let on_started = {
+        let started = started.clone();
+        Callback::from(move |e: InputEvent| {
+            let el: HtmlInputElement = e.target_unchecked_into();
+            started.set(el.value());
+        })
+    };
     let on_message = {
         let message = message.clone();
         Callback::from(move |e: InputEvent| {
@@ -84,7 +96,8 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
 
     let onsubmit = {
         let token = props.token.clone();
-        let (title, impact, message) = (title.clone(), impact.clone(), message.clone());
+        let (title, impact, message, started) =
+            (title.clone(), impact.clone(), message.clone(), started.clone());
         let saving = saving.clone();
         let navigator = navigator.clone();
         let store = store.clone();
@@ -98,10 +111,20 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
                 ));
                 return;
             }
+            // A blank start time leaves the stamping to the server; anything else backdates the
+            // opening update to when the problem actually began.
+            let timestamp = match resolve_update_timestamp(&started) {
+                Ok(timestamp) => timestamp,
+                Err(e) => {
+                    store.set_error(e);
+                    return;
+                }
+            };
             let input = grey_api::CreateIncident {
                 title: title_value,
                 impact: impact.parse().unwrap_or_default(),
                 message: message_value,
+                timestamp,
             };
             let _ = &token;
             let saving = saving.clone();
@@ -137,6 +160,12 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
                             <option value={opt.as_str()} selected={*impact == opt.as_str()}>{impact_caption(opt)}</option>
                         }) }
                     </select>
+                </label>
+                <label>{"Started (UTC)"}
+                    <input type="datetime-local" value={(*started).clone()} oninput={on_started} />
+                    <small class="incident-form__hint">
+                        {"Leave blank to start the incident now, or backdate it to when the problem began."}
+                    </small>
                 </label>
                 <label>{"Initial update"}
                     <textarea rows="4" value={(*message).clone()} oninput={on_message} placeholder="Enter initial update in markdown form..." />

--- a/ui/src/views/new_incident.rs
+++ b/ui/src/views/new_incident.rs
@@ -179,3 +179,33 @@ fn new_incident_form(props: &NewIncidentFormProps) -> Html {
         </div>
     }
 }
+
+#[cfg(all(test, feature = "wasm"))]
+mod tests {
+    use super::*;
+    use crate::contexts::StoreProvider;
+
+    /// Server-renders the admin form the way a signed-in operator sees it. Effects never run during
+    /// SSR, so this exercises the markup and the hooks that build it, not the submit path.
+    async fn render_form() -> String {
+        #[function_component(Harness)]
+        fn harness() -> Html {
+            html! {
+                <StoreProvider>
+                    <NewIncidentForm token={"test-token".to_string()} />
+                </StoreProvider>
+            }
+        }
+
+        yew::ServerRenderer::<Harness>::new().render().await
+    }
+
+    #[tokio::test]
+    async fn offers_a_start_time_alongside_the_opening_update() {
+        let html = render_form().await;
+        assert!(html.contains("Started (UTC)"), "the start time is labelled as UTC: {html}");
+        assert!(html.contains("type=\"datetime-local\""), "it is entered with a date/time picker");
+        assert!(html.contains("Leave blank to start the incident now"), "blank means now");
+        assert!(html.contains("Create incident"));
+    }
+}


### PR DESCRIPTION
Declaring an outage was only ever possible as of "now", which forced operators to describe a timeline in prose ("this started at 14:05") rather than record it. An incident's whole shape — when it started, how long each impact held, when it was resolved — is derived from its updates' timestamps, so a status page could never show the real duration of anything noticed late, nor record retroactively when mitigation actually completed.

Incident update timestamps are now operator-supplied.

## API

- `CreateIncident`, `CreateUpdate` and `PutUpdate` carry an optional `timestamp` (unix seconds, matching the existing `IncidentUpdate::timestamp` encoding). Omitting it keeps the previous behaviour, so existing clients are unaffected; on `PutUpdate` an absent `timestamp` leaves the stored one untouched.
- An update's timestamp joins its message as editable (its `impact` is still fixed once posted), so a mistimed backdated update can be corrected — the timeline, and the derived start/resolution/duration, re-sort around the new time.
- Timestamps are validated at ingest and refused with a `400`: an update may not be dated in the future (the newest update sets an incident's current impact, so a future-dated one would take effect immediately), with five minutes of slack for client clock skew, nor before the unix epoch (ids are minted from the timestamp's unix seconds, which a pre-epoch time would wrap). `grey_api::is_valid_update_timestamp` is shared by the agent and the UI so both apply the same rule.

## Storage

- A backdated opening update also backdates the incident's snowflake id, so a retroactively declared outage sorts into the (id-ordered, newest-first) list where it actually happened rather than at the top.
- Entity `version`s stay on wall-clock now — the gossip LWW clock and the HTTP ETag must not be dragged into the past by a backdated event.
- `IncidentStore::create_incident` now takes a `CreateIncident`, mirroring `create_update`, rather than growing a fourth positional argument.

## UI

- The **Declare Incident** form gains a **Started (UTC)** field, with a hint that leaving it blank starts the incident now.
- The add-update row on an incident's page gains a matching time input beside the impact select, and editing a posted update opens its time alongside its message.
- All three are parsed and validated (blank means "now"; unparseable and future-dated values are reported in the shared error banner) before anything is submitted. Fields are entered in UTC, as the rest of the UI displays times.

## Testing

- `cargo test -p grey-api`, `cargo test -p grey-ui` — pass.
- `cargo test -p grey` — 209 pass. The 5 failures are pre-existing in a checkout without a Trunk-built `ui/dist` ("HTML template not found in embedded assets"); they fail identically on `main` in this environment and CI builds the UI before running them.
- `cargo clippy` introduces no new warnings (the `approx_constant` errors in `agent/src/sample.rs` and `agent/src/js/to_sample.rs` are pre-existing and untouched).
- The stylesheet compiles cleanly with `sass` and both new rules land.

New coverage: wire-format round-trips and back-compat for the optional field, the validation boundary, backdated declaration and list ordering, recording and correcting an update's time in the store, and the `400`/`200` paths through the admin handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WU3iHieAJ8nm5emBWbmnHB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WU3iHieAJ8nm5emBWbmnHB)_