### PR TITLE
Bound own-record history growth; pace notifier state scans

### DIFF
--- a/agent/src/notify.rs
+++ b/agent/src/notify.rs
@@ -41,9 +41,19 @@ use tracing_batteries::prelude::*;
 use crate::config::WebhookConfig;
 use crate::state::{CronStore, ProbeStore, State};
 
-/// How often the notifier re-derives entity state to look for transitions. Kept short enough that a
-/// state change is reported promptly, but long enough to avoid hammering the store.
-const EVALUATION_INTERVAL: Duration = Duration::from_secs(15);
+/// How long one full evaluation cycle takes: every entity's state is re-derived once per interval.
+/// Kept short enough that a state change is reported promptly, but long enough to avoid hammering
+/// the store — decoding every stored probe record is the single most expensive recurring read in
+/// the agent, so the cycle is also *spread out* rather than performed as one large scan (see
+/// [`SCAN_BATCH_SIZE`]).
+const EVALUATION_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How many probes are decoded per scan within an evaluation cycle. The probe set is split into
+/// batches of this size and the batches are spaced evenly across [`EVALUATION_INTERVAL`], so the
+/// store sees a series of small reads instead of one large one — and the gaps leave the
+/// single-threaded runtime free for gossip, probes and HTTP between scans. Each batch's scan still
+/// walks the whole key range, but only decodes its own names' snapshots, which is where the cost is.
+const SCAN_BATCH_SIZE: usize = 8;
 
 /// The signature header, in the Tailscale `t=<unix-seconds>,v1=<hex>` form (see [`WebhookConfig`]).
 /// The signed timestamp travels in the `t=` field, so no separate timestamp header is needed.
@@ -79,27 +89,41 @@ impl Notifier {
         }
     }
 
-    /// Runs the evaluation loop forever. The first pass runs immediately to seed the baseline (so
-    /// startup doesn't replay existing state), then re-evaluates on [`EVALUATION_INTERVAL`].
+    /// Runs the evaluation loop forever. The first cycle starts immediately to seed the baseline
+    /// (so startup doesn't replay existing state), and each cycle — whose batches already spread
+    /// themselves across [`EVALUATION_INTERVAL`] — is followed by whatever remains of the interval,
+    /// so entities are re-evaluated roughly once per interval.
     pub async fn run(mut self) {
         loop {
+            let started = std::time::Instant::now();
             if let Err(e) = self.evaluate().await {
                 warn!(name: "webhook.evaluate", { exception = %e }, "Failed to evaluate notification state.");
             }
-            tokio::time::sleep(EVALUATION_INTERVAL).await;
+            tokio::time::sleep(EVALUATION_INTERVAL.saturating_sub(started.elapsed())).await;
         }
     }
 
-    /// Performs one evaluation pass: re-derives the pooled state, records transitions against the
+    /// Performs one evaluation cycle: re-derives the pooled state, records transitions against the
     /// baseline, and delivers an event to every matching webhook. The baseline is always refreshed
     /// (even with no webhooks configured) so that adding a webhook via a config reload doesn't replay
     /// the state every entity is already in.
+    ///
+    /// The probe set is scanned in batches of [`SCAN_BATCH_SIZE`], spaced evenly across
+    /// [`EVALUATION_INTERVAL`], so the cycle reads as a series of small store operations rather
+    /// than one large one; events are dispatched per batch so detection latency doesn't grow with
+    /// the probe count. Crons are few and cheap, so they remain a single pass at the end.
     async fn evaluate(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let config = self.state.get_config();
-        let now = Utc::now();
 
-        let probes = self.state.get_probe_states().await?;
-        let crons = self.state.get_cron_states().await?;
+        // Deterministic ordering keeps each name in a stable batch (and so on a stable cadence)
+        // across cycles.
+        let mut probe_names = self.state.get_probe_names().await?;
+        probe_names.sort();
+
+        let batches = probe_names.len().div_ceil(SCAN_BATCH_SIZE);
+        // The batches plus the final cron pass are spread across the interval; the run loop's
+        // remainder sleep absorbs whatever this cycle doesn't use.
+        let spacing = EVALUATION_INTERVAL / (batches as u32 + 1);
 
         // Whether a given entity has alerting enabled. The health axis is already debounced by the
         // streak (via each entity's configured window); `enabled` only decides whether a genuine
@@ -124,10 +148,34 @@ impl Notifier {
             }
         };
 
+        let no_probes = HashMap::new();
+        let no_crons = HashMap::new();
+
+        for batch in probe_names.chunks(SCAN_BATCH_SIZE) {
+            let names: std::collections::HashSet<String> = batch.iter().cloned().collect();
+            let probes = self.state.get_probe_states_for(&names).await?;
+
+            let events = detect_transitions(
+                &mut self.last,
+                Utc::now(),
+                &probes,
+                &no_crons,
+                !config.webhooks.is_empty(),
+                &alerting_enabled,
+            );
+
+            if !events.is_empty() {
+                self.dispatch(&config.webhooks, &events).await;
+            }
+
+            tokio::time::sleep(spacing).await;
+        }
+
+        let crons = self.state.get_cron_states().await?;
         let events = detect_transitions(
             &mut self.last,
-            now,
-            &probes,
+            Utc::now(),
+            &no_probes,
             &crons,
             !config.webhooks.is_empty(),
             &alerting_enabled,

--- a/agent/src/state/probes.rs
+++ b/agent/src/state/probes.rs
@@ -24,6 +24,20 @@ pub trait ProbeStore {
     /// The pooled, cluster-merged probe states keyed by probe name.
     async fn get_probe_states(&self) -> Result<HashMap<String, Probe>, Box<dyn Error>>;
 
+    /// The names of every probe visible to this node: the configured set plus any name present in
+    /// stored records (peers may observe probes this node no longer configures). Walks only the
+    /// table's keys, so it is cheap regardless of record sizes.
+    async fn get_probe_names(&self) -> Result<Vec<String>, Box<dyn Error>>;
+
+    /// As [`ProbeStore::get_probe_states`], restricted to the named probes. Decoding record
+    /// snapshots is the dominant cost of a scan, so callers that can tolerate a spread-out view
+    /// (e.g. the notifier) batch the names from [`ProbeStore::get_probe_names`] through this to
+    /// turn one large scan into several small ones.
+    async fn get_probe_states_for(
+        &self,
+        names: &std::collections::HashSet<String>,
+    ) -> Result<HashMap<String, Probe>, Box<dyn Error>>;
+
     /// Persists the configured probe metadata for this node.
     async fn update_probe_config(&self, probe: &crate::Probe) -> Result<(), Box<dyn Error>>;
 
@@ -46,13 +60,23 @@ pub trait ProbeStore {
     async fn gc_loop(&self);
 }
 
-impl ProbeStore for State {
-    async fn get_probe_states(&self) -> Result<HashMap<String, Probe>, Box<dyn Error>> {
+impl State {
+    /// The shared scan behind [`ProbeStore::get_probe_states`] and
+    /// [`ProbeStore::get_probe_states_for`]: `filter` restricts which probe names are seeded and
+    /// decoded (`None` means all). The key walk always covers the whole table — skipping the
+    /// snapshot decode for filtered-out rows is what makes a restricted scan cheap.
+    fn probe_states_filtered(
+        &self,
+        filter: Option<&std::collections::HashSet<String>>,
+    ) -> Result<HashMap<String, Probe>, Box<dyn Error>> {
         let config = self.get_config();
+        let included = |name: &str| filter.map(|f| f.contains(name)).unwrap_or(true);
 
         let mut histories = HashMap::new();
         for probe in config.probes.iter() {
-            histories.insert(probe.name.clone(), probe.into());
+            if included(&probe.name) {
+                histories.insert(probe.name.clone(), probe.into());
+            }
         }
 
         let txn = self.database.begin_read()?;
@@ -64,6 +88,9 @@ impl ProbeStore for State {
             for entry in table.iter()?.filter_map(|r| r.ok()) {
                 let (key, value) = entry;
                 let (_node_id, probe_name) = key.value();
+                if !included(&probe_name) {
+                    continue;
+                }
                 let (_, data) = value.value();
                 if let Ok(snapshot) = rmp_serde::from_slice::<ProbeState>(data) {
                     // A retired record is an observer's tombstone for a probe it no longer runs; it
@@ -93,6 +120,36 @@ impl ProbeStore for State {
         }
 
         Ok(histories)
+    }
+}
+
+impl ProbeStore for State {
+    async fn get_probe_states(&self) -> Result<HashMap<String, Probe>, Box<dyn Error>> {
+        self.probe_states_filtered(None)
+    }
+
+    async fn get_probe_names(&self) -> Result<Vec<String>, Box<dyn Error>> {
+        let config = self.get_config();
+        let mut names: std::collections::HashSet<String> =
+            config.probes.iter().map(|p| p.name.clone()).collect();
+
+        let txn = self.database.begin_read()?;
+        if let Ok(table) = txn.open_table(PROBES_TABLE) {
+            for entry in table.iter()?.filter_map(|r| r.ok()) {
+                let (key, _value) = entry;
+                let (_node_id, probe_name) = key.value();
+                names.insert(probe_name);
+            }
+        }
+
+        Ok(names.into_iter().collect())
+    }
+
+    async fn get_probe_states_for(
+        &self,
+        names: &std::collections::HashSet<String>,
+    ) -> Result<HashMap<String, Probe>, Box<dyn Error>> {
+        self.probe_states_filtered(Some(names))
     }
 
     async fn update_probe_config(&self, probe: &crate::Probe) -> Result<(), Box<dyn Error>> {
@@ -159,6 +216,10 @@ impl ProbeStore for State {
                 // would never pick the tombstone up.
                 snapshot.last_updated = chrono::Utc::now()
                     .max(snapshot.last_updated + chrono::Duration::seconds(1));
+                // A tombstoned record stops receiving results (the only other place an own record
+                // is pruned), so shed its aged-out history here rather than gossiping it around
+                // until the record itself expires.
+                snapshot.prune_history();
                 updates.push((probe_name, snapshot));
             }
 
@@ -202,6 +263,10 @@ impl ProbeStore for State {
                     .unwrap_or_else(|| (probe.into(), 0));
 
                 probe_result.apply(self.node_id, &mut snapshot);
+                // A node's own records never pass through `merge` (the receive path), so this is
+                // where their history retention is enforced; without it they grow by one bucket per
+                // hour for as long as the probe keeps running.
+                snapshot.prune_history();
 
                 let new_data = rmp_serde::to_vec_named(&snapshot)?;
                 table.insert(
@@ -468,6 +533,131 @@ mod tests {
         assert!(
             table.get((node.into(), "stale".to_string())).unwrap().is_none(),
             "an hour-old probe must expire under a 60s expiry (i.e. version read as milliseconds)"
+        );
+    }
+
+    /// A node's own records never pass through `merge` (the receive path), so applying a probe
+    /// result is where their history retention must be enforced — without it they grow by one
+    /// bucket per hour for as long as the probe runs (67 days of buckets was observed in
+    /// production before this was pruned here).
+    #[tokio::test]
+    async fn applying_a_result_prunes_aged_history_buckets() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State::test(dir.path().to_path_buf()).await;
+        let probe_name = state.get_config().probes[0].name.clone();
+        let own: u128 = state.node_id.into();
+
+        // Seed this node's own record with history far beyond the retention window, emulating a
+        // long-running node's accumulated state.
+        {
+            let txn = state.database.begin_write().unwrap();
+            {
+                let mut table = txn.open_table(PROBES_TABLE).unwrap();
+                let (version, mut snapshot) = table
+                    .get((own, probe_name.clone()))
+                    .unwrap()
+                    .map(|existing| {
+                        let (version, data) = existing.value();
+                        (version, rmp_serde::from_slice::<ProbeState>(data).unwrap())
+                    })
+                    .expect("State::test records a probe result");
+
+                let now = chrono::Utc::now();
+                let mut history: Vec<grey_api::ProbeHistoryBucket> = (49..149)
+                    .rev()
+                    .map(|age_hours| grey_api::ProbeHistoryBucket {
+                        start_time: now - chrono::Duration::hours(age_hours),
+                        pass: true,
+                        message: String::new(),
+                        validations: HashMap::new(),
+                        observations: HashMap::new(),
+                    })
+                    .collect();
+                history.append(&mut snapshot.history);
+                snapshot.history = history;
+
+                table
+                    .insert(
+                        (own, probe_name.clone()),
+                        (version, rmp_serde::to_vec_named(&snapshot).unwrap().as_slice()),
+                    )
+                    .unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        state
+            .update_probe_state(&probe_name, crate::result::ProbeResult::test())
+            .await
+            .unwrap();
+
+        let probes = state.get_probe_states().await.unwrap();
+        let probe = probes.get(&probe_name).expect("the probe remains pooled");
+        let cutoff = chrono::Utc::now() - chrono::Duration::hours(48);
+        assert!(
+            !probe.history.is_empty(),
+            "recent history must survive the prune"
+        );
+        assert!(
+            probe.history.iter().all(|h| h.start_time > cutoff),
+            "buckets older than the retention window must be pruned when a result is applied (oldest retained: {:?})",
+            probe.history.first().map(|h| h.start_time)
+        );
+    }
+
+    /// The batched notifier scan must see exactly what the full scan sees: the name inventory
+    /// covers configured and stored probes, and a filtered read returns the same pooled records
+    /// as the unfiltered one, restricted to the requested names.
+    #[tokio::test]
+    async fn filtered_probe_scans_match_the_full_scan() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = State::test(dir.path().to_path_buf()).await;
+        let configured = state.get_config().probes[0].name.clone();
+
+        // A record stored by a peer for a probe this node doesn't configure must appear too.
+        {
+            let txn = state.database.begin_write().unwrap();
+            {
+                let mut table = txn.open_table(PROBES_TABLE).unwrap();
+                let peer_probe = probe_at("peer-only", chrono::Utc::now());
+                let version = peer_probe.version();
+                table
+                    .insert(
+                        (NodeID::new().into(), "peer-only".to_string()),
+                        (version, rmp_serde::to_vec_named(&peer_probe).unwrap().as_slice()),
+                    )
+                    .unwrap();
+            }
+            txn.commit().unwrap();
+        }
+
+        let mut names = state.get_probe_names().await.unwrap();
+        names.sort();
+        let mut expected = vec![configured.clone(), "peer-only".to_string()];
+        expected.sort();
+        assert_eq!(names, expected);
+
+        let full = state.get_probe_states().await.unwrap();
+        for name in &names {
+            let subset = state
+                .get_probe_states_for(&std::iter::once(name.clone()).collect())
+                .await
+                .unwrap();
+            assert_eq!(subset.len(), 1, "a single-name filter returns exactly that probe");
+            assert_eq!(
+                rmp_serde::to_vec_named(&subset[name]).unwrap(),
+                rmp_serde::to_vec_named(&full[name]).unwrap(),
+                "the filtered record for '{name}' must match the full scan's"
+            );
+        }
+
+        assert!(
+            state
+                .get_probe_states_for(&std::collections::HashSet::new())
+                .await
+                .unwrap()
+                .is_empty(),
+            "an empty filter yields an empty map"
         );
     }
 }

--- a/api/src/probe.rs
+++ b/api/src/probe.rs
@@ -51,6 +51,18 @@ impl Probe {
             .unwrap_or_else(Streak::default_recovery_window)
     }
 
+    /// Drops history buckets that have aged out of the 48-hour retention window.
+    ///
+    /// This must run everywhere a record is rewritten, not just on the gossip receive path
+    /// ([`Mergeable::merge`]): an observer's *own* records are only ever updated by applying its
+    /// probe results, and without pruning there they grow by one bucket per hour indefinitely —
+    /// every read of such a record (gossip diffs, the pooled API/UI view, the notifier) then pays
+    /// for decoding the full unbounded history.
+    pub fn prune_history(&mut self) {
+        let cutoff = chrono::Utc::now() - chrono::Duration::hours(24 * 2);
+        self.history.retain(|h| h.start_time > cutoff);
+    }
+
     /// Aggregate all observations into a single total observation
     pub fn total(&self) -> Observation {
         self.observations.values().fold(Observation::default(), |mut acc, obs| {
@@ -135,8 +147,7 @@ impl Mergeable for Probe {
             j += 1;
         }
 
-        self.history
-            .retain(|h| h.start_time > chrono::Utc::now() - chrono::Duration::hours(24 * 2));
+        self.prune_history();
     }
 }
 


### PR DESCRIPTION
## Summary

Root-cause fix for the sustained (and steadily growing) CPU load on long-running grey nodes, found via the new Pyroscope/OTel profiling stack plus offline analysis of prophet's `state.redb`:

- **A node's own probe records were never pruned.** The 48h history retention lived only in `Probe::merge()` — the gossip *receive* path — so records written by `update_probe_state` grew by one bucket/hour forever. Prophet's 31 own records reached **1611 buckets (~67 days) at ~390 KB each** (peers' replicated copies correctly capped at 48 buckets / ~12 KB). Every full-record decode path paid for it on a single-threaded runtime: gossip `diff()`/`apply()` (264–415 ms per exchange vs 8–18 ms on a young node), `GET /` SSR (646 ms vs 32 ms), the notifier's 15 s scan, and each probe-result rewrite. Retention now lives in `Probe::prune_history()`, called from `merge` as before **and** wherever an own record is rewritten (result application, reconcile tombstoning). Existing oversized records shrink at their first write after deploy — no state surgery needed.

- **The notifier now paces its scans.** It re-evaluates on a 60 s cycle (was 15 s) and reads probes in batches of 8 spread evenly across the cycle via the new `get_probe_names()` / `get_probe_states_for()` store methods, so the store sees a series of small decodes instead of one large scan as probe counts grow. Events still dispatch per batch, so detection latency doesn't stretch with probe count.

## Evidence

- grey on prophet: 0.19 cores sustained (12× seer), ~4× growth over 30 days — slope matches +24 buckets/day/record.
- Decode benchmark on prophet's actual state file: 11.4 MiB (own records) per `diff()` call, ~30 ms on a fast amd64 core ≈ the 264 ms observed per gossip exchange on prophet's ARM core.

## Testing

- `applying_a_result_prunes_aged_history_buckets` — seeds an own record with 100h of buckets and asserts a result application prunes past the 48h window.
- `filtered_probe_scans_match_the_full_scan` — the batched notifier reads (names inventory + per-name filtered scans) are byte-identical to the full scan, including peer-only records.
- Full suites green: grey 216, grey-api 66, grey-ui 30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)